### PR TITLE
improve jj skill and CLAUDE.md guidance

### DIFF
--- a/.claude/skills/jj/SKILL.md
+++ b/.claude/skills/jj/SKILL.md
@@ -17,6 +17,21 @@ This project uses Jujutsu (`jj`) for all version control.
 Never run raw `git` commands — they corrupt jj's operation log.
 All git interaction goes through `jj git fetch` and `jj git push`.
 
+## Pre-push checklist (mandatory after any rebase/reorder)
+
+Before every `jj git push --all` after graph changes:
+
+1. `jj log` — are bookmarks where you expect them?
+2. Any open PR whose **base branch is moving** in this push?
+   → `gh pr edit <N> --base master` to temp-base it first.
+   (The risk: if a PR's head becomes reachable from its base after the push,
+   GitHub falsely marks it "merged" — code never reaches master.)
+3. `jj git push --all`
+4. Fix PR bases back: `gh pr edit <N> --base <correct-branch>`
+5. Verify bijection: `gh pr list --json number,headRefName,baseRefName`
+
+Skip this checklist only for routine pushes with no rebase/reorder.
+
 ## Critical rules
 
 1. **No raw git.** Never run `git commit`, `git push`, `git checkout`, etc.
@@ -26,11 +41,11 @@ All git interaction goes through `jj git fetch` and `jj git push`.
    Edits are tracked automatically.
    There is no `jj add` or staged/unstaged distinction.
 
-3. **Right changeset before every edit.** Before editing any file, verify that
-   `@` is the correct changeset for that edit.
-   If starting new work: `jj new master` (or the appropriate parent).
-   If switching tasks mid-conversation: `jj new` or `jj edit <target>` first.
-   Never edit a file while sitting on an unrelated changeset.
+3. **`jj new` before every new task.** Before editing any file for a new piece
+   of work, run `jj log` and confirm `@` is the right changeset.
+   If it isn't: `jj new master` (new work) or `jj edit <target>` (existing work).
+   **This is the single most common mistake — editing files on the wrong
+   changeset and then needing graph surgery to fix it.**
    After finishing a change, run `jj new` to create a fresh empty changeset.
    This protects the completed work from accidental edits.
 
@@ -57,6 +72,35 @@ All git interaction goes through `jj git fetch` and `jj git push`.
    simple messages.
    For longer messages with a body, use `jj describe` (opens editor) or
    pass a multi-line string.
+
+## Stacked vs merge-all: choosing the right PR shape
+
+Before creating PRs from multiple commits, decide: **stacked** or **merge-all**?
+
+**Stacked (linear chain):** Each PR targets the previous PR's branch.
+Use when commits are **sequential** — commit B's diff only makes sense applied
+after commit A (e.g. both edit the same file, or B calls a function A introduces).
+
+```
+master ← A ← B ← C       (PR-A base=master, PR-B base=branch-A, ...)
+```
+
+**Merge-all (independent siblings):** Each PR targets master directly.
+Use when commits are **independent** — they touch different files/areas and
+their diffs apply cleanly in any order.
+
+```
+master ← A
+       ← B                (PR-A base=master, PR-B base=master, ...)
+       ← C
+```
+
+**The decision criterion is semantic, not textual.**
+Ask: "does it make sense to merge B into master without A?"
+If B calls a function A introduces, or extends behaviour A defines, they must
+be stacked — even if the diffs touch different files and rebase cleanly.
+If A and B are genuinely independent features that make sense in either order,
+they should be siblings.
 
 ## This repo's workflow
 
@@ -125,41 +169,15 @@ jj rebase -r <X> -A master -B <merge>    # independent branch off master
 
 ### Safe reorder with open PRs
 
-**CRITICAL:** When reordering commits in a stack with open PRs, GitHub can
-falsely mark a PR as "merged" — closing it without any code reaching master.
+When reordering commits with open PRs, GitHub can falsely mark a PR as
+"merged" if its head becomes reachable from its base branch after the push.
+The PR closes (purple) but code never reaches master.
 
-**How it happens:** In a stack where PR-B has `--base branch-A --head branch-B`,
-if you reorder so that B's commit becomes an ancestor of A's commit and then
-push both branches, GitHub sees B's head reachable from A (B's base branch)
-and concludes B was merged into A.
-The PR shows as "merged" (purple) but the code never went through the merge
-queue and is not on master.
+**How it happens:** PR-B has `--base branch-A --head branch-B`.
+You reorder so B's commit becomes an ancestor of A's, then push both.
+GitHub sees B's head reachable from A and concludes B was merged into A.
 
-**Safe reorder protocol:**
-
-1. **Before pushing**, list all open PRs affected by the reorder.
-2. **Temporarily set PR bases to `master`** for any PR whose base branch will
-   move, be deleted, or gain new ancestors:
-   ```sh
-   gh pr edit <N> --base master
-   ```
-   This is safe because master is guaranteed not to contain any in-flight
-   branch heads.
-3. **Push all branch updates:**
-   ```sh
-   jj git push --all
-   ```
-4. **Create PRs** for any new bookmarks that need them.
-5. **Fix PR bases** to the correct stacked branch:
-   ```sh
-   gh pr edit <N> --base <correct-branch>
-   ```
-
-The key invariant: **at no point during the push should a PR's head be
-reachable from its base branch's HEAD.**
-
-After any reorder, verify by querying open PRs and confirming there is a
-bijection between open PRs and the branches being worked on.
+**Follow the pre-push checklist at the top of this document.**
 
 ### Resolving conflicts
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,6 +67,17 @@ run `tools/coverage.sh //...` (not bare `bazel test //...`) — it runs coverage
 For `bazel run` targets (servers, binaries): run them and confirm they start correctly before pushing — even long-running ones, which should be started, verified, then killed.
 "It builds" is not the same as "it works."
 
+## Communication style
+
+Do not validate or assess the user's points ("You're right", "Good question", "Great point", etc.).
+When the user makes a correction or observation, respond with substance — the edit, the counterpoint, the next step.
+
+## Environment
+
+Development happens in disposable containers.
+Only save session-local memories (ephemeral, current-conversation-only) outside the repo.
+Durable memories (feedback, preferences, project context) must go in-repo (CLAUDE.md, skill files, etc.) so they survive container destruction.
+
 ## Git workflow
 
 This project uses [Jujutsu (`jj`)](https://github.com/jj-vcs/jj) for local version control.


### PR DESCRIPTION
## Summary

- Add pre-push checklist to top of jj skill — mandatory after any rebase/reorder, impossible to skip past
- Add stacked vs merge-all section with semantic decision criterion ("does it make sense to merge B without A?")
- Trim redundant safe-reorder protocol (now points to the checklist)
- Sharpen critical rule 3: "jj new before every new task" instead of vague "right changeset before every edit"
- Add communication style and disposable-container guidance to CLAUDE.md

## Test plan

- [ ] Read through the skill and confirm the checklist, stacked-vs-merge-all, and rule 3 changes are clear
- [ ] Confirm no jj workflow regressions by using the skill in a subsequent session

🤖 Generated with [Claude Code](https://claude.com/claude-code)