### PR TITLE
docs: add MCP server section to CLI README

### DIFF
--- a/services/causes_cli/README.md
+++ b/services/causes_cli/README.md
@@ -45,8 +45,47 @@ Each server has its own session file, stored in `$XDG_DATA_HOME/causes/` (defaul
 The filename is derived from the server URL (e.g. `causes.example.com.json`).
 Per the XDG Base Directory spec, credentials belong in `XDG_DATA_HOME`, not `XDG_CONFIG_HOME`.
 
+### `mcp`
+
+Start an MCP (Model Context Protocol) server on stdio.
+AI tools like Claude Code, Claude Desktop, VS Code, and Cursor can use this to interact with the Causes instance.
+
+The MCP server requires `CAUSES_TOKEN` to be set.
+Get a token with `causes auth login`, then copy it from `~/.local/share/causes/<server>.json`.
+
+#### Claude Code configuration
+
+Add to your Claude Code MCP settings:
+
+```json
+{
+  "mcpServers": {
+    "causes": {
+      "command": "causes",
+      "args": ["mcp"],
+      "env": {
+        "CAUSES_SERVER": "https://causes.example.com",
+        "CAUSES_TOKEN": "<your-session-token>"
+      }
+    }
+  }
+}
+```
+
+#### Available tools
+
+| Tool | Description |
+|---|---|
+| `whoami` | Show the authenticated user's identity |
+| `list_projects` | List all visible projects |
+| `get_project` | Get a project by name |
+| `create_project` | Create a new project |
+| `rename_project` | Rename a project |
+| `delete_project` | Delete a project |
+
 ## Environment variables
 
 | Variable | Default | Description |
 |---|---|---|
 | `CAUSES_SERVER` | `http://[::1]:50051` | Causes API server address |
+| `CAUSES_TOKEN` | — | Session token (required for `causes mcp`) |


### PR DESCRIPTION
## Summary
- Document `causes mcp` subcommand, env vars, Claude Code config example, available tools

## Test plan
- [x] `bazel run //:format.check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)