### PR TITLE
docs: add MCP server section to CLI README

### DIFF
--- a/services/causes_cli/README.md
+++ b/services/causes_cli/README.md
@@ -45,6 +45,42 @@ Each server has its own session file, stored in `$XDG_DATA_HOME/causes/` (defaul
 The filename is derived from the server URL (e.g. `causes.example.com.json`).
 Per the XDG Base Directory spec, credentials belong in `XDG_DATA_HOME`, not `XDG_CONFIG_HOME`.
 
+### `mcp`
+
+Start an MCP (Model Context Protocol) server on stdio.
+AI tools like Claude Code, Claude Desktop, and VS Code can use this to interact with the Causes instance.
+
+No pre-existing session is required.
+On first use, invoke the `login` tool to authenticate via the device flow — the MCP server handles everything, including storing the session.
+
+#### VS Code configuration
+
+Add to `.vscode/mcp.json`:
+
+```json
+{
+  "servers": {
+    "causes": {
+      "type": "stdio",
+      "command": "bazel",
+      "args": ["--quiet", "run", "--", "//services/causes_cli", "--server=https://causes.example.com", "mcp"]
+    }
+  }
+}
+```
+
+#### Available tools
+
+| Tool | Description |
+|---|---|
+| `login` | Authenticate via device flow (one-time) |
+| `whoami` | Show the authenticated user's identity |
+| `list_projects` | List all visible projects |
+| `get_project` | Get a project by name |
+| `create_project` | Create a new project |
+| `rename_project` | Rename a project |
+| `delete_project` | Delete a project |
+
 ## Environment variables
 
 | Variable | Default | Description |


### PR DESCRIPTION
## Summary

- Document `causes mcp` subcommand under Commands section
- VS Code MCP server configuration example using `bazel run`
- Available tools table

## Test plan
- [x] `bazel run //:format.check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)