### PR TITLE
Trigger docs CI on merge_group events

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -5,6 +5,7 @@ on:
     branches: [master]
   pull_request:
     branches: [master]
+  merge_group:
 
 permissions:
   contents: write


### PR DESCRIPTION
## Summary

Without a `merge_group:` trigger the merge queue's temporary validation branch
never fires CI, so the queue stalls forever on `AWAITING_CHECKS`.

## Test plan

- [ ] `build` passes on this PR
- [ ] Merge via merge queue — queue should now run CI, pass, and merge