### PR TITLE
build: short-circuit coverage.sh on unchanged working copy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,9 @@ node_modules/
 .claude/settings.local.json
 .claude/scheduled_tasks.lock
 
+# tools/coverage.sh short-circuit cache — per-worktree, never committed
+.coverage-green
+
 # various native build artifacts (because IDE plugins often kick in even when not needed)
 target
 dist

--- a/tools/coverage.sh
+++ b/tools/coverage.sh
@@ -10,6 +10,23 @@ set -euo pipefail
 REPORT="bazel-out/_coverage/_coverage_report.dat"
 MIN_PCT=25
 
+# Short-circuit: if the working copy's commit_id matches a prior green run,
+# skip the bazel invocation entirely. jj auto-snapshots the working copy
+# into @, so any file edit changes commit_id; MODULE.bazel.lock, .bazelversion,
+# and every other tracked config is included in the hash.
+#
+# The cache lives at the workspace root in .coverage-green (gitignored).
+# Per-worktree by filesystem location, so parallel worktrees never ping-pong.
+# The file is ignored so jj does not snapshot it — otherwise writing the cache
+# would itself change commit_id and invalidate the next run.
+GREEN_CACHE=".coverage-green"
+WORKING_COPY_ID="$(jj log -r @ -T commit_id --no-graph 2>/dev/null || true)"
+if [[ -n "$WORKING_COPY_ID" && -f "$GREEN_CACHE" ]] &&
+	[[ "$(cat "$GREEN_CACHE")" == "$WORKING_COPY_ID $*" ]]; then
+	echo "coverage ok: unchanged since last green (commit $WORKING_COPY_ID)"
+	exit 0
+fi
+
 # Files excluded from the per-file coverage threshold.
 # "Hard to test" is NOT a valid reason — only exclude files where the code
 # is entirely constrained by the type system with no alternative implementations.
@@ -105,3 +122,9 @@ if [[ "$failed" -gt 0 ]]; then
 fi
 
 echo "coverage ok: ${#disk_files[@]} Rust source file(s) checked, all >= ${MIN_PCT}%"
+
+# Record the green state so the next identical turn short-circuits. Keyed on
+# both commit_id and the args, so a different bazel target set re-verifies.
+if [[ -n "$WORKING_COPY_ID" ]]; then
+	printf '%s %s' "$WORKING_COPY_ID" "$*" >"$GREEN_CACHE"
+fi


### PR DESCRIPTION
## Summary

Stop-hook runs `bash tools/coverage.sh //...` on every turn. `bazel coverage` warm is ~0.7s, but many turn-ends don't change files at all — reads, questions, clarifications. Cache the working-copy `commit_id` after a green run and short-circuit the next identical invocation.

jj auto-snapshots the working copy on every jj command, so `commit_id` changes whenever tracked file content changes. `MODULE.bazel.lock`, `.bazelversion`, every config file is tracked — so toolchain updates also invalidate the cache. Cache key also includes the bazel args, so a different target set re-verifies.

## Cache location: `.coverage-green` at the workspace root (gitignored)

- **Per-worktree by construction.** Two worktrees of the same repo get independent caches; no ping-pong.
- **Not snapshotted.** Because it's in `.gitignore`, jj ignores it — writing the cache doesn't change `commit_id`, which would otherwise create an infinite write-invalidate loop.
- **Follows the worktree's lifetime.** Delete the worktree, the cache goes with it. No orphans in `~/.cache/`.
- **Survives `bazel clean`.** The cache is semantically independent — it records "this commit_id has been verified green," which remains true after wiping bazel's action cache (the next miss will repopulate).

## Measured warm cost

| Scenario                          | Wall  |
|-----------------------------------|-------|
| Unchanged tree (cache hit)        | 0.27s |
| Edit → first post-edit run        | 1.7s  |
| Steady edit-free repeat           | 0.27s |

About 3.5× faster on the common case; the remaining ~270ms is `jj log` + shell startup.

## Correctness

- Cache writes only happen after the full check passes, so a broken tree doesn't poison future turns.
- Fresh worktree starts with no cache → pays one full run, then warm.
- `touch`-only (no content change) doesn't change `commit_id` → cache hit remains valid (bazel would have been a no-op anyway).
- If `jj log` fails (not a jj repo), `WORKING_COPY_ID` is empty — script always runs the full check, never writes cache.

## Test plan

- [x] Cache hit on unchanged tree: ~0.27s measured.
- [x] Content edit invalidates cache (`echo x >> README.md` → full run).
- [x] Revert returns to short-circuit after one full run.
- [x] Failed check does not write the cache (format error → bazel fails → cache untouched).
- [x] `.coverage-green` stays out of `jj status` and `commit_id`.
- [x] Pre-push hook still runs the full check (this PR's push triggered it, gated on success).

🤖 Generated with [Claude Code](https://claude.com/claude-code)