### PR TITLE
Add branch protection ruleset and document git workflow

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,3 +13,17 @@ Each commit must do exactly one thing.
 Commits must pass all linting and tests before being made.
 Commits are kept strictly small: **400–500 lines maximum** (diff lines added + removed).
 If a change is larger, split it into a sequence of focused commits.
+
+## Git workflow
+
+Work on feature branches and merge via pull request.
+The master branch is protected: the `build` CI job must pass and all merges go through the merge queue (Merge mode — creates a merge commit).
+
+Keep feature branches up to date using **rebase, never merge**:
+
+```sh
+git fetch origin
+git rebase origin/master
+```
+
+This preserves a clean, linear commit history within each PR so the merge commit added by the queue stands out clearly.


### PR DESCRIPTION
## Summary

- Creates a repository ruleset protecting master: required `build` CI, merge queue (Merge mode), no force-pushes, no deletion
- Documents the rebase-based branch update workflow in CLAUDE.md

## Test plan

- [ ] Verify `build` CI job passes on this PR
- [ ] Merge via merge queue to confirm queue is active