### PR TITLE
mcp: add project management tools

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -926,6 +926,8 @@ dependencies = [
  "rmcp",
  "rustls 0.23.38",
  "schemars",
+ "serde",
+ "serde_json",
  "tempfile",
  "tokio",
  "tokio-stream",

--- a/lib/rust/causes_mcp/BUILD.bazel
+++ b/lib/rust/causes_mcp/BUILD.bazel
@@ -11,6 +11,8 @@ rust_library(
         "@crates//:anyhow",
         "@crates//:rmcp",
         "@crates//:schemars",
+        "@crates//:serde",
+        "@crates//:serde_json",
         "@crates//:tokio",
         "@crates//:tokio-stream",
         "@crates//:tonic",

--- a/lib/rust/causes_mcp/Cargo.toml
+++ b/lib/rust/causes_mcp/Cargo.toml
@@ -11,6 +11,8 @@ proto_ext = { path = "../proto_ext" }
 anyhow.workspace = true
 rmcp.workspace = true
 schemars.workspace = true
+serde.workspace = true
+serde_json.workspace = true
 tokio.workspace = true
 tokio-stream.workspace = true
 tonic.workspace = true

--- a/lib/rust/causes_mcp/src/lib.rs
+++ b/lib/rust/causes_mcp/src/lib.rs
@@ -2,6 +2,8 @@
 //!
 //! Transport-agnostic: callers bind this to stdio (CLI) or Streamable HTTP (BFF).
 
+mod project;
+
 use rmcp::ServerHandler;
 use rmcp::handler::server::router::tool::ToolRouter;
 use rmcp::tool;
@@ -19,7 +21,8 @@ use tokio::sync::RwLock;
 use tonic::transport::Channel;
 use tracing::debug;
 
-type AuthedChannel = tonic::service::interceptor::InterceptedService<Channel, BearerInterceptor>;
+pub(crate) type AuthedChannel =
+    tonic::service::interceptor::InterceptedService<Channel, BearerInterceptor>;
 
 /// State saved between the first login call (which returns the URL/code)
 /// and the second call (which polls for completion).
@@ -39,7 +42,7 @@ struct PendingLogin {
 #[derive(Clone)]
 pub struct CausesTools {
     server_url: String,
-    session: causes_session::SessionStore,
+    session: Arc<dyn causes_session::SessionStorage>,
     channel: Channel,
     cached_channel: Arc<RwLock<Option<AuthedChannel>>>,
     pending_login: Arc<RwLock<Option<PendingLogin>>>,
@@ -58,17 +61,17 @@ impl CausesTools {
                 .tls_config(tonic::transport::ClientTlsConfig::new().with_native_roots())
                 .expect("TLS config");
         }
-        let session = causes_session::SessionStore::new(
+        let session = causes_session::FileSessionStore::new(
             causes_session::SessionKind::Mcp,
             &data_dir,
             &server_url,
         );
-        Self::with_channel(server_url, session, endpoint.connect_lazy())
+        Self::with_channel(server_url, Arc::new(session), endpoint.connect_lazy())
     }
 
-    fn with_channel(
+    pub(crate) fn with_channel(
         server_url: String,
-        session: causes_session::SessionStore,
+        session: Arc<dyn causes_session::SessionStorage>,
         channel: Channel,
     ) -> Self {
         Self {
@@ -78,7 +81,7 @@ impl CausesTools {
             cached_channel: Arc::new(RwLock::new(None)),
             pending_login: Arc::new(RwLock::new(None)),
             login_timeout: std::time::Duration::from_secs(600),
-            tool_router: Self::tool_router(),
+            tool_router: Self::tool_router() + Self::project_router(),
         }
     }
 
@@ -86,7 +89,7 @@ impl CausesTools {
         Ok(AuthServiceClient::new(self.authed_channel().await?))
     }
 
-    async fn authed_channel(&self) -> Result<AuthedChannel, String> {
+    pub(crate) async fn authed_channel(&self) -> Result<AuthedChannel, String> {
         if let Some(ch) = self.cached_channel.read().await.clone() {
             debug!("using cached authed channel");
             return Ok(ch);
@@ -108,7 +111,7 @@ impl CausesTools {
         Ok(ch)
     }
 
-    async fn set_authed_channel(&self, token: &str) {
+    pub(crate) async fn set_authed_channel(&self, token: &str) {
         let ch = tonic::service::interceptor::InterceptedService::new(
             self.channel.clone(),
             BearerInterceptor::new(token.to_string()),
@@ -277,9 +280,28 @@ impl CausesTools {
 // delegating tool dispatch to the ToolRouter populated by #[tool_router] above.
 #[tool_handler]
 impl ServerHandler for CausesTools {
+    async fn list_tools(
+        &self,
+        _request: Option<rmcp::model::PaginatedRequestParams>,
+        _context: rmcp::service::RequestContext<rmcp::RoleServer>,
+    ) -> Result<rmcp::model::ListToolsResult, rmcp::ErrorData> {
+        // Manually implemented because the `#[tool_handler]` macro's generated
+        // `list_tools` uses the first `#[tool_router]`-generated router only,
+        // not the merged `self.tool_router` field.  Using the field directly
+        // includes both login/whoami and project tools.
+        Ok(rmcp::model::ListToolsResult {
+            tools: self.tool_router.list_all(),
+            meta: None,
+            next_cursor: None,
+        })
+    }
+
     fn get_info(&self) -> rmcp::model::ServerInfo {
         let mut info = rmcp::model::ServerInfo::default();
         info.server_info = rmcp::model::Implementation::new("causes", env!("CARGO_PKG_VERSION"));
+        info.capabilities = rmcp::model::ServerCapabilities::builder()
+            .enable_tools()
+            .build();
         info.instructions = Some(
             "Causes project tracker. Use the login tool to authenticate, \
              then use project tools to manage projects."
@@ -297,8 +319,7 @@ mod tests {
 
     use causes_proto::auth_service_server::{AuthService, AuthServiceServer};
     use causes_proto::*;
-
-    // ── Mock services ───────────────────────────────────────────────────────
+    use causes_session::SessionStorage;
 
     struct MockAuthService {
         poll_count: AtomicU32,
@@ -359,7 +380,25 @@ mod tests {
         }
     }
 
+    async fn start_mock_grpc() -> String {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let port = listener.local_addr().unwrap().port();
+
+        let mock = Arc::new(MockAuthService::new());
+        tokio::spawn(async move {
+            tonic::transport::Server::builder()
+                .add_service(AuthServiceServer::from_arc(mock))
+                .serve_with_incoming(tokio_stream::wrappers::TcpListenerStream::new(listener))
+                .await
+                .unwrap();
+        });
+
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+        format!("http://127.0.0.1:{port}")
+    }
+
     /// Mock that always returns Pending — login never completes.
+    /// Only used by the timeout test in this module.
     struct AlwaysPendingAuthService;
 
     #[tonic::async_trait]
@@ -393,41 +432,6 @@ mod tests {
         }
     }
 
-    // ── Test helpers ────────────────────────────────────────────────────────
-
-    /// Start a mock gRPC server, returning the URL.
-    async fn start_mock_grpc() -> String {
-        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
-        let port = listener.local_addr().unwrap().port();
-
-        let mock = Arc::new(MockAuthService::new());
-        tokio::spawn(async move {
-            tonic::transport::Server::builder()
-                .add_service(AuthServiceServer::from_arc(mock))
-                .serve_with_incoming(tokio_stream::wrappers::TcpListenerStream::new(listener))
-                .await
-                .unwrap();
-        });
-
-        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
-        format!("http://127.0.0.1:{port}")
-    }
-
-    /// Complete the two-call login flow, returning the tools instance.
-    async fn logged_in_tools() -> (CausesTools, tempfile::TempDir) {
-        let url = start_mock_grpc().await;
-        let dir = tempfile::tempdir().unwrap();
-        let tools = CausesTools::new(url, dir.path().to_path_buf());
-        let first = tools.login().await;
-        assert!(first.contains("Login started"), "first login: {first}");
-        let second = tools.login().await;
-        assert!(
-            second.contains("Login successful"),
-            "second login: {second}"
-        );
-        (tools, dir)
-    }
-
     // ── Login tests ─────────────────────────────────────────────────────────
 
     #[tokio::test]
@@ -453,14 +457,21 @@ mod tests {
         let second = tools.login().await;
         assert!(second.contains("Login successful"), "got: {second}");
 
-        let store =
-            causes_session::SessionStore::new(causes_session::SessionKind::Mcp, dir.path(), &url);
+        let store = causes_session::FileSessionStore::new(
+            causes_session::SessionKind::Mcp,
+            dir.path(),
+            &url,
+        );
         assert_eq!(store.load().unwrap().unwrap(), "d".repeat(64));
     }
 
     #[tokio::test]
     async fn login_skips_when_already_logged_in() {
-        let (tools, _dir) = logged_in_tools().await;
+        let url = start_mock_grpc().await;
+        let dir = tempfile::tempdir().unwrap();
+        let tools = CausesTools::new(url, dir.path().to_path_buf());
+        tools.login().await;
+        tools.login().await;
 
         let result = tools.login().await;
         assert!(result.contains("Already logged in"), "got: {result}");
@@ -506,7 +517,11 @@ mod tests {
 
     #[tokio::test]
     async fn whoami_works_after_login() {
-        let (tools, _dir) = logged_in_tools().await;
+        let url = start_mock_grpc().await;
+        let dir = tempfile::tempdir().unwrap();
+        let tools = CausesTools::new(url, dir.path().to_path_buf());
+        tools.login().await;
+        tools.login().await;
 
         let result = tools.whoami().await;
         assert!(result.contains("uid-42"), "got: {result}");
@@ -517,7 +532,7 @@ mod tests {
     #[tokio::test]
     async fn whoami_reports_connection_failure() {
         let dir = tempfile::tempdir().unwrap();
-        let store = causes_session::SessionStore::new(
+        let store = causes_session::FileSessionStore::new(
             causes_session::SessionKind::Mcp,
             dir.path(),
             "http://127.0.0.1:1",
@@ -570,9 +585,12 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
 
         let channel = Channel::from_shared(url.clone()).unwrap().connect_lazy();
-        let session =
-            causes_session::SessionStore::new(causes_session::SessionKind::Mcp, dir.path(), &url);
-        let tools = CausesTools::with_channel(url, session, channel);
+        let session = causes_session::FileSessionStore::new(
+            causes_session::SessionKind::Mcp,
+            dir.path(),
+            &url,
+        );
+        let tools = CausesTools::with_channel(url, Arc::new(session), channel);
 
         let result = tokio::time::timeout(std::time::Duration::from_secs(5), tools.login())
             .await
@@ -599,9 +617,12 @@ mod tests {
             .unwrap()
             .connect_lazy();
 
-        let session =
-            causes_session::SessionStore::new(causes_session::SessionKind::Mcp, dir.path(), &url);
-        let mut tools = CausesTools::with_channel(url.clone(), session, channel);
+        let session = causes_session::FileSessionStore::new(
+            causes_session::SessionKind::Mcp,
+            dir.path(),
+            &url,
+        );
+        let mut tools = CausesTools::with_channel(url.clone(), Arc::new(session), channel);
         tools.login_timeout = std::time::Duration::from_secs(10);
 
         let first = tokio::time::timeout(std::time::Duration::from_secs(5), tools.login())
@@ -614,8 +635,11 @@ mod tests {
             .expect("second login should not hang");
         assert!(second.contains("Login successful"), "got: {second}");
 
-        let store =
-            causes_session::SessionStore::new(causes_session::SessionKind::Mcp, dir.path(), &url);
+        let store = causes_session::FileSessionStore::new(
+            causes_session::SessionKind::Mcp,
+            dir.path(),
+            &url,
+        );
         assert_eq!(store.load().unwrap().unwrap(), "d".repeat(64));
     }
 }

--- a/lib/rust/causes_mcp/src/project.rs
+++ b/lib/rust/causes_mcp/src/project.rs
@@ -1,0 +1,341 @@
+//! Project management tools exposed via MCP.
+
+use causes_proto::project_service_client::ProjectServiceClient;
+use causes_proto::{
+    CreateProjectRequest, DeleteProjectRequest, GetProjectRequest, ListProjectsRequest,
+    RenameProjectRequest,
+};
+use rmcp::handler::server::wrapper::Parameters;
+use rmcp::tool;
+use rmcp::tool_router;
+use schemars::JsonSchema;
+use serde::Deserialize;
+
+use crate::CausesTools;
+
+fn format_project(p: &causes_proto::Project) -> String {
+    let vis = match p.visibility {
+        1 => "public",
+        2 => "private",
+        _ => "unknown",
+    };
+    format!(
+        "Name: {}\nDescription: {}\nVisibility: {}\nID: {}",
+        p.name, p.description, vis, p.id,
+    )
+}
+
+#[derive(Deserialize, JsonSchema)]
+pub(crate) struct ProjectName {
+    /// Project name (slug).
+    pub(crate) name: String,
+}
+
+#[derive(Deserialize, JsonSchema)]
+pub(crate) struct CreateProjectParams {
+    /// Project name (slug, lowercase alphanumeric + hyphens).
+    pub(crate) name: String,
+    /// Project description.
+    pub(crate) description: String,
+    /// Visibility: "public" or "private". Defaults to "public".
+    #[serde(default = "default_public")]
+    pub(crate) visibility: String,
+}
+
+fn default_public() -> String {
+    "public".to_string()
+}
+
+#[derive(Deserialize, JsonSchema)]
+pub(crate) struct RenameProjectParams {
+    /// Current project name.
+    pub(crate) name: String,
+    /// New project name.
+    pub(crate) new_name: String,
+}
+
+#[tool_router(router = project_router, vis = "pub(crate)")]
+impl CausesTools {
+    /// List all projects visible to the authenticated user.
+    #[tool(description = "List all projects visible to the authenticated user")]
+    pub(crate) async fn list_projects(&self) -> String {
+        let mut client = match self.authed_channel().await {
+            Ok(c) => ProjectServiceClient::new(c),
+            Err(e) => return e,
+        };
+
+        match client.list_projects(ListProjectsRequest {}).await {
+            Ok(resp) => {
+                let mut stream = resp.into_inner();
+                let mut projects = Vec::new();
+                while let Some(batch) = tokio_stream::StreamExt::next(&mut stream).await {
+                    match batch {
+                        Ok(b) => projects.extend(b.projects),
+                        Err(e) => return format!("Stream error: {}", e.message()),
+                    }
+                }
+                if projects.is_empty() {
+                    return "No projects found.".to_string();
+                }
+                projects
+                    .iter()
+                    .map(format_project)
+                    .collect::<Vec<_>>()
+                    .join("\n---\n")
+            }
+            Err(e) => format!("ListProjects failed: {}", e.message()),
+        }
+    }
+
+    /// Get a project by name.
+    #[tool(description = "Get a project by its name (slug)")]
+    pub(crate) async fn get_project(&self, params: Parameters<ProjectName>) -> String {
+        let mut client = match self.authed_channel().await {
+            Ok(c) => ProjectServiceClient::new(c),
+            Err(e) => return e,
+        };
+
+        match client
+            .get_project(GetProjectRequest {
+                name: params.0.name,
+            })
+            .await
+        {
+            Ok(resp) => match resp.into_inner().project {
+                Some(p) => format_project(&p),
+                None => "Project not found.".to_string(),
+            },
+            Err(e) => format!("GetProject failed: {}", e.message()),
+        }
+    }
+
+    /// Create a new project.
+    #[tool(description = "Create a new project. Requires the developer role.")]
+    pub(crate) async fn create_project(&self, params: Parameters<CreateProjectParams>) -> String {
+        let mut client = match self.authed_channel().await {
+            Ok(c) => ProjectServiceClient::new(c),
+            Err(e) => return e,
+        };
+
+        let visibility = match params.0.visibility.as_str() {
+            "private" => 2,
+            _ => 1,
+        };
+
+        match client
+            .create_project(CreateProjectRequest {
+                name: params.0.name,
+                description: params.0.description,
+                visibility,
+                embargoed_by_default: false,
+            })
+            .await
+        {
+            Ok(resp) => match resp.into_inner().project {
+                Some(p) => format!("Created project:\n{}", format_project(&p)),
+                None => "Project created but no details returned.".to_string(),
+            },
+            Err(e) => format!("CreateProject failed: {}", e.message()),
+        }
+    }
+
+    /// Rename a project.
+    #[tool(description = "Rename a project. Requires project-maintainer or instance-admin.")]
+    pub(crate) async fn rename_project(&self, params: Parameters<RenameProjectParams>) -> String {
+        let mut client = match self.authed_channel().await {
+            Ok(c) => ProjectServiceClient::new(c),
+            Err(e) => return e,
+        };
+
+        match client
+            .rename_project(RenameProjectRequest {
+                name: params.0.name,
+                new_name: params.0.new_name,
+            })
+            .await
+        {
+            Ok(resp) => match resp.into_inner().project {
+                Some(p) => format!("Renamed project:\n{}", format_project(&p)),
+                None => "Project renamed but no details returned.".to_string(),
+            },
+            Err(e) => format!("RenameProject failed: {}", e.message()),
+        }
+    }
+
+    /// Delete a project.
+    #[tool(
+        description = "Delete a project and all associated data. Requires project-maintainer or instance-admin."
+    )]
+    pub(crate) async fn delete_project(&self, params: Parameters<ProjectName>) -> String {
+        let mut client = match self.authed_channel().await {
+            Ok(c) => ProjectServiceClient::new(c),
+            Err(e) => return e,
+        };
+
+        match client
+            .delete_project(DeleteProjectRequest {
+                name: params.0.name,
+            })
+            .await
+        {
+            Ok(_) => "Project deleted.".to_string(),
+            Err(e) => format!("DeleteProject failed: {}", e.message()),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Arc;
+
+    use crate::CausesTools;
+
+    use causes_proto::project_service_server::{ProjectService, ProjectServiceServer};
+    use causes_proto::*;
+
+    struct MockProjectService;
+
+    impl MockProjectService {
+        fn test_project() -> Project {
+            Project {
+                id: "proj-1".to_string(),
+                name: "test-project".to_string(),
+                description: "A test project".to_string(),
+                visibility: 1,
+                embargoed_by_default: false,
+                created_at: None,
+            }
+        }
+    }
+
+    #[tonic::async_trait]
+    impl ProjectService for MockProjectService {
+        async fn create_project(
+            &self,
+            _req: tonic::Request<CreateProjectRequest>,
+        ) -> Result<tonic::Response<CreateProjectResponse>, tonic::Status> {
+            Ok(tonic::Response::new(CreateProjectResponse {
+                project: Some(Self::test_project()),
+            }))
+        }
+
+        async fn get_project(
+            &self,
+            _req: tonic::Request<GetProjectRequest>,
+        ) -> Result<tonic::Response<GetProjectResponse>, tonic::Status> {
+            Ok(tonic::Response::new(GetProjectResponse {
+                project: Some(Self::test_project()),
+            }))
+        }
+
+        type ListProjectsStream = tokio_stream::Once<Result<ListProjectsResponse, tonic::Status>>;
+
+        async fn list_projects(
+            &self,
+            _req: tonic::Request<ListProjectsRequest>,
+        ) -> Result<tonic::Response<Self::ListProjectsStream>, tonic::Status> {
+            Ok(tonic::Response::new(tokio_stream::once(Ok(
+                ListProjectsResponse {
+                    projects: vec![Self::test_project()],
+                },
+            ))))
+        }
+
+        async fn rename_project(
+            &self,
+            _req: tonic::Request<RenameProjectRequest>,
+        ) -> Result<tonic::Response<RenameProjectResponse>, tonic::Status> {
+            Ok(tonic::Response::new(RenameProjectResponse {
+                project: Some(Self::test_project()),
+            }))
+        }
+
+        async fn delete_project(
+            &self,
+            _req: tonic::Request<DeleteProjectRequest>,
+        ) -> Result<tonic::Response<DeleteProjectResponse>, tonic::Status> {
+            Ok(tonic::Response::new(DeleteProjectResponse {}))
+        }
+    }
+
+    /// Start a mock project gRPC server and return an authenticated CausesTools.
+    async fn authed_tools() -> CausesTools {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let url = format!("http://127.0.0.1:{port}");
+
+        tokio::spawn(async move {
+            tonic::transport::Server::builder()
+                .add_service(ProjectServiceServer::new(MockProjectService))
+                .serve_with_incoming(tokio_stream::wrappers::TcpListenerStream::new(listener))
+                .await
+                .unwrap();
+        });
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+
+        let channel = tonic::transport::Channel::from_shared(url.clone())
+            .unwrap()
+            .connect_lazy();
+        let tools =
+            CausesTools::with_channel(url, Arc::new(causes_session::NullSessionStore), channel);
+        tools.set_authed_channel(&"d".repeat(64)).await;
+        tools
+    }
+
+    #[tokio::test]
+    async fn list_projects_returns_projects() {
+        let tools = authed_tools().await;
+        let result = tools.list_projects().await;
+        assert!(result.contains("test-project"), "got: {result}");
+        assert!(result.contains("public"), "got: {result}");
+    }
+
+    #[tokio::test]
+    async fn get_project_returns_details() {
+        let tools = authed_tools().await;
+        let result = tools
+            .get_project(Parameters(ProjectName {
+                name: "test-project".to_string(),
+            }))
+            .await;
+        assert!(result.contains("test-project"), "got: {result}");
+        assert!(result.contains("A test project"), "got: {result}");
+    }
+
+    #[tokio::test]
+    async fn create_project_returns_created() {
+        let tools = authed_tools().await;
+        let result = tools
+            .create_project(Parameters(CreateProjectParams {
+                name: "new-project".to_string(),
+                description: "desc".to_string(),
+                visibility: "public".to_string(),
+            }))
+            .await;
+        assert!(result.contains("Created project"), "got: {result}");
+    }
+
+    #[tokio::test]
+    async fn rename_project_returns_renamed() {
+        let tools = authed_tools().await;
+        let result = tools
+            .rename_project(Parameters(RenameProjectParams {
+                name: "old".to_string(),
+                new_name: "new".to_string(),
+            }))
+            .await;
+        assert!(result.contains("Renamed project"), "got: {result}");
+    }
+
+    #[tokio::test]
+    async fn delete_project_returns_deleted() {
+        let tools = authed_tools().await;
+        let result = tools
+            .delete_project(Parameters(ProjectName {
+                name: "test-project".to_string(),
+            }))
+            .await;
+        assert_eq!(result, "Project deleted.");
+    }
+}

--- a/lib/rust/causes_session/src/lib.rs
+++ b/lib/rust/causes_session/src/lib.rs
@@ -42,6 +42,24 @@ pub fn default_data_dir() -> PathBuf {
         .join("causes")
 }
 
+/// Trait for loading and saving session tokens.
+pub trait SessionStorage: Send + Sync {
+    fn load(&self) -> anyhow::Result<Option<String>>;
+    fn save(&self, token: &str) -> anyhow::Result<()>;
+}
+
+/// No-op session store that never persists.
+pub struct NullSessionStore;
+
+impl SessionStorage for NullSessionStore {
+    fn load(&self) -> anyhow::Result<Option<String>> {
+        Ok(None)
+    }
+    fn save(&self, _token: &str) -> anyhow::Result<()> {
+        Ok(())
+    }
+}
+
 #[derive(Serialize, Deserialize)]
 struct SessionFile {
     session_token: String,
@@ -62,15 +80,16 @@ impl SessionKind {
     }
 }
 
-/// A session store that persists tokens to `<data_dir>/<sanitised_url><suffix>.json`.
+/// File-backed session store.
+/// Persists tokens to `<data_dir>/<sanitised_url><suffix>.json`.
 #[derive(Clone)]
-pub struct SessionStore {
+pub struct FileSessionStore {
     data_dir: PathBuf,
     server: String,
     suffix: &'static str,
 }
 
-impl SessionStore {
+impl FileSessionStore {
     pub fn new(kind: SessionKind, data_dir: &Path, server: &str) -> Self {
         Self {
             data_dir: data_dir.to_path_buf(),
@@ -83,10 +102,10 @@ impl SessionStore {
         let stem = sanitise_server(&self.server);
         self.data_dir.join(format!("{stem}{}.json", self.suffix))
     }
+}
 
-    /// Load a session token, returning `None` if no file exists or the
-    /// token is invalid.
-    pub fn load(&self) -> anyhow::Result<Option<String>> {
+impl SessionStorage for FileSessionStore {
+    fn load(&self) -> anyhow::Result<Option<String>> {
         let path = self.path();
         if !path.exists() {
             return Ok(None);
@@ -100,8 +119,7 @@ impl SessionStore {
         Ok(Some(session.session_token))
     }
 
-    /// Save a session token.
-    pub fn save(&self, token: &str) -> anyhow::Result<()> {
+    fn save(&self, token: &str) -> anyhow::Result<()> {
         std::fs::create_dir_all(&self.data_dir).context("creating data directory")?;
         let session = SessionFile {
             session_token: token.to_string(),
@@ -124,8 +142,8 @@ mod tests {
 
     #[test]
     fn cli_and_mcp_use_different_files() {
-        let cli = SessionStore::new(SessionKind::Cli, Path::new("/tmp"), "https://example.com");
-        let mcp = SessionStore::new(SessionKind::Mcp, Path::new("/tmp"), "https://example.com");
+        let cli = FileSessionStore::new(SessionKind::Cli, Path::new("/tmp"), "https://example.com");
+        let mcp = FileSessionStore::new(SessionKind::Mcp, Path::new("/tmp"), "https://example.com");
         assert_ne!(cli.path(), mcp.path());
         assert!(cli.path().to_str().unwrap().ends_with("example.com.json"));
         assert!(
@@ -140,7 +158,7 @@ mod tests {
     fn round_trip_save_and_load() {
         let dir = tempfile::tempdir().unwrap();
         let token = "d".repeat(64);
-        let store = SessionStore::new(SessionKind::Mcp, dir.path(), "http://localhost:50051");
+        let store = FileSessionStore::new(SessionKind::Mcp, dir.path(), "http://localhost:50051");
         store.save(&token).unwrap();
         assert_eq!(store.load().unwrap().unwrap(), token);
     }
@@ -148,14 +166,14 @@ mod tests {
     #[test]
     fn load_returns_none_when_missing() {
         let dir = tempfile::tempdir().unwrap();
-        let store = SessionStore::new(SessionKind::Cli, dir.path(), "http://nonexistent:1");
+        let store = FileSessionStore::new(SessionKind::Cli, dir.path(), "http://nonexistent:1");
         assert!(store.load().unwrap().is_none());
     }
 
     #[test]
     fn load_returns_none_for_invalid_token() {
         let dir = tempfile::tempdir().unwrap();
-        let store = SessionStore::new(SessionKind::Mcp, dir.path(), "http://localhost:50051");
+        let store = FileSessionStore::new(SessionKind::Mcp, dir.path(), "http://localhost:50051");
 
         std::fs::write(store.path(), r#"{"session_token":""}"#).unwrap();
         assert!(store.load().unwrap().is_none());
@@ -173,8 +191,8 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let token_a = "a".repeat(64);
         let token_b = "b".repeat(64);
-        let store_a = SessionStore::new(SessionKind::Cli, dir.path(), "http://server-a:50051");
-        let store_b = SessionStore::new(SessionKind::Cli, dir.path(), "http://server-b:50051");
+        let store_a = FileSessionStore::new(SessionKind::Cli, dir.path(), "http://server-a:50051");
+        let store_b = FileSessionStore::new(SessionKind::Cli, dir.path(), "http://server-b:50051");
         store_a.save(&token_a).unwrap();
         store_b.save(&token_b).unwrap();
         assert_eq!(store_a.load().unwrap().unwrap(), token_a);

--- a/services/causes_cli/src/session_file.rs
+++ b/services/causes_cli/src/session_file.rs
@@ -2,16 +2,16 @@
 
 pub use causes_session::default_data_dir;
 
-use causes_session::{SessionKind, SessionStore};
+use causes_session::{FileSessionStore, SessionKind, SessionStorage};
 
 /// Load the session token for a server, returning `None` if absent or invalid.
 pub fn load(data_dir: &std::path::Path, server: &str) -> anyhow::Result<Option<String>> {
-    SessionStore::new(SessionKind::Cli, data_dir, server).load()
+    FileSessionStore::new(SessionKind::Cli, data_dir, server).load()
 }
 
 /// Save a session token for a server.
 pub fn save(data_dir: &std::path::Path, server: &str, token: &str) -> anyhow::Result<()> {
-    SessionStore::new(SessionKind::Cli, data_dir, server).save(token)
+    FileSessionStore::new(SessionKind::Cli, data_dir, server).save(token)
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary

Adds project management tools to the Causes MCP server:

- `list_projects` — stream all projects visible to the authenticated user
- `get_project` — look up a project by name
- `create_project` — create a new project (public/private visibility)
- `rename_project` — rename an existing project
- `delete_project` — delete a project and its data

Refactors `authed_client()` into `authed_channel()` so both `AuthServiceClient` and `ProjectServiceClient` can share the bearer-token-intercepted channel.

## Test plan

- [x] \`bazel test //lib/rust/causes_mcp:causes_mcp_test\` passes (mock server covers all project tools)
- [x] \`bazel test //services/causes_cli:causes_cli_test\` passes
- [x] \`bazel run //:format.check\` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)