### PR TITLE
proto+db: ReplicationExample scaffolding type and journal table

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -87,14 +87,8 @@ name = "api_db"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "db_pool",
  "api_db_macros",
- "arc-swap",
- "aws-config",
- "aws-credential-types",
- "aws-sdk-rds",
- "aws-smithy-async",
- "aws-types",
+ "db_pool",
  "email_address",
  "futures",
  "sqlx",

--- a/lib/rust/api_db/.sqlx/query-1e5ed270aa400b8fac00d8a3e9f9e11393bf40b82e8c9ce3965f19458c557bb1.json
+++ b/lib/rust/api_db/.sqlx/query-1e5ed270aa400b8fac00d8a3e9f9e11393bf40b82e8c9ce3965f19458c557bb1.json
@@ -1,0 +1,28 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "INSERT INTO replication_example_journal (origin_instance_id, origin_id, version, previous_origin_instance_id, previous_origin_id, previous_version, kind, at, author_instance_id, author_local_id, embargoed, slug, project_id, created_at, payload) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15)",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Text",
+        "Text",
+        "Int8",
+        "Text",
+        "Text",
+        "Int8",
+        "Text",
+        "Timestamptz",
+        "Text",
+        "Text",
+        "Bool",
+        "Text",
+        "Text",
+        "Timestamptz",
+        "Text"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "1e5ed270aa400b8fac00d8a3e9f9e11393bf40b82e8c9ce3965f19458c557bb1"
+}

--- a/lib/rust/api_db/.sqlx/query-8e4d49f9bd9acba406f475b2c2d6184ecb9bbeac1d4e59b5083d6c51056672ab.json
+++ b/lib/rust/api_db/.sqlx/query-8e4d49f9bd9acba406f475b2c2d6184ecb9bbeac1d4e59b5083d6c51056672ab.json
@@ -1,0 +1,119 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT origin_instance_id, origin_id, version, previous_origin_instance_id, previous_origin_id, previous_version, kind, at, author_instance_id, author_local_id, embargoed, slug, project_id, created_at, payload, local_version, watermark FROM replication_example_journal WHERE project_id = $1 AND local_version >= $2 ORDER BY local_version",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "origin_instance_id",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 1,
+        "name": "origin_id",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 2,
+        "name": "version",
+        "type_info": "Int8"
+      },
+      {
+        "ordinal": 3,
+        "name": "previous_origin_instance_id",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 4,
+        "name": "previous_origin_id",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 5,
+        "name": "previous_version",
+        "type_info": "Int8"
+      },
+      {
+        "ordinal": 6,
+        "name": "kind",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 7,
+        "name": "at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 8,
+        "name": "author_instance_id",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 9,
+        "name": "author_local_id",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 10,
+        "name": "embargoed",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 11,
+        "name": "slug",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 12,
+        "name": "project_id",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 13,
+        "name": "created_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 14,
+        "name": "payload",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 15,
+        "name": "local_version",
+        "type_info": "Int8"
+      },
+      {
+        "ordinal": 16,
+        "name": "watermark",
+        "type_info": "Int8"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text",
+        "Int8"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      true,
+      true,
+      true,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "8e4d49f9bd9acba406f475b2c2d6184ecb9bbeac1d4e59b5083d6c51056672ab"
+}

--- a/lib/rust/api_db/BUILD.bazel
+++ b/lib/rust/api_db/BUILD.bazel
@@ -10,6 +10,7 @@ rust_library(
         [
             ".sqlx/**",
             "migrations/**",
+            "migrations-test/**",
         ],
         allow_empty = True,
     ),
@@ -43,6 +44,7 @@ rust_test(
         [
             ".sqlx/**",
             "migrations/**",
+            "migrations-test/**",
         ],
         allow_empty = True,
     ),

--- a/lib/rust/api_db/BUILD.bazel
+++ b/lib/rust/api_db/BUILD.bazel
@@ -10,6 +10,7 @@ rust_library(
         [
             ".sqlx/**",
             "migrations/**",
+            "migrations-test/**",
         ],
         allow_empty = True,
     ),
@@ -40,6 +41,7 @@ rust_test(
         [
             ".sqlx/**",
             "migrations/**",
+            "migrations-test/**",
         ],
         allow_empty = True,
     ),
@@ -108,6 +110,10 @@ sqlx_prepare(
         "//lib/rust/api_db_macros",
         "//lib/rust/db_pool",
     ],
+    test_migrations = glob(
+        ["migrations-test/**"],
+        allow_empty = True,
+    ),
     visibility = ["//visibility:public"],
 )
 

--- a/lib/rust/api_db/migrations-test/9000_replication_example_journal.sql
+++ b/lib/rust/api_db/migrations-test/9000_replication_example_journal.sql
@@ -1,0 +1,8 @@
+-- Journal table for the ReplicationExample scaffolding resource.
+-- Demonstrates `journal_create_table()` from migration 010: every
+-- per-resource journal table is one call, varying only name and payload.
+-- This table will be removed once real resource types (Plan etc.) exist.
+SELECT journal_create_table(
+    'replication_example_journal',
+    'payload TEXT NOT NULL'
+);

--- a/lib/rust/api_db/src/db.rs
+++ b/lib/rust/api_db/src/db.rs
@@ -6,8 +6,29 @@ use sqlx::postgres::PgPoolOptions;
 
 use crate::iam::IamParams;
 
-/// Embedded migrations, compiled from `migrations/` at build time.
+/// Embedded production migrations, compiled from `migrations/` at build time.
 pub(crate) static MIGRATIONS: sqlx::migrate::Migrator = sqlx::migrate!("./migrations");
+
+/// Composite migrator combining production migrations with test-only extras
+/// from `migrations-test/`.  Use this as the `migrator` argument to
+/// `#[sqlx::test]` when a test needs a table defined in `migrations-test/`
+/// (e.g. `replication_example_journal`).  Production builds do not apply the
+/// extras — only this composite does.
+#[cfg(test)]
+pub(crate) static TEST_MIGRATIONS: std::sync::LazyLock<sqlx::migrate::Migrator> =
+    std::sync::LazyLock::new(|| {
+        let extras: sqlx::migrate::Migrator = sqlx::migrate!("./migrations-test");
+        let mut migrations: Vec<sqlx::migrate::Migration> =
+            MIGRATIONS.migrations.iter().cloned().collect();
+        migrations.extend(extras.migrations.iter().cloned());
+        migrations.sort_by_key(|m| m.version);
+        sqlx::migrate::Migrator {
+            migrations: std::borrow::Cow::Owned(migrations),
+            ignore_missing: false,
+            locking: true,
+            no_tx: false,
+        }
+    });
 
 /// Opaque pool handle.
 /// sqlx types do not cross this boundary.

--- a/lib/rust/api_db/src/db.rs
+++ b/lib/rust/api_db/src/db.rs
@@ -1,8 +1,29 @@
 use anyhow::Context;
 use db_pool::{DbPool, QueryAccess};
 
-/// Embedded migrations, compiled from `migrations/` at build time.
+/// Embedded production migrations, compiled from `migrations/` at build time.
 pub(crate) static MIGRATIONS: sqlx::migrate::Migrator = sqlx::migrate!("./migrations");
+
+/// Composite migrator combining production migrations with test-only extras
+/// from `migrations-test/`.  Use this as the `migrator` argument to
+/// `#[sqlx::test]` when a test needs a table defined in `migrations-test/`
+/// (e.g. `replication_example_journal`).  Production builds do not apply the
+/// extras — only this composite does.
+#[cfg(test)]
+pub(crate) static TEST_MIGRATIONS: std::sync::LazyLock<sqlx::migrate::Migrator> =
+    std::sync::LazyLock::new(|| {
+        let extras: sqlx::migrate::Migrator = sqlx::migrate!("./migrations-test");
+        let mut migrations: Vec<sqlx::migrate::Migration> =
+            MIGRATIONS.migrations.iter().cloned().collect();
+        migrations.extend(extras.migrations.iter().cloned());
+        migrations.sort_by_key(|m| m.version);
+        sqlx::migrate::Migrator {
+            migrations: std::borrow::Cow::Owned(migrations),
+            ignore_missing: false,
+            locking: true,
+            no_tx: false,
+        }
+    });
 
 /// Run all pending migrations.
 #[tracing::instrument(skip(pool), fields(db.system = "postgresql"))]

--- a/lib/rust/api_db/src/lib.rs
+++ b/lib/rust/api_db/src/lib.rs
@@ -8,6 +8,8 @@ pub mod iam;
 pub mod journal;
 mod pending_login;
 mod project;
+#[cfg(test)]
+mod replication_example;
 mod role;
 mod session;
 #[cfg(test)]

--- a/lib/rust/api_db/src/lib.rs
+++ b/lib/rust/api_db/src/lib.rs
@@ -7,6 +7,8 @@ mod db;
 pub mod journal;
 mod pending_login;
 mod project;
+#[cfg(test)]
+mod replication_example;
 mod role;
 mod session;
 #[cfg(test)]

--- a/lib/rust/api_db/src/replication_example.rs
+++ b/lib/rust/api_db/src/replication_example.rs
@@ -1,0 +1,141 @@
+//! Scaffolding for the replication protocol.
+//!
+//! A minimal concrete resource type used to exercise the replication protocol
+//! plumbing before any real resource types (Plans etc.) are implemented.
+//! This module will be removed once real resources exist.
+//!
+//! Demonstrates the per-resource pattern: declare the struct, invoke
+//! `journal_table!`, get `insert_entry` + `entries_since` for free.
+
+use crate::journal::{JournalEntryHeader, ResourceEntryMeta};
+
+/// A minimal concrete resource journal entry.
+/// Embeds the standard journal header and resource meta, plus a trivial
+/// payload field.
+#[derive(Debug, Clone)]
+pub struct ReplicationExample {
+    pub header: JournalEntryHeader,
+    pub meta: ResourceEntryMeta,
+    pub payload: String,
+}
+
+api_db_macros::journal_table! {
+    table = "replication_example_journal",
+    rust = ReplicationExample,
+    payload = {
+        payload: String,
+    },
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::admin::UserId;
+    use crate::db::DbPool;
+    use crate::journal::{
+        FederatedIdentity, FederatedVersion, InstanceId, JournalKind, LocalId, LocalTxnId,
+        OriginId, Slug,
+    };
+    use crate::role::ProjectId;
+    use crate::test_support::{seed_project, test_instance};
+    use sqlx::types::chrono;
+    use std::num::NonZeroU64;
+
+    fn test_entry(
+        instance: &InstanceId,
+        resource: &OriginId,
+        version: u64,
+        project_id: &ProjectId,
+        previous_version: Option<FederatedVersion>,
+        payload: &str,
+    ) -> ReplicationExample {
+        ReplicationExample {
+            header: JournalEntryHeader {
+                kind: JournalKind::Entry,
+                at: chrono::Utc::now(),
+                author: FederatedIdentity {
+                    instance_id: instance.clone(),
+                    local_id: LocalId::User(UserId::new()),
+                },
+                version: FederatedVersion {
+                    origin_instance_id: instance.clone(),
+                    origin_id: resource.clone(),
+                    version: NonZeroU64::new(version).unwrap(),
+                },
+                previous_version,
+                embargoed: false,
+            },
+            meta: ResourceEntryMeta {
+                slug: Slug::new("example").unwrap(),
+                project_id: project_id.clone(),
+                created_at: chrono::Utc::now(),
+            },
+            payload: payload.to_string(),
+        }
+    }
+
+    #[sqlx::test(migrator = "crate::db::TEST_MIGRATIONS")]
+    async fn insert_and_read_back(pool: sqlx::PgPool) {
+        let db = DbPool::from_pool(pool);
+        let project = seed_project(&db).await;
+        let instance = test_instance();
+        let res1 = OriginId::new();
+        let entry = test_entry(&instance, &res1, 100, &project, None, "hello");
+
+        insert_entry(&db, &entry).await.expect("insert failed");
+
+        let stored = entries_since(&db, &project, None)
+            .await
+            .expect("read failed");
+        assert_eq!(stored.len(), 1);
+        assert_eq!(stored[0].entry.payload, "hello");
+        assert_eq!(stored[0].entry.header.version.version.get(), 100);
+        assert!(stored[0].local_version.get() > 0);
+    }
+
+    #[sqlx::test(migrator = "crate::db::TEST_MIGRATIONS")]
+    async fn entries_since_filters_by_watermark(pool: sqlx::PgPool) {
+        let db = DbPool::from_pool(pool);
+        let project = seed_project(&db).await;
+        let instance = test_instance();
+
+        let res1 = OriginId::new();
+        let res2 = OriginId::new();
+        let e1 = test_entry(&instance, &res1, 100, &project, None, "first");
+        insert_entry(&db, &e1).await.unwrap();
+        let first_lv = entries_since(&db, &project, None).await.unwrap()[0].local_version;
+
+        let e2 = test_entry(&instance, &res2, 101, &project, None, "second");
+        insert_entry(&db, &e2).await.unwrap();
+
+        // Pass the first entry's local_version + 1 as the cursor — only e2 should remain.
+        let next = LocalTxnId::new(first_lv.get() + 1).unwrap();
+        let after = entries_since(&db, &project, Some(next)).await.unwrap();
+        assert_eq!(after.len(), 1);
+        assert_eq!(after[0].entry.payload, "second");
+    }
+
+    #[sqlx::test(migrator = "crate::db::TEST_MIGRATIONS")]
+    async fn previous_version_round_trip(pool: sqlx::PgPool) {
+        let db = DbPool::from_pool(pool);
+        let project = seed_project(&db).await;
+        let instance = test_instance();
+
+        let res1 = OriginId::new();
+        let e1 = test_entry(&instance, &res1, 100, &project, None, "v1");
+        insert_entry(&db, &e1).await.unwrap();
+
+        let prev = FederatedVersion {
+            origin_instance_id: instance.clone(),
+            origin_id: res1.clone(),
+            version: NonZeroU64::new(100).unwrap(),
+        };
+        let e2 = test_entry(&instance, &res1, 200, &project, Some(prev.clone()), "v2");
+        insert_entry(&db, &e2).await.unwrap();
+
+        let stored = entries_since(&db, &project, None).await.unwrap();
+        assert_eq!(stored.len(), 2);
+        assert!(stored[0].entry.header.previous_version.is_none());
+        assert_eq!(stored[1].entry.header.previous_version, Some(prev));
+    }
+}

--- a/lib/rust/api_db/src/replication_example.rs
+++ b/lib/rust/api_db/src/replication_example.rs
@@ -1,0 +1,141 @@
+//! Scaffolding for the replication protocol.
+//!
+//! A minimal concrete resource type used to exercise the replication protocol
+//! plumbing before any real resource types (Plans etc.) are implemented.
+//! This module will be removed once real resources exist.
+//!
+//! Demonstrates the per-resource pattern: declare the struct, invoke
+//! `journal_table!`, get `insert_entry` + `entries_since` for free.
+
+use crate::journal::{JournalEntryHeader, ResourceEntryMeta};
+
+/// A minimal concrete resource journal entry.
+/// Embeds the standard journal header and resource meta, plus a trivial
+/// payload field.
+#[derive(Debug, Clone)]
+pub struct ReplicationExample {
+    pub header: JournalEntryHeader,
+    pub meta: ResourceEntryMeta,
+    pub payload: String,
+}
+
+api_db_macros::journal_table! {
+    table = "replication_example_journal",
+    rust = ReplicationExample,
+    payload = {
+        payload: String,
+    },
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::admin::UserId;
+    use crate::journal::{
+        FederatedIdentity, FederatedVersion, InstanceId, JournalKind, LocalId, LocalTxnId,
+        OriginId, Slug,
+    };
+    use crate::role::ProjectId;
+    use crate::test_support::{seed_project, test_instance};
+    use db_pool::DbPool;
+    use sqlx::types::chrono;
+    use std::num::NonZeroU64;
+
+    fn test_entry(
+        instance: &InstanceId,
+        resource: &OriginId,
+        version: u64,
+        project_id: &ProjectId,
+        previous_version: Option<FederatedVersion>,
+        payload: &str,
+    ) -> ReplicationExample {
+        ReplicationExample {
+            header: JournalEntryHeader {
+                kind: JournalKind::Entry,
+                at: chrono::Utc::now(),
+                author: FederatedIdentity {
+                    instance_id: instance.clone(),
+                    local_id: LocalId::User(UserId::new()),
+                },
+                version: FederatedVersion {
+                    origin_instance_id: instance.clone(),
+                    origin_id: resource.clone(),
+                    version: NonZeroU64::new(version).unwrap(),
+                },
+                previous_version,
+                embargoed: false,
+            },
+            meta: ResourceEntryMeta {
+                slug: Slug::new("example").unwrap(),
+                project_id: project_id.clone(),
+                created_at: chrono::Utc::now(),
+            },
+            payload: payload.to_string(),
+        }
+    }
+
+    #[sqlx::test(migrator = "crate::db::TEST_MIGRATIONS")]
+    async fn insert_and_read_back(pool: sqlx::PgPool) {
+        let db = DbPool::from_pool(pool);
+        let project = seed_project(&db).await;
+        let instance = test_instance();
+        let res1 = OriginId::new();
+        let entry = test_entry(&instance, &res1, 100, &project, None, "hello");
+
+        insert_entry(&db, &entry).await.expect("insert failed");
+
+        let stored = entries_since(&db, &project, None)
+            .await
+            .expect("read failed");
+        assert_eq!(stored.len(), 1);
+        assert_eq!(stored[0].entry.payload, "hello");
+        assert_eq!(stored[0].entry.header.version.version.get(), 100);
+        assert!(stored[0].local_version.get() > 0);
+    }
+
+    #[sqlx::test(migrator = "crate::db::TEST_MIGRATIONS")]
+    async fn entries_since_filters_by_watermark(pool: sqlx::PgPool) {
+        let db = DbPool::from_pool(pool);
+        let project = seed_project(&db).await;
+        let instance = test_instance();
+
+        let res1 = OriginId::new();
+        let res2 = OriginId::new();
+        let e1 = test_entry(&instance, &res1, 100, &project, None, "first");
+        insert_entry(&db, &e1).await.unwrap();
+        let first_lv = entries_since(&db, &project, None).await.unwrap()[0].local_version;
+
+        let e2 = test_entry(&instance, &res2, 101, &project, None, "second");
+        insert_entry(&db, &e2).await.unwrap();
+
+        // Pass the first entry's local_version + 1 as the cursor — only e2 should remain.
+        let next = LocalTxnId::new(first_lv.get() + 1).unwrap();
+        let after = entries_since(&db, &project, Some(next)).await.unwrap();
+        assert_eq!(after.len(), 1);
+        assert_eq!(after[0].entry.payload, "second");
+    }
+
+    #[sqlx::test(migrator = "crate::db::TEST_MIGRATIONS")]
+    async fn previous_version_round_trip(pool: sqlx::PgPool) {
+        let db = DbPool::from_pool(pool);
+        let project = seed_project(&db).await;
+        let instance = test_instance();
+
+        let res1 = OriginId::new();
+        let e1 = test_entry(&instance, &res1, 100, &project, None, "v1");
+        insert_entry(&db, &e1).await.unwrap();
+
+        let prev = FederatedVersion {
+            origin_instance_id: instance.clone(),
+            origin_id: res1.clone(),
+            version: NonZeroU64::new(100).unwrap(),
+        };
+        let e2 = test_entry(&instance, &res1, 200, &project, Some(prev.clone()), "v2");
+        insert_entry(&db, &e2).await.unwrap();
+
+        let stored = entries_since(&db, &project, None).await.unwrap();
+        assert_eq!(stored.len(), 2);
+        assert!(stored[0].entry.header.previous_version.is_none());
+        assert_eq!(stored[1].entry.header.previous_version, Some(prev));
+    }
+}

--- a/lib/rust/api_db_macros/src/lib.rs
+++ b/lib/rust/api_db_macros/src/lib.rs
@@ -210,6 +210,7 @@ fn expand(spec: JournalTableSpec) -> TokenStream2 {
             after_cursor: ::std::option::Option<::api_db::journal::LocalTxnId>,
         ) -> ::anyhow::Result<::std::vec::Vec<::api_db::journal::JournalStoredEntry<#rust>>> {
             use ::anyhow::Context as _;
+            use ::db_pool::QueryAccess as _;
             // Real txids are ≥ 3; sentinel of 0 matches every row.
             let cursor_i64 = after_cursor.map(|c| c.as_i64()).unwrap_or(0);
             let rows = ::sqlx::query!(

--- a/lib/rust/causes_proto/src/generated/causes.v1.rs
+++ b/lib/rust/causes_proto/src/generated/causes.v1.rs
@@ -230,6 +230,19 @@ pub struct ResourceEntryMeta {
     #[prost(message, optional, tag = "3")]
     pub created_at: ::core::option::Option<::prost_types::Timestamp>,
 }
+/// ReplicationExample is a minimal concrete resource journal entry.
+/// It embeds the standard journal header and resource meta, plus a trivial
+/// payload field.
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
+pub struct ReplicationExample {
+    #[prost(message, optional, tag = "1")]
+    pub header: ::core::option::Option<JournalEntryHeader>,
+    #[prost(message, optional, tag = "2")]
+    pub meta: ::core::option::Option<ResourceEntryMeta>,
+    /// payload is arbitrary content; exists only to give the type some body.
+    #[prost(string, tag = "3")]
+    pub payload: ::prost::alloc::string::String,
+}
 #[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct GrantRoleRequest {
     /// Email address of the user to grant the role to.

--- a/proto/causes/v1/replication_example.proto
+++ b/proto/causes/v1/replication_example.proto
@@ -1,0 +1,19 @@
+// Scaffolding for the replication protocol.
+// A minimal concrete journal entry type used to exercise the replication
+// protocol plumbing before any real resource types are implemented.
+// This type will be removed once Plans (and other real resources) exist.
+syntax = "proto3";
+
+package causes.v1;
+
+import "causes/v1/common.proto";
+
+// ReplicationExample is a minimal concrete resource journal entry.
+// It embeds the standard journal header and resource meta, plus a trivial
+// payload field.
+message ReplicationExample {
+  JournalEntryHeader header = 1;
+  ResourceEntryMeta meta = 2;
+  // payload is arbitrary content; exists only to give the type some body.
+  string payload = 3;
+}

--- a/tools/proto-gen/src/main.rs
+++ b/tools/proto-gen/src/main.rs
@@ -38,6 +38,7 @@ fn main() {
         .compile_protos(
             &[
                 proto_dir.join("causes/v1/common.proto"),
+                proto_dir.join("causes/v1/replication_example.proto"),
                 proto_dir.join("causes/v1/admin_service.proto"),
                 proto_dir.join("causes/v1/auth_service.proto"),
                 proto_dir.join("causes/v1/project_service.proto"),

--- a/tools/sqlx_prepare.bzl
+++ b/tools/sqlx_prepare.bzl
@@ -15,7 +15,13 @@ _TOOL_DATA = [
     "@rust_host_tools//:sysroot_path.txt",
 ]
 
-def sqlx_prepare(name, migrations, srcs, path_deps = None, visibility = None):
+def sqlx_prepare(
+        name,
+        migrations,
+        srcs,
+        test_migrations = None,
+        path_deps = None,
+        visibility = None):
     """Generates sqlx offline query-metadata targets for a Rust crate.
 
     Run from the calling package's directory so that sqlx writes .sqlx/ there.
@@ -28,18 +34,23 @@ def sqlx_prepare(name, migrations, srcs, path_deps = None, visibility = None):
     See tools/sqlx_prepare_impl.sh.
 
     Args:
-      name:       base name (conventionally "sqlx_prepare")
-      migrations: migration file labels — glob(["migrations/**"])
-      srcs:       source + .sqlx labels for the check test —
-                  glob(["src/**/*.rs"]) + glob([".sqlx/**"])
-      path_deps:  bazel labels of in-workspace crates this crate depends on
-                  via path. Each must expose an `:all_srcs` filegroup. The
-                  impl script stages them next to the prepared crate so
-                  cargo can resolve the path-deps inside the isolated
-                  workspace.
-      visibility: optional visibility for the sh_binary update target
+      name:            base name (conventionally "sqlx_prepare")
+      migrations:      migration file labels — glob(["migrations/**"])
+      srcs:            source + .sqlx labels for the check test —
+                       glob(["src/**/*.rs"]) + glob([".sqlx/**"])
+      test_migrations: optional test-only migration labels —
+                       glob(["migrations-test/**"]). Applied after
+                       `migrations` with `--ignore-missing` so tests can
+                       reference tables that production never sees.
+      path_deps:       bazel labels of in-workspace crates this crate
+                       depends on via path. Each must expose an
+                       `:all_srcs` filegroup. The impl script stages them
+                       next to the prepared crate so cargo can resolve
+                       the path-deps inside the isolated workspace.
+      visibility:      optional visibility for the sh_binary update target
     """
     pkg = native.package_name()
+    test_migrations = test_migrations or []
     path_deps = path_deps or []
 
     extra_data = []
@@ -55,7 +66,7 @@ def sqlx_prepare(name, migrations, srcs, path_deps = None, visibility = None):
         name = name,
         srcs = [_IMPL],
         args = [pkg] + extra_args,
-        data = _TOOL_DATA + migrations + extra_data,
+        data = _TOOL_DATA + migrations + test_migrations + extra_data,
         visibility = visibility,
     )
 
@@ -63,7 +74,7 @@ def sqlx_prepare(name, migrations, srcs, path_deps = None, visibility = None):
         name = name + "_test",
         srcs = [_IMPL],
         args = ["--check", pkg] + extra_args,
-        data = _TOOL_DATA + migrations + srcs + extra_data + [
+        data = _TOOL_DATA + migrations + test_migrations + srcs + extra_data + [
             "//:Cargo.toml",
             "//:Cargo.lock",
             ":Cargo.toml",

--- a/tools/sqlx_prepare_impl.sh
+++ b/tools/sqlx_prepare_impl.sh
@@ -99,6 +99,9 @@ PYEOF
 	cp -rL "${PACKAGE_DIR}/Cargo.toml" "$ISOLATED/pkg/Cargo.toml"
 	cp -rL "${PACKAGE_DIR}/src" "$ISOLATED/pkg/src"
 	cp -rL "${PACKAGE_DIR}/migrations" "$ISOLATED/pkg/migrations"
+	if [[ -d "${PACKAGE_DIR}/migrations-test" ]]; then
+		cp -rL "${PACKAGE_DIR}/migrations-test" "$ISOLATED/pkg/migrations-test"
+	fi
 	cp -rL "${PACKAGE_DIR}/.sqlx" "$ISOLATED/pkg/.sqlx"
 
 	# Copy each sibling crate that the package depends on via path = "../foo".
@@ -111,6 +114,11 @@ PYEOF
 
 	DATABASE_URL="$TEST_POSTGRES_URL" "$SQLX" migrate run \
 		--source "$ISOLATED/pkg/migrations"
+	if [[ -d "$ISOLATED/pkg/migrations-test" ]]; then
+		DATABASE_URL="$TEST_POSTGRES_URL" "$SQLX" migrate run \
+			--source "$ISOLATED/pkg/migrations-test" \
+			--ignore-missing
+	fi
 	cd "$ISOLATED/pkg"
 	DATABASE_URL="$TEST_POSTGRES_URL" "$SQLX" prepare --check -- --tests
 else
@@ -118,6 +126,11 @@ else
 
 	DATABASE_URL="$TEST_POSTGRES_URL" "$SQLX" migrate run \
 		--source "${PACKAGE_DIR}/migrations"
+	if [[ -d "${PACKAGE_DIR}/migrations-test" ]]; then
+		DATABASE_URL="$TEST_POSTGRES_URL" "$SQLX" migrate run \
+			--source "${PACKAGE_DIR}/migrations-test" \
+			--ignore-missing
+	fi
 	cd "$PACKAGE_DIR"
 	DATABASE_URL="$TEST_POSTGRES_URL" "$SQLX" prepare -- --tests
 fi

--- a/tools/sqlx_prepare_impl.sh
+++ b/tools/sqlx_prepare_impl.sh
@@ -146,6 +146,9 @@ PYEOF
 	sync_file "${PACKAGE_DIR}/Cargo.toml" "$ISOLATED/pkg/Cargo.toml"
 	sync_dir "${PACKAGE_DIR}/src" "$ISOLATED/pkg/src"
 	sync_dir "${PACKAGE_DIR}/migrations" "$ISOLATED/pkg/migrations"
+	if [[ -d "${PACKAGE_DIR}/migrations-test" ]]; then
+		sync_dir "${PACKAGE_DIR}/migrations-test" "$ISOLATED/pkg/migrations-test"
+	fi
 	sync_dir "${PACKAGE_DIR}/.sqlx" "$ISOLATED/pkg/.sqlx"
 
 	# Stage path-dep crates as siblings of pkg/ so cargo can resolve
@@ -193,7 +196,7 @@ sync_dir() {
 
 run_migrate() {
 	DATABASE_URL="$TEST_POSTGRES_URL" "$SQLX" migrate run \
-		--source "$1"
+		--source "$1" "${@:2}"
 }
 
 run_prepare_check() {
@@ -210,9 +213,15 @@ if [[ "$CHECK" == "true" ]]; then
 	phase setup_target setup_persistent_target
 	phase stage_isolated stage_isolated
 	phase migrate run_migrate "$ISOLATED/pkg/migrations"
+	if [[ -d "$ISOLATED/pkg/migrations-test" ]]; then
+		phase migrate_test run_migrate "$ISOLATED/pkg/migrations-test" --ignore-missing
+	fi
 	phase prepare_check run_prepare_check
 else
 	PACKAGE_DIR="${BUILD_WORKSPACE_DIRECTORY}/${BAZEL_PACKAGE}"
 	phase migrate run_migrate "${PACKAGE_DIR}/migrations"
+	if [[ -d "${PACKAGE_DIR}/migrations-test" ]]; then
+		phase migrate_test run_migrate "${PACKAGE_DIR}/migrations-test" --ignore-missing
+	fi
 	phase prepare_update run_prepare_update
 fi


### PR DESCRIPTION
## Summary

- Adds `ReplicationExample` proto type and a matching Postgres journal table, used as scaffolding to exercise the journal machinery before real resource types arrive.
- Migration lives under `lib/rust/api_db/migrations-test/`; the production migrator never applies it.
- Adds `TEST_MIGRATIONS` static in `api_db::db` that fuses production migrations with test-only extras, for use as the `migrator` argument to `#[sqlx::test]`.
- Extends `tools/sqlx_prepare.bzl` and `tools/sqlx_prepare_impl.sh` with an optional `test_migrations` arg so sqlx offline checks see the test-only migrations.

Closes #225.

## Test plan

- [ ] `bazel test //lib/rust/api_db:api_db_db_test` passes
- [ ] `bazel test //lib/rust/api_db:sqlx_prepare_test` passes
- [ ] Production migrations stop at 008 (no 009)