### PR TITLE
cli: add 'causes mcp' subcommand for stdio transport

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -470,8 +470,10 @@ name = "causes_cli"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "causes_mcp",
  "causes_proto",
  "clap",
+ "rmcp",
  "serde",
  "serde_json",
  "tempfile",

--- a/services/causes_cli/BUILD.bazel
+++ b/services/causes_cli/BUILD.bazel
@@ -4,9 +4,11 @@ rust_binary(
     name = "causes_cli",
     srcs = glob(["src/**/*.rs"]),
     deps = [
+        "//lib/rust/causes_mcp",
         "//lib/rust/causes_proto",
         "@crates//:anyhow",
         "@crates//:clap",
+        "@crates//:rmcp",
         "@crates//:serde",
         "@crates//:serde_json",
         "@crates//:tokio",

--- a/services/causes_cli/Cargo.toml
+++ b/services/causes_cli/Cargo.toml
@@ -5,8 +5,10 @@ edition.workspace = true
 license.workspace = true
 
 [dependencies]
+causes_mcp = { path = "../../lib/rust/causes_mcp" }
 causes_proto = { path = "../../lib/rust/causes_proto" }
 clap.workspace = true
+rmcp.workspace = true
 anyhow.workspace = true
 serde.workspace = true
 serde_json.workspace = true

--- a/services/causes_cli/src/main.rs
+++ b/services/causes_cli/src/main.rs
@@ -2,6 +2,7 @@ use clap::Parser;
 
 mod admin;
 mod auth;
+mod mcp;
 mod project;
 pub(crate) mod rpc;
 mod session_file;
@@ -28,6 +29,8 @@ enum Command {
     Admin(admin::AdminArgs),
     /// Manage authentication.
     Auth(auth::AuthArgs),
+    /// Start MCP (Model Context Protocol) server on stdio.
+    Mcp,
     /// Manage projects.
     Project(project::ProjectArgs),
 }
@@ -40,6 +43,7 @@ async fn main() -> anyhow::Result<()> {
     match cli.command {
         Command::Admin(args) => admin::run(&cli.server, &data_dir, args).await,
         Command::Auth(args) => auth::run(&cli.server, &data_dir, args).await,
+        Command::Mcp => mcp::run(&cli.server).await,
         Command::Project(args) => project::run(&cli.server, &data_dir, args).await,
     }
 }

--- a/services/causes_cli/src/mcp.rs
+++ b/services/causes_cli/src/mcp.rs
@@ -1,0 +1,37 @@
+use anyhow::Context;
+use rmcp::ServiceExt;
+
+/// Run the MCP server on stdio.
+///
+/// Reads `CAUSES_TOKEN` from the environment for gRPC authentication.
+/// The server address comes from the `--server` CLI flag.
+pub async fn run(server: &str) -> anyhow::Result<()> {
+    let token = std::env::var("CAUSES_TOKEN")
+        .context("CAUSES_TOKEN environment variable is required for MCP mode")?;
+
+    let handler = causes_mcp::CausesTools::new(server.to_string(), token);
+
+    let transport = rmcp::transport::io::stdio();
+    let server = handler.serve(transport).await?;
+    server.waiting().await?;
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn mcp_requires_causes_token() {
+        // Verify that run() fails without CAUSES_TOKEN set.
+        // We can't actually start the server (it would block on stdio),
+        // but we can check the env var validation.
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        let err = rt.block_on(run("http://unused:1")).unwrap_err();
+        assert!(err.to_string().contains("CAUSES_TOKEN"), "got: {err}");
+    }
+}


### PR DESCRIPTION
## Summary
- Add `causes mcp` subcommand that starts the MCP server on stdio
- Reads `CAUSES_TOKEN` from environment for gRPC auth
- Test verifies env var validation

## Test plan
- [x] `bazel run //:format.check` passes
- [x] `bash tools/coverage.sh //...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)