### PR TITLE
build: make format checks cacheable via per-target sh_tests

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -7,7 +7,7 @@
           {
             "type": "command",
             "if": "Bash(jj git push:*)",
-            "command": "{ bazel run //:format.check && bash tools/coverage.sh //...; } || printf '{\"continue\":false,\"stopReason\":\"Pre-push gate failed — fix format/coverage issues before pushing.\"}'",
+            "command": "bash tools/coverage.sh //... || printf '{\"continue\":false,\"stopReason\":\"Pre-push gate failed — fix format/coverage issues before pushing.\"}'",
             "timeout": 300,
             "statusMessage": "Running pre-push checks (format + coverage)..."
           }
@@ -19,7 +19,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "{ bazel run //:format.check && bash tools/coverage.sh //...; } || printf '{\"decision\":\"block\",\"reason\":\"Format or coverage check failed — fix before finishing.\"}'",
+            "command": "bash tools/coverage.sh //... || printf '{\"decision\":\"block\",\"reason\":\"Format or coverage check failed — fix before finishing.\"}'",
             "timeout": 300,
             "statusMessage": "Running post-work checks (format + coverage)..."
           }

--- a/.devcontainer/BUILD.bazel
+++ b/.devcontainer/BUILD.bazel
@@ -1,6 +1,7 @@
 load("@npm//:defs.bzl", "npm_link_all_packages")
 load("@npm__at_devcontainers_cli__0.84.1//:package_json.bzl", devcontainers_cli_bin = "bin")
 load("@rules_shell//shell:sh_test.bzl", "sh_test")
+load("//tools/lint:format_check.bzl", "format_srcs")
 
 npm_link_all_packages()
 
@@ -20,3 +21,5 @@ sh_test(
         "requires-docker",
     ],
 )
+
+format_srcs()

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,6 +1,13 @@
 load("@aspect_rules_lint//format:defs.bzl", "format_multirun")
 load("@gazelle//:def.bzl", "gazelle")
 load("@rules_python//python:pip.bzl", "compile_pip_requirements")
+load(
+    "//tools/lint:format_check.bzl",
+    "buildifier_check",
+    "shfmt_check",
+    "taplo_check",
+    "yamlfmt_check",
+)
 load("//tools/lint:linters.bzl", "markdown_lint_test", "yamllint_lint_test")
 
 package(default_visibility = ["//visibility:public"])
@@ -9,9 +16,11 @@ exports_files([
     ".clippy.toml",
     ".pymarkdown.json",
     ".shellcheckrc",
+    ".yamlfmt",
     ".yamllint",
     "Cargo.toml",
     "Cargo.lock",
+    "rustfmt.toml",
 ])
 
 # Run with: bazel run //:gazelle
@@ -72,4 +81,132 @@ markdown_lint_test(
         "*.md",
         "designdocs/**/*.md",
     ]),
+)
+
+# ── Cacheable format check ────────────────────────────────────────────────────
+# Per-language aggregator filegroups + sh_test targets. Each language's
+# sh_test only invalidates when its own inputs change, so an unchanged tree
+# hits the bazel test cache instantly instead of re-running formatters.
+# Run with:
+#   bazel test //... --test_tag_filters=format_check_auto --build_tests_only
+# Every rust_* target emits a tagged _rustfmt_check sibling via build/rust.bzl;
+# the four aggregators below cover Starlark, TOML, shell, and YAML.
+
+# Root-level sources (.github/workflows/* belongs to the root package since
+# that subtree has no BUILD.bazel of its own).
+filegroup(
+    name = "starlark_format_srcs",
+    srcs = glob(
+        [
+            "*.bzl",
+            "BUILD.bazel",
+            "*.bazel",
+        ],
+        allow_empty = True,
+    ),
+    visibility = ["//visibility:public"],
+)
+
+filegroup(
+    name = "toml_format_srcs",
+    srcs = glob(
+        ["*.toml"],
+        allow_empty = True,
+    ),
+    visibility = ["//visibility:public"],
+)
+
+filegroup(
+    name = "shell_format_srcs",
+    srcs = glob(
+        ["*.sh"],
+        allow_empty = True,
+    ),
+    visibility = ["//visibility:public"],
+)
+
+filegroup(
+    name = "yaml_format_srcs",
+    srcs = glob(
+        [
+            "*.yml",
+            "*.yaml",
+            ".github/**/*.yml",
+            ".github/**/*.yaml",
+        ],
+        allow_empty = True,
+    ),
+    visibility = ["//visibility:public"],
+)
+
+# Every subpackage calls format_srcs() to emit its own per-language filegroups.
+# Adding a new package means appending it here — the only non-Rust commit
+# discipline this design costs.
+_FORMAT_PACKAGES = [
+    "//.devcontainer:",
+    "//build:",
+    "//build/patches:",
+    "//docs:",
+    "//infra:",
+    "//infra/postgres:",
+    "//lib/rust/api_db:",
+    "//lib/rust/causes_mcp:",
+    "//lib/rust/causes_proto:",
+    "//lib/rust/causes_session:",
+    "//lib/rust/proto_ext:",
+    "//proto:",
+    "//services/causes_api:",
+    "//services/causes_cli:",
+    "//tools:",
+    "//tools/lint:",
+    "//tools/proto-gen:",
+]
+
+# Aggregate each language's per-package filegroups into one non-empty filegroup.
+# `$(rootpaths ...)` in sh_test args errors on empty expansions, so we can't
+# reference per-package filegroups individually — they'd be empty for packages
+# without files of that language.
+
+filegroup(
+    name = "_all_starlark_format_srcs",
+    srcs = [":starlark_format_srcs"] +
+           [p + "starlark_format_srcs" for p in _FORMAT_PACKAGES],
+)
+
+filegroup(
+    name = "_all_toml_format_srcs",
+    srcs = [":toml_format_srcs"] +
+           [p + "toml_format_srcs" for p in _FORMAT_PACKAGES],
+)
+
+filegroup(
+    name = "_all_shell_format_srcs",
+    srcs = [":shell_format_srcs"] +
+           [p + "shell_format_srcs" for p in _FORMAT_PACKAGES],
+)
+
+filegroup(
+    name = "_all_yaml_format_srcs",
+    srcs = [":yaml_format_srcs"] +
+           [p + "yaml_format_srcs" for p in _FORMAT_PACKAGES],
+)
+
+buildifier_check(
+    name = "format_starlark_check",
+    srcs = [":_all_starlark_format_srcs"],
+)
+
+taplo_check(
+    name = "format_toml_check",
+    srcs = [":_all_toml_format_srcs"],
+)
+
+shfmt_check(
+    name = "format_shell_check",
+    srcs = [":_all_shell_format_srcs"],
+)
+
+yamlfmt_check(
+    name = "format_yaml_check",
+    srcs = [":_all_yaml_format_srcs"],
 )

--- a/build/BUILD.bazel
+++ b/build/BUILD.bazel
@@ -1,1 +1,4 @@
 # This package exists so that //build:rust.bzl is loadable.
+load("//tools/lint:format_check.bzl", "format_srcs")
+
+format_srcs()

--- a/build/patches/BUILD.bazel
+++ b/build/patches/BUILD.bazel
@@ -1,1 +1,5 @@
+load("//tools/lint:format_check.bzl", "format_srcs")
+
 exports_files(glob(["*.patch"]))
+
+format_srcs()

--- a/build/rust.bzl
+++ b/build/rust.bzl
@@ -1,16 +1,44 @@
-"Rust build macros with project-wide defaults (e.g. -Dwarnings)."
+"""Rust build macros with project-wide defaults (e.g. -Dwarnings).
+
+Each Rust target also gets a sibling <name>_rustfmt_check sh_test that caches
+its inputs, so bazel test short-circuits on an unformatted-file-free tree
+instead of re-running rustfmt from scratch every time.
+"""
 
 load("@rules_rs//rs:rust_binary.bzl", _rust_binary = "rust_binary")
 load("@rules_rs//rs:rust_library.bzl", _rust_library = "rust_library")
 load("@rules_rs//rs:rust_test.bzl", _rust_test = "rust_test")
+load("//tools/lint:format_check.bzl", "rustfmt_check")
 
 _DEFAULT_RUSTC_FLAGS = ["-Dwarnings"]
 
-def rust_binary(rustc_flags = [], **kwargs):
-    _rust_binary(rustc_flags = _DEFAULT_RUSTC_FLAGS + rustc_flags, **kwargs)
+def rust_binary(name, srcs = [], rustc_flags = [], **kwargs):
+    _rust_binary(
+        name = name,
+        srcs = srcs,
+        rustc_flags = _DEFAULT_RUSTC_FLAGS + rustc_flags,
+        **kwargs
+    )
+    rustfmt_check(name = name + "_rustfmt_check", srcs = srcs)
 
-def rust_library(rustc_flags = [], **kwargs):
-    _rust_library(rustc_flags = _DEFAULT_RUSTC_FLAGS + rustc_flags, **kwargs)
+def rust_library(name, srcs = [], rustc_flags = [], **kwargs):
+    _rust_library(
+        name = name,
+        srcs = srcs,
+        rustc_flags = _DEFAULT_RUSTC_FLAGS + rustc_flags,
+        **kwargs
+    )
+    rustfmt_check(name = name + "_rustfmt_check", srcs = srcs)
 
-def rust_test(rustc_flags = [], **kwargs):
-    _rust_test(rustc_flags = _DEFAULT_RUSTC_FLAGS + rustc_flags, **kwargs)
+def rust_test(name, srcs = [], rustc_flags = [], **kwargs):
+    _rust_test(
+        name = name,
+        srcs = srcs,
+        rustc_flags = _DEFAULT_RUSTC_FLAGS + rustc_flags,
+        **kwargs
+    )
+
+    # When rust_test uses `crate = ":foo"` it inherits srcs from that crate and
+    # `srcs` here is []; the library's own _rustfmt_check already covers them,
+    # so rustfmt_check() is a no-op.
+    rustfmt_check(name = name + "_rustfmt_check", srcs = srcs)

--- a/docs/BUILD.bazel
+++ b/docs/BUILD.bazel
@@ -4,6 +4,7 @@ load(
 )
 load("@rules_shell//shell:sh_binary.bzl", "sh_binary")
 load("@rules_shell//shell:sh_test.bzl", "sh_test")
+load("//tools/lint:format_check.bzl", "format_srcs")
 load("//tools/lint:linters.bzl", "yamllint_lint_test")
 
 # Hermetically managed zensical binary.
@@ -122,3 +123,5 @@ sh_test(
         "@bazel_tools//tools/bash/runfiles",
     ],
 )
+
+format_srcs()

--- a/infra/BUILD.bazel
+++ b/infra/BUILD.bazel
@@ -1,4 +1,5 @@
 load("@rules_shell//shell:sh_binary.bzl", "sh_binary")
+load("//tools/lint:format_check.bzl", "format_srcs")
 load("//tools/lint:linters.bzl", "markdown_lint_test")
 
 # Run the AWS CLI.
@@ -42,3 +43,5 @@ markdown_lint_test(
     name = "pymarkdown_github",
     srcs = ["github/README.md"],
 )
+
+format_srcs()

--- a/infra/postgres/BUILD.bazel
+++ b/infra/postgres/BUILD.bazel
@@ -1,5 +1,6 @@
 load("@rules_shell//shell:sh_binary.bzl", "sh_binary")
 load("@rules_shell//shell:sh_test.bzl", "sh_test")
+load("//tools/lint:format_check.bzl", "format_srcs")
 load("//tools/lint:linters.bzl", "markdown_lint_test")
 load(":defs.bzl", "extract_tarball")
 
@@ -51,3 +52,5 @@ markdown_lint_test(
     name = "pymarkdown",
     srcs = ["README.md"],
 )
+
+format_srcs()

--- a/lib/rust/api_db/BUILD.bazel
+++ b/lib/rust/api_db/BUILD.bazel
@@ -1,6 +1,7 @@
 load("@rules_shell//shell:sh_test.bzl", "sh_test")
 load("//build:rust.bzl", "rust_library", "rust_test")
 load("//tools:sqlx_prepare.bzl", "sqlx_prepare")
+load("//tools/lint:format_check.bzl", "format_srcs")
 
 rust_library(
     name = "api_db",
@@ -99,3 +100,5 @@ sqlx_prepare(
     migrations = glob(["migrations/**"]),
     visibility = ["//visibility:public"],
 )
+
+format_srcs()

--- a/lib/rust/causes_mcp/BUILD.bazel
+++ b/lib/rust/causes_mcp/BUILD.bazel
@@ -1,4 +1,5 @@
 load("//build:rust.bzl", "rust_library", "rust_test")
+load("//tools/lint:format_check.bzl", "format_srcs")
 
 rust_library(
     name = "causes_mcp",
@@ -29,3 +30,5 @@ rust_test(
         "@crates//:tempfile",
     ],
 )
+
+format_srcs()

--- a/lib/rust/causes_proto/BUILD.bazel
+++ b/lib/rust/causes_proto/BUILD.bazel
@@ -1,4 +1,5 @@
 load("//build:rust.bzl", "rust_library")
+load("//tools/lint:format_check.bzl", "format_srcs")
 
 rust_library(
     name = "causes_proto",
@@ -17,3 +18,5 @@ filegroup(
     srcs = glob(["src/generated/**"]),
     visibility = ["//tools:__pkg__"],
 )
+
+format_srcs()

--- a/lib/rust/causes_session/BUILD.bazel
+++ b/lib/rust/causes_session/BUILD.bazel
@@ -1,4 +1,5 @@
 load("//build:rust.bzl", "rust_library", "rust_test")
+load("//tools/lint:format_check.bzl", "format_srcs")
 
 rust_library(
     name = "causes_session",
@@ -18,3 +19,5 @@ rust_test(
         "@crates//:tempfile",
     ],
 )
+
+format_srcs()

--- a/lib/rust/proto_ext/BUILD.bazel
+++ b/lib/rust/proto_ext/BUILD.bazel
@@ -1,4 +1,5 @@
 load("//build:rust.bzl", "rust_library", "rust_test")
+load("//tools/lint:format_check.bzl", "format_srcs")
 
 rust_library(
     name = "proto_ext",
@@ -13,3 +14,5 @@ rust_test(
     name = "proto_ext_test",
     crate = ":proto_ext",
 )
+
+format_srcs()

--- a/proto/BUILD.bazel
+++ b/proto/BUILD.bazel
@@ -1,4 +1,5 @@
 load("@rules_proto//proto:defs.bzl", "proto_library")
+load("//tools/lint:format_check.bzl", "format_srcs")
 load("//tools/lint:linters.bzl", "buf_lint_test", "yamllint_lint_test")
 
 exports_files(["buf.yaml"])
@@ -70,3 +71,5 @@ genrule(
     ],
     visibility = ["//docs:__pkg__"],
 )
+
+format_srcs()

--- a/services/causes_api/BUILD.bazel
+++ b/services/causes_api/BUILD.bazel
@@ -1,6 +1,7 @@
 load("@aspect_bazel_lib//lib:tar.bzl", "tar")
 load("@rules_oci//oci:defs.bzl", "oci_image", "oci_load")
 load("//build:rust.bzl", "rust_binary", "rust_test")
+load("//tools/lint:format_check.bzl", "format_srcs")
 
 rust_binary(
     name = "causes_api",
@@ -67,3 +68,5 @@ filegroup(
     srcs = [":image_load"],
     output_group = "tarball",
 )
+
+format_srcs()

--- a/services/causes_cli/BUILD.bazel
+++ b/services/causes_cli/BUILD.bazel
@@ -1,4 +1,5 @@
 load("//build:rust.bzl", "rust_binary", "rust_test")
+load("//tools/lint:format_check.bzl", "format_srcs")
 
 rust_binary(
     name = "causes_cli",
@@ -23,3 +24,5 @@ rust_test(
         "@crates//:tempfile",
     ],
 )
+
+format_srcs()

--- a/tools/BUILD.bazel
+++ b/tools/BUILD.bazel
@@ -2,6 +2,7 @@ load("@rules_python//python:defs.bzl", "py_binary")
 load("@rules_shell//shell:sh_binary.bzl", "sh_binary")
 load("@rules_shell//shell:sh_test.bzl", "sh_test")
 load("//build:rust.bzl", "rust_binary")
+load("//tools/lint:format_check.bzl", "format_srcs")
 
 exports_files([
     "proto_gen_impl.sh",
@@ -133,3 +134,5 @@ sh_test(
         "@rust_host_tools//:rustfmt",
     ],
 )
+
+format_srcs()

--- a/tools/coverage.sh
+++ b/tools/coverage.sh
@@ -18,6 +18,9 @@ SKIP_FILES=(
 	"services/causes_api/src/store.rs"                 # trait delegation to api_db
 )
 
+# Runs every test in one bazel invocation, including the format_check_auto
+# tagged sh_tests. Those produce no Rust coverage data — they're bundled
+# here so the hook pays only one bazel analysis phase instead of two.
 bazel coverage "$@"
 
 if [[ ! -f "$REPORT" ]]; then

--- a/tools/lint/BUILD.bazel
+++ b/tools/lint/BUILD.bazel
@@ -3,6 +3,7 @@ load(
     "py_console_script_binary",
 )
 load("@rules_shell//shell:sh_binary.bzl", "sh_binary")
+load(":format_check.bzl", "format_srcs")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -24,7 +25,14 @@ py_console_script_binary(
     script = "pymarkdown",
 )
 
-exports_files(["run_pymarkdown.sh"])
+exports_files([
+    "run_pymarkdown.sh",
+    "run_rustfmt_check.sh",
+    "run_buildifier_check.sh",
+    "run_taplo_check.sh",
+    "run_shfmt_check.sh",
+    "run_yamlfmt_check.sh",
+])
 
 sh_binary(
     name = "run_pymarkdown",
@@ -57,3 +65,5 @@ sh_binary(
         "@bazel_tools//tools/bash/runfiles",
     ],
 )
+
+format_srcs()

--- a/tools/lint/format_check.bzl
+++ b/tools/lint/format_check.bzl
@@ -1,0 +1,128 @@
+"""Cacheable format-check primitives.
+
+Unlike aspect_rules_lint's format_multirun (which runs uncached every time via
+bazel run), these macros emit sh_test targets whose inputs — source files,
+formatter binary, formatter config — are declared. Bazel's action cache keys
+on those inputs, so repeat runs on an unchanged tree hit the cache instantly.
+"""
+
+load("@rules_shell//shell:sh_test.bzl", "sh_test")
+
+_COMMON_DATA = [
+    "@bazel_tools//tools/bash/runfiles",
+    "@rules_shell//shell/runfiles",
+]
+_FORMAT_TAG = "format_check_auto"
+
+def rustfmt_check(name, srcs, tags = [], **kwargs):
+    """sh_test that runs rustfmt --check over the .rs files in srcs.
+
+    Declared inputs:
+    - the .rs files themselves
+    - //:rustfmt.toml
+    - @rust_host_tools//:rustfmt
+    - the driver script
+
+    No-op when srcs contains no .rs files (e.g. rust_test with crate = ":foo").
+    """
+    rs_srcs = [s for s in srcs if type(s) == "string" and s.endswith(".rs")]
+    if not rs_srcs:
+        return
+    sh_test(
+        name = name,
+        srcs = ["//tools/lint:run_rustfmt_check.sh"],
+        args = ["$(rootpath %s)" % s for s in rs_srcs],
+        data = rs_srcs + [
+            "//:rustfmt.toml",
+            "@rust_host_tools//:rustfmt",
+        ] + _COMMON_DATA,
+        tags = tags + [_FORMAT_TAG],
+        **kwargs
+    )
+
+def format_srcs():
+    """Per-language filegroups aggregating this package's formattable files.
+
+    Call once at the end of each BUILD.bazel. The root-level format-check
+    targets concatenate each package's filegroups into one aggregated
+    filegroup per language.
+    """
+    native.filegroup(
+        name = "starlark_format_srcs",
+        srcs = native.glob(
+            ["*.bzl", "BUILD.bazel", "*.bazel"],
+            allow_empty = True,
+        ),
+        visibility = ["//visibility:public"],
+    )
+    native.filegroup(
+        name = "toml_format_srcs",
+        srcs = native.glob(["*.toml"], allow_empty = True),
+        visibility = ["//visibility:public"],
+    )
+    native.filegroup(
+        name = "shell_format_srcs",
+        srcs = native.glob(["*.sh"], allow_empty = True),
+        visibility = ["//visibility:public"],
+    )
+    native.filegroup(
+        name = "yaml_format_srcs",
+        srcs = native.glob(
+            ["*.yml", "*.yaml"],
+            allow_empty = True,
+        ),
+        visibility = ["//visibility:public"],
+    )
+
+def _formatter_check(name, driver, formatter_data, srcs, tags = [], **kwargs):
+    sh_test(
+        name = name,
+        srcs = [driver],
+        args = ["$(rootpaths %s)" % s for s in srcs],
+        data = srcs + formatter_data + _COMMON_DATA,
+        tags = tags + [_FORMAT_TAG],
+        **kwargs
+    )
+
+def buildifier_check(name, srcs, **kwargs):
+    """sh_test that runs buildifier -mode=check over the Starlark files in srcs."""
+    _formatter_check(
+        name = name,
+        driver = "//tools/lint:run_buildifier_check.sh",
+        formatter_data = ["@buildifier_prebuilt//:buildifier"],
+        srcs = srcs,
+        **kwargs
+    )
+
+def taplo_check(name, srcs, **kwargs):
+    """sh_test that runs `taplo format --check` over the TOML files in srcs."""
+    _formatter_check(
+        name = name,
+        driver = "//tools/lint:run_taplo_check.sh",
+        formatter_data = ["//tools/lint:taplo_extracted"],
+        srcs = srcs,
+        **kwargs
+    )
+
+def shfmt_check(name, srcs, **kwargs):
+    """sh_test that runs `shfmt -d` (diff mode) over the shell files in srcs."""
+    _formatter_check(
+        name = name,
+        driver = "//tools/lint:run_shfmt_check.sh",
+        formatter_data = ["@aspect_rules_lint//format:shfmt"],
+        srcs = srcs,
+        **kwargs
+    )
+
+def yamlfmt_check(name, srcs, **kwargs):
+    """sh_test that runs `yamlfmt -lint -conf //:.yamlfmt` over the YAML files in srcs."""
+    _formatter_check(
+        name = name,
+        driver = "//tools/lint:run_yamlfmt_check.sh",
+        formatter_data = [
+            "@aspect_rules_lint//format:yamlfmt",
+            "//:.yamlfmt",
+        ],
+        srcs = srcs,
+        **kwargs
+    )

--- a/tools/lint/run_buildifier_check.sh
+++ b/tools/lint/run_buildifier_check.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# Bazel sh_test driver: runs buildifier -mode=check over workspace-relative
+# paths received as space-separated args (from $(rootpaths :filegroup)).
+set -euo pipefail
+
+# shellcheck source=/dev/null
+if [[ -f "${RUNFILES_DIR:-/dev/null}/rules_shell/shell/runfiles/runfiles.bash" ]]; then
+	source "${RUNFILES_DIR}/rules_shell/shell/runfiles/runfiles.bash"
+elif [[ -f "${RUNFILES_DIR:-/dev/null}/bazel_tools/tools/bash/runfiles/runfiles.bash" ]]; then
+	source "${RUNFILES_DIR}/bazel_tools/tools/bash/runfiles/runfiles.bash"
+else
+	echo >&2 "ERROR: cannot find runfiles.bash"
+	exit 1
+fi
+
+BUILDIFIER="$(rlocation buildifier_prebuilt+/buildifier/buildifier)"
+
+files=()
+for arg in "$@"; do
+	for f in $arg; do
+		# $(rootpath) for same-package files emits "./foo"; rlocation rejects "./".
+		files+=("$(rlocation "_main/${f#./}")")
+	done
+done
+
+[[ ${#files[@]} -gt 0 ]] || exit 0
+exec "$BUILDIFIER" -mode=check "${files[@]}"

--- a/tools/lint/run_rustfmt_check.sh
+++ b/tools/lint/run_rustfmt_check.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# Bazel sh_test driver: runs rustfmt --check over arg files.
+# Args are workspace-relative paths ($(rootpath) from the macro).
+set -euo pipefail
+
+# shellcheck source=/dev/null
+if [[ -f "${RUNFILES_DIR:-/dev/null}/rules_shell/shell/runfiles/runfiles.bash" ]]; then
+	source "${RUNFILES_DIR}/rules_shell/shell/runfiles/runfiles.bash"
+elif [[ -f "${RUNFILES_DIR:-/dev/null}/bazel_tools/tools/bash/runfiles/runfiles.bash" ]]; then
+	source "${RUNFILES_DIR}/bazel_tools/tools/bash/runfiles/runfiles.bash"
+else
+	echo >&2 "ERROR: cannot find runfiles.bash"
+	exit 1
+fi
+
+RUSTFMT="$(rlocation rust_host_tools/bin/rustfmt)"
+CONFIG_DIR="$(dirname "$(rlocation _main/rustfmt.toml)")"
+
+if [[ $# -eq 0 ]]; then
+	exit 0
+fi
+
+files=()
+for arg in "$@"; do
+	f="$(rlocation "_main/$arg")" || {
+		echo >&2 "ERROR: cannot resolve $arg via rlocation"
+		exit 1
+	}
+	files+=("$f")
+done
+
+exec "$RUSTFMT" --check --config-path="$CONFIG_DIR" "${files[@]}"

--- a/tools/lint/run_shfmt_check.sh
+++ b/tools/lint/run_shfmt_check.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# Bazel sh_test driver: runs `shfmt -d` over workspace-relative paths received
+# as space-separated args.
+set -euo pipefail
+
+# shellcheck source=/dev/null
+if [[ -f "${RUNFILES_DIR:-/dev/null}/rules_shell/shell/runfiles/runfiles.bash" ]]; then
+	source "${RUNFILES_DIR}/rules_shell/shell/runfiles/runfiles.bash"
+elif [[ -f "${RUNFILES_DIR:-/dev/null}/bazel_tools/tools/bash/runfiles/runfiles.bash" ]]; then
+	source "${RUNFILES_DIR}/bazel_tools/tools/bash/runfiles/runfiles.bash"
+else
+	echo >&2 "ERROR: cannot find runfiles.bash"
+	exit 1
+fi
+
+SHFMT="$(rlocation rules_multitool++multitool+multitool/tools/shfmt/shfmt)"
+
+files=()
+for arg in "$@"; do
+	for f in $arg; do
+		files+=("$(rlocation "_main/${f#./}")")
+	done
+done
+
+[[ ${#files[@]} -gt 0 ]] || exit 0
+exec "$SHFMT" -d "${files[@]}"

--- a/tools/lint/run_taplo_check.sh
+++ b/tools/lint/run_taplo_check.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# Bazel sh_test driver: runs `taplo format --check` over workspace-relative
+# paths received as space-separated args.
+set -euo pipefail
+
+# shellcheck source=/dev/null
+if [[ -f "${RUNFILES_DIR:-/dev/null}/rules_shell/shell/runfiles/runfiles.bash" ]]; then
+	source "${RUNFILES_DIR}/rules_shell/shell/runfiles/runfiles.bash"
+elif [[ -f "${RUNFILES_DIR:-/dev/null}/bazel_tools/tools/bash/runfiles/runfiles.bash" ]]; then
+	source "${RUNFILES_DIR}/bazel_tools/tools/bash/runfiles/runfiles.bash"
+else
+	echo >&2 "ERROR: cannot find runfiles.bash"
+	exit 1
+fi
+
+TAPLO="$(rlocation _main/tools/lint/taplo_bin)"
+
+files=()
+for arg in "$@"; do
+	for f in $arg; do
+		files+=("$(rlocation "_main/${f#./}")")
+	done
+done
+
+[[ ${#files[@]} -gt 0 ]] || exit 0
+exec "$TAPLO" format --check "${files[@]}"

--- a/tools/lint/run_yamlfmt_check.sh
+++ b/tools/lint/run_yamlfmt_check.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# Bazel sh_test driver: runs `yamlfmt -lint` over workspace-relative paths
+# received as space-separated args.
+set -euo pipefail
+
+# shellcheck source=/dev/null
+if [[ -f "${RUNFILES_DIR:-/dev/null}/rules_shell/shell/runfiles/runfiles.bash" ]]; then
+	source "${RUNFILES_DIR}/rules_shell/shell/runfiles/runfiles.bash"
+elif [[ -f "${RUNFILES_DIR:-/dev/null}/bazel_tools/tools/bash/runfiles/runfiles.bash" ]]; then
+	source "${RUNFILES_DIR}/bazel_tools/tools/bash/runfiles/runfiles.bash"
+else
+	echo >&2 "ERROR: cannot find runfiles.bash"
+	exit 1
+fi
+
+YAMLFMT="$(rlocation rules_multitool++multitool+multitool/tools/yamlfmt/yamlfmt)"
+CONF="$(rlocation _main/.yamlfmt)"
+
+files=()
+for arg in "$@"; do
+	for f in $arg; do
+		files+=("$(rlocation "_main/${f#./}")")
+	done
+done
+
+[[ ${#files[@]} -gt 0 ]] || exit 0
+exec "$YAMLFMT" -conf "$CONF" -lint "${files[@]}"

--- a/tools/proto-gen/BUILD.bazel
+++ b/tools/proto-gen/BUILD.bazel
@@ -1,4 +1,5 @@
 load("//build:rust.bzl", "rust_binary")
+load("//tools/lint:format_check.bzl", "format_srcs")
 
 rust_binary(
     name = "proto_gen",
@@ -8,3 +9,5 @@ rust_binary(
         "@crates//:tonic-prost-build",
     ],
 )
+
+format_srcs()


### PR DESCRIPTION
## Summary

- `bazel run //:format.check` re-ran every formatter unconditionally (measured 6.8s warm) because its inputs were discovered at runtime via `git ls-files`. Replaced with Bazel `sh_test` targets that declare their inputs, so the action cache short-circuits unchanged trees.
- `build/rust.bzl` wraps `rust_library`/`rust_binary`/`rust_test` to emit a sibling `<name>_rustfmt_check` — zero commit discipline for adding new Rust targets, same pattern clippy uses via aspect in `.bazelrc`.
- Non-Rust languages (Starlark/TOML/shell/YAML) get per-package `format_srcs()` filegroups aggregated into four root-level `format_*_check` tests via new macros in `tools/lint/format_check.bzl`.
- `tools/coverage.sh` runs a single `bazel coverage //...` that covers format-check tests alongside coverage — saves one analysis phase.
- `.claude/settings.json` Stop + pre-push hooks simplified to `bash tools/coverage.sh //...`.

**Warm-cache turn-end: 8.3s → ~2.8s (3× faster).** A Rust edit pays only the affected target's `_rustfmt_check` rebuild.

## False-cache-hit defences

- `rustfmt.toml` and `.yamlfmt` exported from root and declared in `data`; rustfmt invoked with `--config-path`, yamlfmt with `-conf`.
- Formatter binary versions participate in the action cache key via runfiles hash.
- `glob()` re-evaluation picks up new files; new Rust targets auto-covered via the macro wrapper.

## Non-goals

- `//:format` (the `format_multirun` in-place formatter) is unchanged — still the way to fix formatting.
- `aspect_rules_lint`'s `format_multirun` itself is untouched; we just no longer use its `.check` variant in the hook.

## Future: TypeScript

When TS lands, wrap its `ts_project`/`js_binary` macros the same way `build/rust.bzl` wraps Rust, pointing at prettier or biome. No changes to aggregator macros or the hook needed.

## Test plan

- [x] `bazel test //... --test_tag_filters=format_check_auto --build_tests_only` passes (13 tests: 9 per-target rustfmt + 4 language aggregators).
- [x] Second run hits the test cache on every target.
- [x] Introducing a rustfmt-unclean file makes only that target's `_rustfmt_check` fail; others stay cached.
- [x] `bash tools/coverage.sh //...` still passes all Rust coverage thresholds.
- [x] Warm-cache hook total measured at 2.6–3.2s over 3 runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)