### PR TITLE
Configure Renovate for automated dependency updates

### DIFF
--- a/.github/workflows/renovate-lockfile.yml
+++ b/.github/workflows/renovate-lockfile.yml
@@ -1,0 +1,39 @@
+name: renovate-lockfile
+
+# Renovate (hosted) cannot run Bazel, so MODULE.bazel.lock would be stale
+# after a bazel_dep update.  This workflow detects that case and pushes the
+# regenerated lockfile back to the Renovate branch before CI runs.
+on:
+  push:
+    branches: ["renovate/**"]
+    paths: ["MODULE.bazel"]
+
+permissions:
+  contents: write
+
+jobs:
+  update-lockfile:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.ref_name }}
+
+      - name: Install Bazelisk
+        uses: bazel-contrib/setup-bazel@0.9.0
+        with:
+          bazelisk-cache: true
+          disk-cache: ${{ github.workflow }}
+          repository-cache: true
+
+      - name: Regenerate MODULE.bazel.lock
+        run: bazel mod deps --lockfile_mode=update
+
+      - name: Commit updated lockfile
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add MODULE.bazel.lock
+          git diff --cached --quiet && exit 0
+          git commit -m "chore: update MODULE.bazel.lock"
+          git push

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,34 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["config:recommended"],
+
+  "minimumReleaseAge": "3 days",
+
+  "automerge": true,
+  "platformAutomerge": true,
+  "automergeStrategy": "merge",
+
+  "osvVulnerabilityAlerts": true,
+  "vulnerabilityAlerts": {
+    "minimumReleaseAge": "0 days"
+  },
+
+  "customManagers": [
+    {
+      "customType": "regex",
+      "fileMatch": ["^\\.devcontainer/Dockerfile$"],
+      "matchStrings": ["ARG BAZELISK_VERSION=(?<currentValue>\\S+)"],
+      "depNameTemplate": "bazelbuild/bazelisk",
+      "datasourceTemplate": "github-releases",
+      "extractVersionTemplate": "^v(?<version>.*)$"
+    },
+    {
+      "customType": "regex",
+      "fileMatch": ["^\\.devcontainer/Dockerfile$"],
+      "matchStrings": ["ARG BUILDIFIER_VERSION=(?<currentValue>\\S+)"],
+      "depNameTemplate": "bazelbuild/buildtools",
+      "datasourceTemplate": "github-releases",
+      "extractVersionTemplate": "^v(?<version>.*)$"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- `renovate.json`: 3-day minimum release age, auto-merge via merge queue, OSV vulnerability alerts (security fixes bypass the age wait)
- Custom regex managers for Bazelisk and Buildifier versions in the Dockerfile
- `renovate-lockfile.yml`: regenerates `MODULE.bazel.lock` when Renovate pushes a `MODULE.bazel` change — hosted Renovate can't run Bazel itself, so without this the CI would always fail on bzlmod dep updates

## How it flows

1. Renovate detects a new release ≥ 3 days old → creates a PR
2. If `MODULE.bazel` changed → `renovate-lockfile` workflow updates the lockfile
3. `build` CI passes → Renovate enables auto-merge → merge queue picks it up
4. Merge queue runs `merge_group` CI → merges

For vulnerability/malware alerts, step 1 happens immediately (no age wait).

## Test plan

- [ ] `build` passes on this PR
- [ ] Merge via merge queue
- [ ] Renovate bot opens its onboarding or first dependency PR after merge