### PR TITLE
fix: drop NOT NULL before nulling project_id

### DIFF
--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -499,7 +499,7 @@
     },
     "@@rules_multitool+//multitool:extension.bzl%multitool": {
       "general": {
-        "bzlTransitiveDigest": "bUAIj7+iQveUL37FLVQ+wqtGkQMyahXU4dysFJ22+/g=",
+        "bzlTransitiveDigest": "JwbhrCdKUGaor1qUL1BjTXfS9sjYjh6/kJKUNFbf6wI=",
         "usagesDigest": "TEO2RWqEoh/9V+zpKsbi7shFJAjSqnD+BofsgRbgoT0=",
         "recordedInputs": [
           "REPO_MAPPING:bazel_features+,bazel_features_globals bazel_features++version_extension+bazel_features_globals",

--- a/lib/rust/api_db/migrations/006_role_assignments_fk.sql
+++ b/lib/rust/api_db/migrations/006_role_assignments_fk.sql
@@ -8,11 +8,13 @@
 
 ALTER TABLE role_assignments DROP CONSTRAINT role_assignments_pkey;
 
+ALTER TABLE role_assignments
+    ALTER COLUMN project_id DROP DEFAULT,
+    ALTER COLUMN project_id DROP NOT NULL;
+
 UPDATE role_assignments SET project_id = NULL WHERE project_id = '';
 
 ALTER TABLE role_assignments
-    ALTER COLUMN project_id DROP DEFAULT,
-    ALTER COLUMN project_id DROP NOT NULL,
     ADD CONSTRAINT role_assignments_project_id_fkey
         FOREIGN KEY (project_id) REFERENCES projects(id);
 


### PR DESCRIPTION
## Summary

- Migration 006 fails on production because it runs `UPDATE role_assignments SET project_id = NULL` while the `NOT NULL` constraint is still active
- Fix: reorder so `ALTER COLUMN DROP NOT NULL` executes before the `UPDATE`, then add the FK constraint separately

## Test plan

- [x] `api_db_db_test` passes (migrations run against real PostgreSQL)
- [x] `sqlx_prepare_test` passes (offline metadata still valid)
- [x] Full `tools/coverage.sh //...` passes (20/20 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)