### PR TITLE
docs: TLA+ model of replication protocol safety

### DIFF
--- a/designdocs/Replication.md
+++ b/designdocs/Replication.md
@@ -5,6 +5,7 @@ It is the specification for implementors building a Causes-compatible instance o
 
 For the design rationale behind these decisions, see [ADR-013](Decisions.md#adr-013-replication-protocol) in Decisions.md.
 For the broader federation strategy, see [ADR-006](Decisions.md#adr-006-federation-strategy--distribute-dont-federate-by-default).
+For a machine-checked TLA+ model of the protocol's safety properties, see [tla/Replication.tla](tla/Replication.tla).
 
 ## Overview
 

--- a/designdocs/tla/README.md
+++ b/designdocs/tla/README.md
@@ -1,0 +1,81 @@
+# TLA+ specification of the replication protocol
+
+`Replication.tla` is a formal model of the protocol described in [../Replication.md](../Replication.md), small enough to fit in a finite state space yet rich enough to exercise the interesting interactions: dedup under multi-path delivery, embargo filtering with asymmetric trust, the previous-version chain across instances, and replication path tracking.
+
+The model intentionally does **not** include out-of-order commits / watermark mechanics.
+Versions are atomic and monotonic per node.
+The watermark behaviour is exercised in the Rust `txn_sim` module instead, which can model concurrent transactions cheaply.
+
+## Running the model checker
+
+Prerequisite: a JRE 11 or later.
+On Debian/Ubuntu:
+
+```sh
+sudo apt install openjdk-21-jre-headless
+```
+
+Then:
+
+```sh
+designdocs/tla/run_tlc.sh
+```
+
+The script downloads `tla2tools.jar` to `~/.cache/tla/` on first run and invokes TLC on `Replication.tla` with `Replication.cfg`.
+
+To pass extra TLC flags:
+
+```sh
+designdocs/tla/run_tlc.sh -workers auto
+```
+
+## What the spec covers
+
+Constants (configured in `Replication.cfg`):
+
+- `Nodes = {"A", "B", "C"}`
+- `Projects = {"P1"}`
+- `ResourceIds = {"r1"}`
+- `Trust`: `A` and `B` serve embargoed content to each other; `C` is excluded
+- `MaxOps = 4`: cap on operations to keep the state space finite
+
+Actions:
+
+- `Create(node, rid, proj, emb)`: write a new resource on `node`
+- `Edit(node, prev)`: write a follow-up referencing an existing entry on this node (cross-instance edits create a new origin entry on the editor)
+- `Pull(receiver, upstream, proj)`: receiver pulls eligible entries from upstream — applies embargo trust, dedup, and origin filter
+
+Invariants checked at every reachable state:
+
+- `NoDuplicates`: no two entries on a node share `(origin, rid, ver)`
+- `PathStartsWithOrigin`: every stored entry's path begins with its origin
+- `PathEndsWithSelf`: every stored entry's path ends with the storing node
+- `EmbargoFilter`: embargoed entries traverse only trusted hops
+- `ProjectIsolation`: every entry has a valid project
+- `ChainIntactOrEmbargoGap`: previous-version references resolve locally OR the referenced entry is embargoed (acceptable gap)
+- `TypeOK`: type-correctness of all variables
+
+## State space size
+
+Observed at time of writing on a devcontainer with 32 cores:
+
+| MaxOps | Distinct states | Wall time    |
+|--------|-----------------|--------------|
+| 4      | 1 147           | < 1 s        |
+| 5      | 6 035           | < 1 s        |
+| 6      | 34 504          | ~2 s         |
+
+The default is 6.
+Higher values scale roughly 5-6× per added op; beyond 8 or 9 ops, TLC starts needing more time and memory.
+
+Increasing `Nodes` grows the space faster still.
+For exhaustive runs over a bigger space, pass `-workers auto` to parallelise.
+
+## Limitations vs. the protocol spec
+
+- No watermark / out-of-order commits (use `txn_sim` for that)
+- No tombstone op (single `kind = entry` only)
+- Trust matrix is configuration-time; runtime trust changes not modelled
+- No liveness assertions (model checker can be extended with `[]<>` for eventual consistency under fairness; deferred)
+
+These limitations let the spec stay focused on safety properties of the routing/dedup/embargo logic.

--- a/designdocs/tla/Replication.cfg
+++ b/designdocs/tla/Replication.cfg
@@ -1,0 +1,18 @@
+SPECIFICATION Spec
+
+\* Substitute abstract constants with concrete values defined in ReplicationMC.
+CONSTANTS
+    Nodes <- MCNodes
+    Projects <- MCProjects
+    ResourceIds <- MCResourceIds
+    Trust <- MCTrust
+    MaxOps <- MCMaxOps
+
+INVARIANTS
+    NoDuplicates
+    PathStartsWithOrigin
+    PathEndsWithSelf
+    EmbargoFilter
+    ProjectIsolation
+    ChainIntactOrEmbargoGap
+    TypeOK

--- a/designdocs/tla/Replication.tla
+++ b/designdocs/tla/Replication.tla
@@ -1,0 +1,220 @@
+---------------------------- MODULE Replication ----------------------------
+(***************************************************************************)
+(* TLA+ specification of the Causes replication protocol.                  *)
+(*                                                                         *)
+(* Models a small bounded state space: a few nodes, one project, one       *)
+(* resource id, a handful of operations.  Despite the small size, the      *)
+(* state space exercises the interesting behaviours: dedup under multi-    *)
+(* path delivery, embargo filtering with asymmetric trust, the previous-   *)
+(* version chain across instances, and replication path tracking.          *)
+(*                                                                         *)
+(* Out-of-order commits (the watermark mechanism) are NOT modelled here    *)
+(* — we treat each write as atomic and version monotonic per node.  The    *)
+(* watermark simulation lives in the Rust `txn_sim` module instead.        *)
+(*                                                                         *)
+(* Run:                                                                    *)
+(*   designdocs/tla/run_tlc.sh                                             *)
+(***************************************************************************)
+EXTENDS Naturals, FiniteSets, Sequences, TLC
+
+CONSTANTS
+    Nodes,         \* Set of node identifiers, e.g. {"A", "B", "C"}
+    Projects,      \* Set of projects, e.g. {"P1"}
+    ResourceIds,   \* Set of resource identifiers, e.g. {"r1"}
+    Trust,         \* Function: Node -> SUBSET Nodes (peers served embargoed)
+    MaxOps         \* Bound on total operations (keeps state space finite)
+
+ASSUME Trust \in [Nodes -> SUBSET Nodes]
+ASSUME MaxOps \in Nat
+
+VARIABLES
+    entries,        \* Function: Node -> SUBSET Entry
+    cursors,        \* Function: Node -> Node -> Project -> Nat
+    nextVersion,    \* Function: Node -> Nat
+    opCount         \* Total number of operations performed
+
+vars == <<entries, cursors, nextVersion, opCount>>
+
+(***************************************************************************)
+(* An entry carries the journal header fields plus path tracking:          *)
+(*   origin: the writing node (origin_instance_id)                         *)
+(*   rid:    the resource id (origin_id)                                   *)
+(*   ver:    the version assigned by the writing node                     *)
+(*   prev:   federated reference to previous version (or NullRef)         *)
+(*   emb:    embargo flag                                                  *)
+(*   proj:   the project this entry belongs to                            *)
+(*   path:   sequence of nodes — first is origin, last is storing node    *)
+(***************************************************************************)
+NullRef == [origin |-> "_", rid |-> "_", ver |-> 0]
+
+VRef(e) == [origin |-> e.origin, rid |-> e.rid, ver |-> e.ver]
+
+\* Has the receiver already stored an entry with this federated identity?
+Has(receiver, origin, rid, ver) ==
+    \E e \in entries[receiver] :
+        e.origin = origin /\ e.rid = rid /\ e.ver = ver
+
+\* Maximum of a non-empty natural-number set
+Max(S) == CHOOSE x \in S : \A y \in S : x >= y
+
+(***************************************************************************)
+(* Initial state: nothing exists, all cursors zero, no ops performed.     *)
+(***************************************************************************)
+Init ==
+    /\ entries = [n \in Nodes |-> {}]
+    /\ cursors = [n \in Nodes |-> [u \in Nodes |-> [p \in Projects |-> 0]]]
+    /\ nextVersion = [n \in Nodes |-> 1]
+    /\ opCount = 0
+
+(***************************************************************************)
+(* Action: a node creates a brand-new resource.                            *)
+(* Constraint: this node has not previously created an entry with this    *)
+(* (origin=self, rid) pair.                                               *)
+(***************************************************************************)
+Create(n, rid, proj, emb) ==
+    /\ opCount < MaxOps
+    /\ \A e \in entries[n] : ~(e.origin = n /\ e.rid = rid)
+    /\ LET v == nextVersion[n]
+           entry == [origin |-> n, rid |-> rid, ver |-> v,
+                     prev   |-> NullRef, emb |-> emb,
+                     proj   |-> proj, path |-> <<n>>]
+       IN
+           /\ entries' = [entries EXCEPT ![n] = @ \cup {entry}]
+           /\ nextVersion' = [nextVersion EXCEPT ![n] = v + 1]
+    /\ opCount' = opCount + 1
+    /\ UNCHANGED cursors
+
+(***************************************************************************)
+(* Action: a node edits an entry it already has.  Produces a new entry    *)
+(* on the editing node; previous_version chains back to the source.       *)
+(* The new entry's origin is the editor (cross-instance edits create new  *)
+(* origin entries; same-instance edits keep origin = editor too).         *)
+(***************************************************************************)
+Edit(n, prev) ==
+    /\ opCount < MaxOps
+    /\ prev \in entries[n]
+    /\ LET v == nextVersion[n]
+           entry == [origin |-> n, rid |-> prev.rid, ver |-> v,
+                     prev   |-> VRef(prev), emb |-> prev.emb,
+                     proj   |-> prev.proj, path |-> <<n>>]
+       IN
+           /\ entries' = [entries EXCEPT ![n] = @ \cup {entry}]
+           /\ nextVersion' = [nextVersion EXCEPT ![n] = v + 1]
+    /\ opCount' = opCount + 1
+    /\ UNCHANGED cursors
+
+(***************************************************************************)
+(* Action: receiver pulls all eligible entries from upstream for proj.    *)
+(* Filters: not originated at receiver; embargoed only if upstream serves  *)
+(* embargo to receiver; not already present (dedup).                      *)
+(* Cursor advances to the max version of all visible entries (since we    *)
+(* don't model out-of-order commits, version itself is the watermark).    *)
+(***************************************************************************)
+Pull(receiver, upstream, proj) ==
+    /\ opCount < MaxOps
+    /\ receiver # upstream
+    /\ LET cur        == cursors[receiver][upstream][proj]
+           serveEmb   == receiver \in Trust[upstream]
+           visible    == { e \in entries[upstream] :
+                             e.proj = proj /\ e.ver >= cur }
+           candidates == { e \in visible :
+                             /\ e.origin # receiver
+                             /\ (~e.emb \/ serveEmb)
+                             /\ ~Has(receiver, e.origin, e.rid, e.ver) }
+           accepted   == { [origin |-> e.origin, rid |-> e.rid, ver |-> e.ver,
+                            prev   |-> e.prev, emb |-> e.emb,
+                            proj   |-> e.proj,
+                            path   |-> e.path \o <<receiver>>] :
+                           e \in candidates }
+           newCursor  == IF visible = {} THEN cur ELSE Max({e.ver : e \in visible})
+       IN
+           /\ entries' = [entries EXCEPT ![receiver] = @ \cup accepted]
+           /\ cursors' =
+                 [cursors EXCEPT ![receiver] =
+                    [@ EXCEPT ![upstream] =
+                       [@ EXCEPT ![proj] = newCursor]]]
+    /\ opCount' = opCount + 1
+    /\ UNCHANGED nextVersion
+
+(***************************************************************************)
+(* Next-state relation: at each step, perform one of the available        *)
+(* actions.  Quantifiers enumerate every possible parameter combination.  *)
+(***************************************************************************)
+Next ==
+    \/ \E n \in Nodes, rid \in ResourceIds, proj \in Projects, emb \in BOOLEAN :
+        Create(n, rid, proj, emb)
+    \/ \E n \in Nodes : \E e \in entries[n] : Edit(n, e)
+    \/ \E r \in Nodes, u \in Nodes, p \in Projects : Pull(r, u, p)
+
+Spec == Init /\ [][Next]_vars
+
+(***************************************************************************)
+(*                              Invariants                                 *)
+(***************************************************************************)
+
+\* No two entries on a node share federated identity.
+NoDuplicates ==
+    \A n \in Nodes :
+        \A e1, e2 \in entries[n] :
+            (e1.origin = e2.origin /\ e1.rid = e2.rid /\ e1.ver = e2.ver)
+                => e1 = e2
+
+\* Path begins with the writing instance.
+PathStartsWithOrigin ==
+    \A n \in Nodes :
+        \A e \in entries[n] :
+            Head(e.path) = e.origin
+
+\* Path ends with the storing node.
+PathEndsWithSelf ==
+    \A n \in Nodes :
+        \A e \in entries[n] :
+            e.path[Len(e.path)] = n
+
+\* An embargoed entry has a path consisting only of trusted hops:
+\* every step path[i] -> path[i+1] is allowed because path[i] serves
+\* embargoed content to path[i+1].
+EmbargoFilter ==
+    \A n \in Nodes :
+        \A e \in entries[n] :
+            e.emb =>
+                \A i \in 1..(Len(e.path) - 1) :
+                    e.path[i+1] \in Trust[e.path[i]]
+
+\* Every entry's project is one of the configured projects.
+ProjectIsolation ==
+    \A n \in Nodes :
+        \A e \in entries[n] :
+            e.proj \in Projects
+
+\* If an entry's previous_version is non-null, the referenced entry is
+\* either present on the same node OR is embargoed (acceptable gap when
+\* we couldn't legally see it).
+ChainIntactOrEmbargoGap ==
+    \A n \in Nodes :
+        \A e \in entries[n] :
+            e.prev # NullRef =>
+                \/ Has(n, e.prev.origin, e.prev.rid, e.prev.ver)
+                \/ \E other \in Nodes :
+                       \E p \in entries[other] :
+                           /\ p.origin = e.prev.origin
+                           /\ p.rid = e.prev.rid
+                           /\ p.ver = e.prev.ver
+                           /\ p.emb
+
+\* Type correctness — useful sanity check, also bounds the state space.
+TypeOK ==
+    /\ entries \in [Nodes -> SUBSET [
+            origin: Nodes \cup {"_"},
+            rid: ResourceIds \cup {"_"},
+            ver: 0..MaxOps,
+            prev: [origin: Nodes \cup {"_"}, rid: ResourceIds \cup {"_"}, ver: 0..MaxOps],
+            emb: BOOLEAN,
+            proj: Projects,
+            path: Seq(Nodes)
+        ]]
+    /\ cursors \in [Nodes -> [Nodes -> [Projects -> 0..MaxOps]]]
+    /\ nextVersion \in [Nodes -> 1..(MaxOps + 1)]
+    /\ opCount \in 0..MaxOps
+
+=============================================================================

--- a/designdocs/tla/ReplicationMC.tla
+++ b/designdocs/tla/ReplicationMC.tla
@@ -1,0 +1,23 @@
+---------------------------- MODULE ReplicationMC ----------------------------
+(***************************************************************************)
+(* Model-checking configuration for Replication.tla.  Binds constants to   *)
+(* concrete values; TLC's .cfg file can't express record literals directly *)
+(* so we define them here and substitute via CONSTANTS <- in the .cfg.     *)
+(***************************************************************************)
+EXTENDS Replication
+
+MCNodes == {"A", "B", "C"}
+MCProjects == {"P1"}
+MCResourceIds == {"r1"}
+
+\* A and B mutually trust each other for embargoed content; C is excluded.
+MCTrust == [
+    n \in MCNodes |->
+        IF n = "A" THEN {"B"}
+        ELSE IF n = "B" THEN {"A"}
+        ELSE {}
+]
+
+MCMaxOps == 6
+
+=============================================================================

--- a/designdocs/tla/run_tlc.sh
+++ b/designdocs/tla/run_tlc.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# Run the TLA+ TLC model checker against Replication.tla.
+#
+# Prerequisites:
+#   - Java 11 or later (e.g. `apt install openjdk-21-jre-headless`).
+#
+# Downloads tla2tools.jar on first run and caches it in ~/.cache/tla.
+# Pass extra TLC arguments after `--`, e.g. `run_tlc.sh -- -workers auto`.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CACHE_DIR="${HOME}/.cache/tla"
+JAR_PATH="${CACHE_DIR}/tla2tools.jar"
+JAR_VERSION="1.8.0"
+JAR_URL="https://github.com/tlaplus/tlaplus/releases/download/v${JAR_VERSION}/tla2tools.jar"
+
+if ! command -v java >/dev/null 2>&1; then
+	echo "ERROR: java is not installed." >&2
+	echo "Install OpenJDK 11+ (e.g. 'sudo apt install openjdk-21-jre-headless')." >&2
+	exit 1
+fi
+
+if [ ! -f "${JAR_PATH}" ]; then
+	echo "Downloading tla2tools.jar v${JAR_VERSION} to ${JAR_PATH}..."
+	mkdir -p "${CACHE_DIR}"
+	curl -fsSL -o "${JAR_PATH}.tmp" "${JAR_URL}"
+	mv "${JAR_PATH}.tmp" "${JAR_PATH}"
+fi
+
+cd "${SCRIPT_DIR}"
+exec java -XX:+UseParallelGC -cp "${JAR_PATH}" tlc2.TLC \
+	-config Replication.cfg \
+	-deadlock \
+	"$@" \
+	ReplicationMC.tla


### PR DESCRIPTION
## Summary

Bounded TLA+ model of the replication protocol, checked with TLC.

The model covers routing, dedup, embargo filtering (with asymmetric trust), path tracking, and the previous-version chain. Out-of-order commits / watermark mechanics are not modelled — those are covered by the Rust \`txn_sim\` module.

Stacked on #233.

### Model

- 3 nodes, 1 project, 1 resource, MaxOps=6
- Trust matrix: A↔B trusted; C excluded
- Actions: Create, Edit, Pull
- Invariants: NoDuplicates, PathStartsWithOrigin, PathEndsWithSelf, EmbargoFilter, ProjectIsolation, ChainIntactOrEmbargoGap, TypeOK

### Observed state space

| MaxOps | Distinct states | Wall time |
|--------|-----------------|-----------|
| 4      | 1 147           | < 1 s     |
| 5      | 6 035           | < 1 s     |
| 6      | 34 504          | ~2 s      |

Verified: TLC catches a deliberately-false invariant (confirmed against \`entries[n] = {}\` which fails on the first Create step with a full counterexample trace).

### Running

Requires a JRE locally (not in the devcontainer default):

\`\`\`sh
sudo apt install openjdk-21-jre-headless
designdocs/tla/run_tlc.sh
\`\`\`

The script downloads \`tla2tools.jar\` on first run and caches it in \`~/.cache/tla/\`.

### Files

- \`designdocs/tla/Replication.tla\` — abstract spec
- \`designdocs/tla/ReplicationMC.tla\` — concrete constants for TLC
- \`designdocs/tla/Replication.cfg\` — TLC configuration
- \`designdocs/tla/run_tlc.sh\` — runner (downloads tools, invokes TLC)
- \`designdocs/tla/README.md\` — run instructions + state-space table
- \`designdocs/Replication.md\` — linked from the intro

No Bazel integration yet — this is exploratory and requires external Java. Bazel-hosted JRE + tla2tools is a separate yak-shave.

## Test plan

- [x] \`bash designdocs/tla/run_tlc.sh\` — 34k states, all invariants hold
- [x] \`bazel test //:pymarkdown\` — markdown lint passes
- [x] \`tools/coverage.sh //...\` — unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)