### PR TITLE
db: ReplicationExample journal table, insert, and query

### DIFF
--- a/designdocs/Replication.md
+++ b/designdocs/Replication.md
@@ -284,8 +284,8 @@ See [cognitedata/txid-syncing](https://github.com/cognitedata/txid-syncing) for 
 Each journal table includes two Postgres-specific columns:
 
 ```sql
-local_version  BIGINT NOT NULL DEFAULT pg_current_xact_id()::bigint
-watermark      BIGINT NOT NULL DEFAULT pg_snapshot_xmin(pg_current_snapshot())::bigint
+local_version  BIGINT NOT NULL DEFAULT pg_current_xact_id()::text::bigint
+watermark      BIGINT NOT NULL DEFAULT pg_snapshot_xmin(pg_current_snapshot())::text::bigint
 ```
 
 `local_version` is the transaction ID at commit time on this instance.

--- a/lib/rust/api_db/.sqlx/query-221b105230b50879ba327907435e0ec5d5b8e69cad69db5a719065d5279e442d.json
+++ b/lib/rust/api_db/.sqlx/query-221b105230b50879ba327907435e0ec5d5b8e69cad69db5a719065d5279e442d.json
@@ -1,0 +1,28 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "INSERT INTO replication_example_journal (\n            origin_instance_id, origin_id, version,\n            previous_origin_instance_id, previous_origin_id, previous_version,\n            kind, at, author_instance_id, author_local_id, embargoed,\n            slug, project_id, created_at,\n            payload\n        ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15)",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Text",
+        "Text",
+        "Int8",
+        "Text",
+        "Text",
+        "Int8",
+        "Text",
+        "Timestamptz",
+        "Text",
+        "Text",
+        "Bool",
+        "Text",
+        "Text",
+        "Timestamptz",
+        "Text"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "221b105230b50879ba327907435e0ec5d5b8e69cad69db5a719065d5279e442d"
+}

--- a/lib/rust/api_db/.sqlx/query-74a86dfa021c1a5723e4775c3651e747db1735e6b555889a16e86ce6d1cb05c8.json
+++ b/lib/rust/api_db/.sqlx/query-74a86dfa021c1a5723e4775c3651e747db1735e6b555889a16e86ce6d1cb05c8.json
@@ -1,0 +1,15 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "INSERT INTO projects (id, name, visibility) VALUES ($1, $2, 'public')",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Text",
+        "Text"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "74a86dfa021c1a5723e4775c3651e747db1735e6b555889a16e86ce6d1cb05c8"
+}

--- a/lib/rust/api_db/.sqlx/query-de8c138fde794ec12714a1c2fc28ab966adae0ffa81636473e1b996f6f7163cd.json
+++ b/lib/rust/api_db/.sqlx/query-de8c138fde794ec12714a1c2fc28ab966adae0ffa81636473e1b996f6f7163cd.json
@@ -1,0 +1,119 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT origin_instance_id, origin_id, version,\n                previous_origin_instance_id, previous_origin_id, previous_version,\n                kind, at, author_instance_id, author_local_id, embargoed,\n                slug, project_id, created_at,\n                payload, local_version, watermark\n         FROM replication_example_journal\n         WHERE project_id = $1 AND local_version >= $2\n         ORDER BY local_version",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "origin_instance_id",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 1,
+        "name": "origin_id",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 2,
+        "name": "version",
+        "type_info": "Int8"
+      },
+      {
+        "ordinal": 3,
+        "name": "previous_origin_instance_id",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 4,
+        "name": "previous_origin_id",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 5,
+        "name": "previous_version",
+        "type_info": "Int8"
+      },
+      {
+        "ordinal": 6,
+        "name": "kind",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 7,
+        "name": "at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 8,
+        "name": "author_instance_id",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 9,
+        "name": "author_local_id",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 10,
+        "name": "embargoed",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 11,
+        "name": "slug",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 12,
+        "name": "project_id",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 13,
+        "name": "created_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 14,
+        "name": "payload",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 15,
+        "name": "local_version",
+        "type_info": "Int8"
+      },
+      {
+        "ordinal": 16,
+        "name": "watermark",
+        "type_info": "Int8"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text",
+        "Int8"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      true,
+      true,
+      true,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "de8c138fde794ec12714a1c2fc28ab966adae0ffa81636473e1b996f6f7163cd"
+}

--- a/lib/rust/api_db/migrations/009_replication_example_journal.sql
+++ b/lib/rust/api_db/migrations/009_replication_example_journal.sql
@@ -1,0 +1,66 @@
+-- Journal table for the ReplicationExample scaffolding resource.
+-- This table will be removed when real resource types (Plans etc.) exist.
+-- The schema serves as the reference shape for per-resource journal tables.
+
+CREATE TABLE replication_example_journal (
+    -- JournalEntryHeader: federation identity
+    origin_instance_id TEXT   NOT NULL,
+    origin_id          TEXT   NOT NULL,
+    version            BIGINT NOT NULL,
+
+    -- JournalEntryHeader: previous version (nullable triple — all-or-none)
+    previous_origin_instance_id TEXT,
+    previous_origin_id          TEXT,
+    previous_version            BIGINT,
+
+    -- JournalEntryHeader: other fields
+    kind                TEXT        NOT NULL,  -- 'entry' or 'tombstone'
+    at                  TIMESTAMPTZ NOT NULL,
+    author_instance_id  TEXT        NOT NULL,
+    author_local_id     TEXT        NOT NULL,
+    embargoed           BOOLEAN     NOT NULL DEFAULT false,
+
+    -- ResourceEntryMeta fields
+    slug        TEXT        NOT NULL,
+    project_id  TEXT        NOT NULL REFERENCES projects(id),
+    created_at  TIMESTAMPTZ NOT NULL,
+
+    -- Resource-specific fields
+    payload     TEXT        NOT NULL,
+
+    -- Replication-serving columns (Postgres-specific, not in proto)
+    local_version BIGINT NOT NULL DEFAULT pg_current_xact_id()::text::bigint,
+    watermark     BIGINT NOT NULL DEFAULT pg_snapshot_xmin(pg_current_snapshot())::text::bigint,
+
+    PRIMARY KEY (origin_instance_id, origin_id, version),
+
+    -- All three previous_* columns must be set together or none at all.
+    CONSTRAINT previous_version_all_or_none CHECK (
+        (previous_origin_instance_id IS NULL
+            AND previous_origin_id IS NULL
+            AND previous_version IS NULL)
+        OR
+        (previous_origin_instance_id IS NOT NULL
+            AND previous_origin_id IS NOT NULL
+            AND previous_version IS NOT NULL)
+    )
+);
+
+-- Replication serving index: project + local commit order.
+CREATE INDEX replication_example_journal_local_version_idx
+    ON replication_example_journal (project_id, local_version);
+
+-- Trigger-compatible wrapper around check_repeatable_read().
+-- Each journal table uses this trigger function to enforce isolation on writes.
+CREATE FUNCTION check_repeatable_read_trigger() RETURNS trigger AS $$
+BEGIN
+    PERFORM check_repeatable_read();
+    RETURN NULL;
+END;
+$$ LANGUAGE plpgsql;
+
+-- Enforce snapshot isolation on writes.
+CREATE TRIGGER replication_example_journal_check_isolation
+    BEFORE INSERT OR UPDATE ON replication_example_journal
+    FOR EACH STATEMENT
+    EXECUTE FUNCTION check_repeatable_read_trigger();

--- a/lib/rust/api_db/src/replication_example.rs
+++ b/lib/rust/api_db/src/replication_example.rs
@@ -4,7 +4,15 @@
 //! plumbing before any real resource types (Plans etc.) are implemented.
 //! This module will be removed once real resources exist.
 
-use crate::journal::{JournalEntryHeader, ResourceEntryMeta};
+use std::num::NonZeroU64;
+
+use anyhow::Context;
+
+use crate::db::DbPool;
+use crate::journal::{
+    FederatedIdentity, FederatedVersion, InstanceId, JournalEntryHeader, ResourceEntryMeta,
+};
+use crate::role::ProjectId;
 
 /// A minimal concrete resource journal entry.
 /// Embeds the standard journal header and resource meta, plus a trivial
@@ -14,4 +22,283 @@ pub struct ReplicationExample {
     pub header: JournalEntryHeader,
     pub meta: ResourceEntryMeta,
     pub payload: String,
+}
+
+/// Insert a journal entry into `replication_example_journal`.
+///
+/// Runs in a REPEATABLE READ transaction (required by the replication
+/// protocol's causal ordering guarantee, enforced by the table trigger).
+/// `local_version` and `watermark` are assigned by the database via DEFAULT
+/// expressions.
+pub async fn insert_entry(pool: &DbPool, entry: &ReplicationExample) -> anyhow::Result<()> {
+    let version_i64: i64 = entry
+        .header
+        .version
+        .version
+        .get()
+        .try_into()
+        .context("version does not fit in i64")?;
+
+    let (prev_instance, prev_id, prev_version): (Option<String>, Option<String>, Option<i64>) =
+        match &entry.header.previous_version {
+            None => (None, None, None),
+            Some(prev) => {
+                let v: i64 = prev
+                    .version
+                    .get()
+                    .try_into()
+                    .context("previous_version does not fit in i64")?;
+                (
+                    Some(prev.origin_instance_id.as_str().to_owned()),
+                    Some(prev.origin_id.clone()),
+                    Some(v),
+                )
+            }
+        };
+
+    let mut tx = pool.pool().begin().await.context("beginning transaction")?;
+    sqlx::query("SET TRANSACTION ISOLATION LEVEL REPEATABLE READ")
+        .execute(&mut *tx)
+        .await
+        .context("setting isolation level")?;
+
+    sqlx::query!(
+        "INSERT INTO replication_example_journal (
+            origin_instance_id, origin_id, version,
+            previous_origin_instance_id, previous_origin_id, previous_version,
+            kind, at, author_instance_id, author_local_id, embargoed,
+            slug, project_id, created_at,
+            payload
+        ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15)",
+        entry.header.version.origin_instance_id.as_str(),
+        entry.header.version.origin_id,
+        version_i64,
+        prev_instance,
+        prev_id,
+        prev_version,
+        entry.header.kind.as_str(),
+        entry.header.at,
+        entry.header.author.instance_id.as_str(),
+        entry.header.author.local_id,
+        entry.header.embargoed,
+        entry.meta.slug,
+        entry.meta.project_id.as_str(),
+        entry.meta.created_at,
+        entry.payload,
+    )
+    .execute(&mut *tx)
+    .await
+    .context("inserting replication_example journal entry")?;
+
+    tx.commit().await.context("committing transaction")?;
+    Ok(())
+}
+
+/// One row from `replication_example_journal` with its Postgres-specific
+/// replication columns exposed.
+#[derive(Debug, Clone)]
+pub struct StoredEntry {
+    pub entry: ReplicationExample,
+    pub local_version: i64,
+    pub watermark: i64,
+}
+
+/// Fetch entries for a project with `local_version >= after_watermark`,
+/// ordered by `local_version` ascending.
+///
+/// This is the core replication-serving query: the caller passes the last
+/// watermark it saw, and the server returns entries from there onward.
+/// Entries with the same `local_version` as `after_watermark` may be
+/// re-delivered (at-least-once); callers must dedup by federated version.
+pub async fn entries_since(
+    pool: &DbPool,
+    project_id: &ProjectId,
+    after_watermark: i64,
+) -> anyhow::Result<Vec<StoredEntry>> {
+    let rows = sqlx::query!(
+        "SELECT origin_instance_id, origin_id, version,
+                previous_origin_instance_id, previous_origin_id, previous_version,
+                kind, at, author_instance_id, author_local_id, embargoed,
+                slug, project_id, created_at,
+                payload, local_version, watermark
+         FROM replication_example_journal
+         WHERE project_id = $1 AND local_version >= $2
+         ORDER BY local_version",
+        project_id.as_str(),
+        after_watermark,
+    )
+    .fetch_all(&pool.pool())
+    .await
+    .context("querying replication_example journal")?;
+
+    rows.into_iter()
+        .map(|r| {
+            let version = FederatedVersion {
+                origin_instance_id: InstanceId::from_raw(&r.origin_instance_id)?,
+                origin_id: r.origin_id,
+                version: NonZeroU64::new(r.version.try_into().context("version out of range")?)
+                    .context("version is zero")?,
+            };
+
+            let previous_version = match (
+                r.previous_origin_instance_id,
+                r.previous_origin_id,
+                r.previous_version,
+            ) {
+                (None, None, None) => None,
+                (Some(i), Some(id), Some(v)) => Some(FederatedVersion {
+                    origin_instance_id: InstanceId::from_raw(&i)?,
+                    origin_id: id,
+                    version: NonZeroU64::new(v.try_into().context("prev version out of range")?)
+                        .context("previous_version is zero")?,
+                }),
+                _ => anyhow::bail!("partial previous_version triple"),
+            };
+
+            let header = JournalEntryHeader {
+                kind: r.kind.parse()?,
+                at: r.at,
+                author: FederatedIdentity {
+                    instance_id: InstanceId::from_raw(&r.author_instance_id)?,
+                    local_id: r.author_local_id,
+                },
+                version,
+                previous_version,
+                embargoed: r.embargoed,
+            };
+            let meta = ResourceEntryMeta {
+                slug: r.slug,
+                project_id: ProjectId::new(r.project_id)?,
+                created_at: r.created_at,
+            };
+
+            Ok(StoredEntry {
+                entry: ReplicationExample {
+                    header,
+                    meta,
+                    payload: r.payload,
+                },
+                local_version: r.local_version,
+                watermark: r.watermark,
+            })
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::journal::JournalKind;
+    use sqlx::types::chrono;
+    use uuid::Uuid;
+
+    fn test_instance() -> InstanceId {
+        InstanceId::from_raw(&Uuid::new_v4().to_string()).unwrap()
+    }
+
+    fn test_entry(
+        instance: &InstanceId,
+        resource_id: &str,
+        version: u64,
+        project_id: &ProjectId,
+        previous_version: Option<FederatedVersion>,
+        payload: &str,
+    ) -> ReplicationExample {
+        ReplicationExample {
+            header: JournalEntryHeader {
+                kind: JournalKind::Entry,
+                at: chrono::Utc::now(),
+                author: FederatedIdentity {
+                    instance_id: instance.clone(),
+                    local_id: "user-1".to_string(),
+                },
+                version: FederatedVersion {
+                    origin_instance_id: instance.clone(),
+                    origin_id: resource_id.to_string(),
+                    version: NonZeroU64::new(version).unwrap(),
+                },
+                previous_version,
+                embargoed: false,
+            },
+            meta: ResourceEntryMeta {
+                slug: "example".to_string(),
+                project_id: project_id.clone(),
+                created_at: chrono::Utc::now(),
+            },
+            payload: payload.to_string(),
+        }
+    }
+
+    async fn seed_project(pool: &DbPool) -> ProjectId {
+        // Bypass the normal project creation (which requires a user) by
+        // directly inserting a minimal project row for the test.
+        let id = Uuid::new_v4().to_string();
+        sqlx::query!(
+            "INSERT INTO projects (id, name, visibility) VALUES ($1, $2, 'public')",
+            id,
+            format!("p-{}", &id[..8]),
+        )
+        .execute(&pool.pool())
+        .await
+        .expect("seed project");
+        ProjectId::new(id).unwrap()
+    }
+
+    #[sqlx::test(migrator = "crate::db::MIGRATIONS")]
+    async fn insert_and_read_back(pool: sqlx::PgPool) {
+        let db = DbPool::from_pool(pool);
+        let project = seed_project(&db).await;
+        let instance = test_instance();
+        let entry = test_entry(&instance, "res-1", 100, &project, None, "hello");
+
+        insert_entry(&db, &entry).await.expect("insert failed");
+
+        let stored = entries_since(&db, &project, 0).await.expect("read failed");
+        assert_eq!(stored.len(), 1);
+        assert_eq!(stored[0].entry.payload, "hello");
+        assert_eq!(stored[0].entry.header.version.version.get(), 100);
+        assert!(stored[0].local_version > 0);
+    }
+
+    #[sqlx::test(migrator = "crate::db::MIGRATIONS")]
+    async fn entries_since_filters_by_watermark(pool: sqlx::PgPool) {
+        let db = DbPool::from_pool(pool);
+        let project = seed_project(&db).await;
+        let instance = test_instance();
+
+        let e1 = test_entry(&instance, "res-1", 100, &project, None, "first");
+        insert_entry(&db, &e1).await.unwrap();
+        let first_lv = entries_since(&db, &project, 0).await.unwrap()[0].local_version;
+
+        let e2 = test_entry(&instance, "res-2", 101, &project, None, "second");
+        insert_entry(&db, &e2).await.unwrap();
+
+        // Pass the first entry's local_version + 1 as the cursor — only e2 should remain.
+        let after = entries_since(&db, &project, first_lv + 1).await.unwrap();
+        assert_eq!(after.len(), 1);
+        assert_eq!(after[0].entry.payload, "second");
+    }
+
+    #[sqlx::test(migrator = "crate::db::MIGRATIONS")]
+    async fn previous_version_round_trip(pool: sqlx::PgPool) {
+        let db = DbPool::from_pool(pool);
+        let project = seed_project(&db).await;
+        let instance = test_instance();
+
+        let e1 = test_entry(&instance, "res-1", 100, &project, None, "v1");
+        insert_entry(&db, &e1).await.unwrap();
+
+        let prev = FederatedVersion {
+            origin_instance_id: instance.clone(),
+            origin_id: "res-1".to_string(),
+            version: NonZeroU64::new(100).unwrap(),
+        };
+        let e2 = test_entry(&instance, "res-1", 200, &project, Some(prev.clone()), "v2");
+        insert_entry(&db, &e2).await.unwrap();
+
+        let stored = entries_since(&db, &project, 0).await.unwrap();
+        assert_eq!(stored.len(), 2);
+        assert!(stored[0].entry.header.previous_version.is_none());
+        assert_eq!(stored[1].entry.header.previous_version, Some(prev));
+    }
 }


### PR DESCRIPTION
## Summary

- Add migration 009: `replication_example_journal` table with full journal header + resource meta + payload, plus Postgres replication columns (`local_version`, `watermark`) defaulting to `pg_current_xact_id()` and `pg_snapshot_xmin()`
- Add `check_repeatable_read_trigger()` wrapper and BEFORE trigger on the table — writes fail if isolation is below REPEATABLE READ
- Check constraint ensures `previous_version` triple is all-or-none
- Add Rust functions `insert_entry()` (opens REPEATABLE READ transaction) and `entries_since()` (replication-serving query ordered by `local_version`)
- `StoredEntry` exposes `local_version` and `watermark` columns for replication
- Fix stale `::bigint` cast in `Replication.md` — `xid8` requires `::text::bigint`

Stacked on #224.

## Test plan

- [x] `tools/coverage.sh //...` — 38 files, all above threshold
- [x] Tests: insert-and-read, watermark filtering, previous_version round-trip
- [x] Markdown lint passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)