### PR TITLE
test: hermetic TLA+ via bazel and protocol-faithful txn model

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -59,6 +59,32 @@ http_file(
     url = "https://github.com/theseus-rs/postgresql-binaries/releases/download/17.9.0/postgresql-17.9.0-x86_64-unknown-linux-gnu.tar.gz",
 )
 
+# Eclipse Temurin JRE 21 for Linux x86_64.  Used by //infra/tla to run TLC.
+# Update by checking https://github.com/adoptium/temurin21-binaries/releases
+# and recomputing sha256.
+http_archive(
+    name = "temurin_jre_linux_amd64",
+    build_file_content = """
+filegroup(
+    name = "files",
+    srcs = glob(["**"]),
+    visibility = ["//visibility:public"],
+)
+""",
+    sha256 = "553dda64b3b1c3c16f8afe402377ffebe64fb4a1721a46ed426a91fd18185e62",
+    strip_prefix = "jdk-21.0.5+11-jre",
+    url = "https://github.com/adoptium/temurin21-binaries/releases/download/jdk-21.0.5%2B11/OpenJDK21U-jre_x64_linux_hotspot_21.0.5_11.tar.gz",
+)
+
+# TLA+ tools (TLC model checker, SANY parser, etc.) bundled as a single jar.
+# Update: check https://github.com/tlaplus/tlaplus/releases for new versions.
+http_file(
+    name = "tla2tools",
+    downloaded_file_path = "tla2tools.jar",
+    sha256 = "af03b2baae73b523fe162c0ff195c5adeed42cd1d092200b0bde2cd15914f624",
+    url = "https://github.com/tlaplus/tlaplus/releases/download/v1.8.0/tla2tools.jar",
+)
+
 # AWS CLI 2.34.14 Linux amd64, used by //infra:aws.
 # Update: download new zip, run sha256sum, update version and sha256 here.
 # https://awscli.amazonaws.com/awscli-exe-linux-x86_64-VERSION.zip

--- a/designdocs/tla/BUILD.bazel
+++ b/designdocs/tla/BUILD.bazel
@@ -1,0 +1,53 @@
+load("//infra/tla:defs.bzl", "tla_test")
+load("//tools/lint:format_check.bzl", "format_srcs")
+load("//tools/lint:linters.bzl", "markdown_lint_test")
+
+# Routing-only model: dedup, paths, embargo filter, chain integrity.
+# Fast (~1s); always runs in CI.
+tla_test(
+    name = "replication_tlc_test",
+    srcs = [
+        "Replication.tla",
+        "ReplicationMC.tla",
+    ],
+    config = "Replication.cfg",
+    entry = "ReplicationMC.tla",
+)
+
+# Protocol-faithful model with txn lifecycle: admits Postgres-style out-of-
+# order commits.  Adds the NoCommittedEntryLost invariant which proves the
+# watermark cursor doesn't permanently skip late-committing entries.
+# Slower than the routing-only model.
+tla_test(
+    name = "replication_txn_tlc_test",
+    srcs = [
+        "Replication.tla",
+        "ReplicationMC.tla",
+        "ReplicationTxn.tla",
+        "ReplicationTxnMC.tla",
+    ],
+    config = "ReplicationTxn.cfg",
+    entry = "ReplicationTxnMC.tla",
+)
+
+# Deeper run of the txn model with MaxOps=10 (~17s, ~2.9M states).
+# Tagged manual so it only runs on explicit invocation.
+tla_test(
+    name = "replication_txn_deep_tlc_test",
+    srcs = [
+        "Replication.tla",
+        "ReplicationMC.tla",
+        "ReplicationTxn.tla",
+        "ReplicationTxnDeepMC.tla",
+    ],
+    config = "ReplicationTxnDeep.cfg",
+    entry = "ReplicationTxnDeepMC.tla",
+    tags = ["manual"],
+)
+
+format_srcs()
+
+markdown_lint_test(
+    name = "pymarkdown",
+    srcs = ["README.md"],
+)

--- a/designdocs/tla/README.md
+++ b/designdocs/tla/README.md
@@ -1,81 +1,76 @@
 # TLA+ specification of the replication protocol
 
-`Replication.tla` is a formal model of the protocol described in [../Replication.md](../Replication.md), small enough to fit in a finite state space yet rich enough to exercise the interesting interactions: dedup under multi-path delivery, embargo filtering with asymmetric trust, the previous-version chain across instances, and replication path tracking.
+Formal models of the protocol described in [../Replication.md](../Replication.md), checked with [TLC](https://lamport.azurewebsites.net/tla/tla.html).
 
-The model intentionally does **not** include out-of-order commits / watermark mechanics.
-Versions are atomic and monotonic per node.
-The watermark behaviour is exercised in the Rust `txn_sim` module instead, which can model concurrent transactions cheaply.
+Two models with increasing fidelity:
 
-## Running the model checker
+- [`Replication.tla`](Replication.tla) — routing-only.
+  Versions are a simple per-node counter with atomic assignment.
+  Fast; checks dedup, path, embargo, chain.
 
-Prerequisite: a JRE 11 or later.
-On Debian/Ubuntu:
+- [`ReplicationTxn.tla`](ReplicationTxn.tla) — protocol-faithful.
+  Models transaction lifecycle (begin/insert/commit), allowing out-of-order commits.
+  Adds `NoCommittedEntryLost` to verify the watermark cursor doesn't permanently skip late-committing entries.
+  Admits the Postgres reference implementation.
 
-```sh
-sudo apt install openjdk-21-jre-headless
-```
+The routing-only model existed first.
+Moving to the txn model caught a real modelling error: my first attempt filtered replication on origin-version rather than local-version, which would have lost entries when receivers forwarded replicated content.
+The counterexample trace pointed straight at the confused identifier; the fix matched the reference implementation's separation of `origin_id+version` (federated identity) from `local_version` (per-node commit order).
 
-Then:
+## Running
 
-```sh
-designdocs/tla/run_tlc.sh
-```
-
-The script downloads `tla2tools.jar` to `~/.cache/tla/` on first run and invokes TLC on `Replication.tla` with `Replication.cfg`.
-
-To pass extra TLC flags:
+Both models run under Bazel with a hermetic JRE + tla2tools.jar fetched on first build:
 
 ```sh
-designdocs/tla/run_tlc.sh -workers auto
+# Fast — always in CI.
+bazel test //designdocs/tla:replication_tlc_test
+bazel test //designdocs/tla:replication_txn_tlc_test
+
+# Deeper — manual (~17s).
+bazel test //designdocs/tla:replication_txn_deep_tlc_test
 ```
 
-## What the spec covers
+For ad-hoc runs outside Bazel (e.g. when iterating on the spec), use the shell wrapper, which requires Java locally and caches `tla2tools.jar` in `~/.cache/tla`:
 
-Constants (configured in `Replication.cfg`):
+```sh
+designdocs/tla/run_tlc.sh                 # defaults to Replication model
+```
 
-- `Nodes = {"A", "B", "C"}`
-- `Projects = {"P1"}`
-- `ResourceIds = {"r1"}`
-- `Trust`: `A` and `B` serve embargoed content to each other; `C` is excluded
-- `MaxOps = 4`: cap on operations to keep the state space finite
+Or run `bazel test` as above for the Bazel-hermetic path.
 
-Actions:
+## What the specs cover
 
-- `Create(node, rid, proj, emb)`: write a new resource on `node`
-- `Edit(node, prev)`: write a follow-up referencing an existing entry on this node (cross-instance edits create a new origin entry on the editor)
-- `Pull(receiver, upstream, proj)`: receiver pulls eligible entries from upstream — applies embargo trust, dedup, and origin filter
+### Routing-only model (`Replication.tla`)
 
-Invariants checked at every reachable state:
+Actions: `Create`, `Edit`, `Pull`.
+Invariants: `NoDuplicates`, `PathStartsWithOrigin`, `PathEndsWithSelf`, `EmbargoFilter`, `ProjectIsolation`, `ChainIntactOrEmbargoGap`, `TypeOK`.
 
-- `NoDuplicates`: no two entries on a node share `(origin, rid, ver)`
-- `PathStartsWithOrigin`: every stored entry's path begins with its origin
-- `PathEndsWithSelf`: every stored entry's path ends with the storing node
-- `EmbargoFilter`: embargoed entries traverse only trusted hops
-- `ProjectIsolation`: every entry has a valid project
-- `ChainIntactOrEmbargoGap`: previous-version references resolve locally OR the referenced entry is embargoed (acceptable gap)
-- `TypeOK`: type-correctness of all variables
+### Txn model (`ReplicationTxn.tla`)
 
-## State space size
+Adds: each insert allocates a txid and is uncommitted until `Commit(n, v)` runs.
+Multiple transactions can be in-flight concurrently; commits can interleave with other commits and pulls.
+Each row carries its own `localVersion` (per-instance commit-order position) and `watermark` (lowest in-flight version at insert time).
+Pull filters on `localVersion` and advances the cursor to `max(watermark)` of the visible set.
 
-Observed at time of writing on a devcontainer with 32 cores:
+Extra invariant: **`NoCommittedEntryLost`** — for any committed entry on an upstream with `localVersion < cursor[receiver][upstream][project]`, either the receiver has it, or the receiver is the origin, or the entry is embargoed to an untrusted peer.
+This is precisely the property the watermark mechanism exists to preserve: cursor advance must never skip a late-committing entry.
 
-| MaxOps | Distinct states | Wall time    |
-|--------|-----------------|--------------|
-| 4      | 1 147           | < 1 s        |
-| 5      | 6 035           | < 1 s        |
-| 6      | 34 504          | ~2 s         |
+## Observed state-space sizes
 
-The default is 6.
-Higher values scale roughly 5-6× per added op; beyond 8 or 9 ops, TLC starts needing more time and memory.
+On a devcontainer with `-workers auto`:
 
-Increasing `Nodes` grows the space faster still.
-For exhaustive runs over a bigger space, pass `-workers auto` to parallelise.
+| Model                          | MaxOps | Distinct states | Wall time |
+|--------------------------------|--------|-----------------|-----------|
+| `Replication`                  | 4      | 1 147           | < 1 s     |
+| `Replication`                  | 6      | 34 504          | ~2 s      |
+| `ReplicationTxn`               | 7      | 15 011          | ~3 s      |
+| `ReplicationTxn`               | 8      | 109 184         | ~3 s      |
+| `ReplicationTxn`               | 9 (CI) | 540 853         | ~5 s      |
+| `ReplicationTxnDeep`           | 10     | 2 883 330       | ~17 s     |
 
-## Limitations vs. the protocol spec
+## Limitations
 
-- No watermark / out-of-order commits (use `txn_sim` for that)
-- No tombstone op (single `kind = entry` only)
-- Trust matrix is configuration-time; runtime trust changes not modelled
-- No liveness assertions (model checker can be extended with `[]<>` for eventual consistency under fairness; deferred)
-
-These limitations let the spec stay focused on safety properties of the routing/dedup/embargo logic.
+- Single project, single resource id — combinations of multiple projects/resources are modelled by the Rust `replication_sim` instead, which is faster to iterate
+- No tombstone op (entries are either present or not)
+- No liveness (TLC `[]<>` supported but not used — eventual-consistency assertions live in the Rust sim's quiescence checks)
+- Trust matrix is static

--- a/designdocs/tla/ReplicationTxn.cfg
+++ b/designdocs/tla/ReplicationTxn.cfg
@@ -1,0 +1,18 @@
+SPECIFICATION Spec
+
+CONSTANTS
+    Nodes <- MCNodes
+    Projects <- MCProjects
+    ResourceIds <- MCResourceIds
+    Trust <- MCTrust
+    MaxOps <- MCMaxOps
+
+INVARIANTS
+    NoDuplicates
+    PathStartsWithOrigin
+    PathEndsWithSelf
+    EmbargoFilter
+    ProjectIsolation
+    ChainIntactOrEmbargoGap
+    NoCommittedEntryLost
+    TypeOK

--- a/designdocs/tla/ReplicationTxn.tla
+++ b/designdocs/tla/ReplicationTxn.tla
@@ -1,0 +1,256 @@
+--------------------------- MODULE ReplicationTxn ---------------------------
+(***************************************************************************)
+(* Protocol-faithful TLA+ model: admits any implementation that satisfies  *)
+(* the causal-ordering constraint on versions, including those (like the   *)
+(* Postgres reference implementation) where transactions can commit out    *)
+(* of order.                                                               *)
+(*                                                                         *)
+(* Differences from Replication.tla:                                       *)
+(* - Each insert begins a transaction with a fresh version, then commits   *)
+(*   later (possibly after other transactions have committed).             *)
+(* - Each row carries a watermark = min(in-flight versions at insert       *)
+(*   time).  This is the "safe resume point" for cursor wind-back.         *)
+(* - Pull only sees committed rows.                                        *)
+(* - Cursor advances to the max watermark of visible entries (not max     *)
+(*   version), allowing the protocol to deliver late-committing entries   *)
+(*   that have ver < cursor on a subsequent pull.                          *)
+(*                                                                         *)
+(* This subsumes the simpler model: any execution of Replication.tla      *)
+(* corresponds to a serialised execution here (where every Begin is       *)
+(* immediately followed by Commit before any other action).                *)
+(***************************************************************************)
+EXTENDS Naturals, FiniteSets, Sequences, TLC
+
+CONSTANTS Nodes, Projects, ResourceIds, Trust, MaxOps
+
+ASSUME Trust \in [Nodes -> SUBSET Nodes]
+ASSUME MaxOps \in Nat
+
+VARIABLES
+    entries,        \* Node -> SUBSET Entry
+    cursors,        \* Node -> Node -> Project -> Nat
+    nextVersion,    \* Node -> Nat (txid allocator)
+    inFlight,       \* Node -> SUBSET Nat (in-flight txids)
+    opCount
+
+vars == <<entries, cursors, nextVersion, inFlight, opCount>>
+
+NullRef == [origin |-> "_", rid |-> "_", ver |-> 0]
+VRef(e) == [origin |-> e.origin, rid |-> e.rid, ver |-> e.ver]
+
+Min(S) == CHOOSE x \in S : \A y \in S : x <= y
+Max(S) == CHOOSE x \in S : \A y \in S : x >= y
+
+\* xmin observed at insert time on node n: the lowest in-flight version
+\* (including the new one being allocated).
+XminWith(n, newV) == Min(inFlight[n] \cup {newV})
+
+Has(receiver, origin, rid, ver) ==
+    \E e \in entries[receiver] :
+        e.origin = origin /\ e.rid = rid /\ e.ver = ver
+
+Init ==
+    /\ entries = [n \in Nodes |-> {}]
+    /\ cursors = [n \in Nodes |-> [u \in Nodes |-> [p \in Projects |-> 0]]]
+    /\ nextVersion = [n \in Nodes |-> 1]
+    /\ inFlight = [n \in Nodes |-> {}]
+    /\ opCount = 0
+
+(***************************************************************************)
+(* Action: open a transaction and write a brand-new resource entry.       *)
+(* The entry is uncommitted; visible only after Commit.                   *)
+(*                                                                         *)
+(* For locally-authored entries: localVersion == ver == txid.             *)
+(***************************************************************************)
+BeginNew(n, rid, proj, emb) ==
+    /\ opCount < MaxOps
+    /\ \A e \in entries[n] : ~(e.origin = n /\ e.rid = rid)
+    /\ LET v == nextVersion[n]
+           wm == XminWith(n, v)
+           entry == [origin |-> n, rid |-> rid, ver |-> v,
+                     localVersion |-> v, watermark |-> wm,
+                     prev |-> NullRef, emb |-> emb,
+                     committed |-> FALSE,
+                     proj |-> proj, path |-> <<n>>]
+       IN
+           /\ entries' = [entries EXCEPT ![n] = @ \cup {entry}]
+           /\ nextVersion' = [nextVersion EXCEPT ![n] = v + 1]
+           /\ inFlight' = [inFlight EXCEPT ![n] = @ \cup {v}]
+    /\ opCount' = opCount + 1
+    /\ UNCHANGED cursors
+
+(***************************************************************************)
+(* Action: open a transaction that edits an existing committed entry.     *)
+(* Same-instance edit pattern.                                            *)
+(***************************************************************************)
+BeginEdit(n, prev) ==
+    /\ opCount < MaxOps
+    /\ prev \in entries[n]
+    /\ prev.committed
+    /\ LET v == nextVersion[n]
+           wm == XminWith(n, v)
+           entry == [origin |-> n, rid |-> prev.rid, ver |-> v,
+                     localVersion |-> v, watermark |-> wm,
+                     prev |-> VRef(prev), emb |-> prev.emb,
+                     committed |-> FALSE,
+                     proj |-> prev.proj, path |-> <<n>>]
+       IN
+           /\ entries' = [entries EXCEPT ![n] = @ \cup {entry}]
+           /\ nextVersion' = [nextVersion EXCEPT ![n] = v + 1]
+           /\ inFlight' = [inFlight EXCEPT ![n] = @ \cup {v}]
+    /\ opCount' = opCount + 1
+    /\ UNCHANGED cursors
+
+(***************************************************************************)
+(* Action: commit an in-flight transaction.  All entries with version=v   *)
+(* on this node become visible.                                           *)
+(***************************************************************************)
+Commit(n, v) ==
+    /\ opCount < MaxOps
+    /\ v \in inFlight[n]
+    /\ entries' = [entries EXCEPT ![n] =
+            { IF e.ver = v
+              THEN [e EXCEPT !.committed = TRUE]
+              ELSE e : e \in entries[n] }]
+    /\ inFlight' = [inFlight EXCEPT ![n] = @ \ {v}]
+    /\ opCount' = opCount + 1
+    /\ UNCHANGED <<cursors, nextVersion>>
+
+(***************************************************************************)
+(* Action: receiver pulls committed entries from upstream.                *)
+(* Filter is on `localVersion` (upstream's local commit order), not `ver` *)
+(* (origin's version).  The receiver assigns its own localVersion and    *)
+(* watermark when storing the entry — replicated entries get a fresh txid *)
+(* in the receiver's namespace, matching the reference implementation.   *)
+(***************************************************************************)
+Pull(receiver, upstream, proj) ==
+    /\ opCount < MaxOps
+    /\ receiver # upstream
+    /\ LET cur        == cursors[receiver][upstream][proj]
+           serveEmb   == receiver \in Trust[upstream]
+           visible    == { e \in entries[upstream] :
+                             /\ e.committed
+                             /\ e.proj = proj
+                             /\ e.localVersion >= cur }
+           candidates == { e \in visible :
+                             /\ e.origin # receiver
+                             /\ (~e.emb \/ serveEmb)
+                             /\ ~Has(receiver, e.origin, e.rid, e.ver) }
+           recvTxid   == nextVersion[receiver]
+           recvWm     == XminWith(receiver, recvTxid)
+           accepted   == { [origin |-> e.origin, rid |-> e.rid, ver |-> e.ver,
+                            localVersion |-> recvTxid, watermark |-> recvWm,
+                            prev |-> e.prev, emb |-> e.emb,
+                            committed |-> TRUE,
+                            proj |-> e.proj,
+                            path |-> e.path \o <<receiver>>] :
+                           e \in candidates }
+           newCursor  == IF visible = {} THEN cur
+                         ELSE Max({e.watermark : e \in visible})
+       IN
+           /\ entries' = [entries EXCEPT ![receiver] = @ \cup accepted]
+           /\ cursors' = [cursors EXCEPT ![receiver] =
+                            [@ EXCEPT ![upstream] =
+                               [@ EXCEPT ![proj] = newCursor]]]
+           /\ nextVersion' = IF candidates = {} THEN nextVersion
+                             ELSE [nextVersion EXCEPT ![receiver] = recvTxid + 1]
+    /\ opCount' = opCount + 1
+    /\ UNCHANGED inFlight
+
+Next ==
+    \/ \E n \in Nodes, rid \in ResourceIds, proj \in Projects, emb \in BOOLEAN :
+        BeginNew(n, rid, proj, emb)
+    \/ \E n \in Nodes : \E e \in entries[n] : BeginEdit(n, e)
+    \/ \E n \in Nodes : \E v \in inFlight[n] : Commit(n, v)
+    \/ \E r \in Nodes, u \in Nodes, p \in Projects : Pull(r, u, p)
+
+Spec == Init /\ [][Next]_vars
+
+(***************************************************************************)
+(*                              Invariants                                 *)
+(***************************************************************************)
+
+NoDuplicates ==
+    \A n \in Nodes :
+        \A e1, e2 \in entries[n] :
+            (e1.origin = e2.origin /\ e1.rid = e2.rid /\ e1.ver = e2.ver)
+                => e1 = e2
+
+PathStartsWithOrigin ==
+    \A n \in Nodes :
+        \A e \in entries[n] :
+            Head(e.path) = e.origin
+
+PathEndsWithSelf ==
+    \A n \in Nodes :
+        \A e \in entries[n] :
+            e.path[Len(e.path)] = n
+
+EmbargoFilter ==
+    \A n \in Nodes :
+        \A e \in entries[n] :
+            e.emb =>
+                \A i \in 1..(Len(e.path) - 1) :
+                    e.path[i+1] \in Trust[e.path[i]]
+
+ProjectIsolation ==
+    \A n \in Nodes :
+        \A e \in entries[n] :
+            e.proj \in Projects
+
+\* The new, more interesting invariant.  If the cursor on r for (u, p) has
+\* advanced past some committed entry e on u, then either r has e, or r
+\* would never legally receive e (origin or embargo filter).
+\*
+\* In other words: no committed entry is permanently lost just because the
+\* cursor moved past it.  This is precisely what the watermark mechanism
+\* exists to prevent — without it, a cursor advance to max(version) could
+\* skip a late-committing low-version entry.
+NoCommittedEntryLost ==
+    \A r \in Nodes :
+        \A u \in Nodes :
+            \A p \in Projects :
+                \A e \in entries[u] :
+                    (e.committed /\ e.proj = p
+                        /\ e.localVersion < cursors[r][u][p]) =>
+                            \/ Has(r, e.origin, e.rid, e.ver)
+                            \/ e.origin = r
+                            \/ (e.emb /\ r \notin Trust[u])
+
+\* previous_version chain integrity (only checked on committed entries).
+ChainIntactOrEmbargoGap ==
+    \A n \in Nodes :
+        \A e \in entries[n] :
+            (e.committed /\ e.prev # NullRef) =>
+                \/ \E q \in entries[n] :
+                    /\ q.committed
+                    /\ q.origin = e.prev.origin
+                    /\ q.rid = e.prev.rid
+                    /\ q.ver = e.prev.ver
+                \/ \E other \in Nodes : \E p \in entries[other] :
+                    /\ p.origin = e.prev.origin
+                    /\ p.rid = e.prev.rid
+                    /\ p.ver = e.prev.ver
+                    /\ p.emb
+
+TypeOK ==
+    /\ entries \in [Nodes -> SUBSET [
+            origin: Nodes \cup {"_"},
+            rid: ResourceIds \cup {"_"},
+            ver: 0..(MaxOps * Cardinality(Nodes)),
+            localVersion: 0..(MaxOps * Cardinality(Nodes)),
+            watermark: 0..(MaxOps * Cardinality(Nodes)),
+            prev: [origin: Nodes \cup {"_"},
+                   rid: ResourceIds \cup {"_"},
+                   ver: 0..(MaxOps * Cardinality(Nodes))],
+            emb: BOOLEAN,
+            committed: BOOLEAN,
+            proj: Projects,
+            path: Seq(Nodes)
+        ]]
+    /\ cursors \in [Nodes -> [Nodes -> [Projects -> 0..(MaxOps * Cardinality(Nodes))]]]
+    /\ nextVersion \in [Nodes -> 1..(MaxOps + 1)]
+    /\ inFlight \in [Nodes -> SUBSET (1..MaxOps)]
+    /\ opCount \in 0..MaxOps
+
+=============================================================================

--- a/designdocs/tla/ReplicationTxnDeep.cfg
+++ b/designdocs/tla/ReplicationTxnDeep.cfg
@@ -1,0 +1,18 @@
+SPECIFICATION Spec
+
+CONSTANTS
+    Nodes <- MCNodes
+    Projects <- MCProjects
+    ResourceIds <- MCResourceIds
+    Trust <- MCTrust
+    MaxOps <- MCMaxOps
+
+INVARIANTS
+    NoDuplicates
+    PathStartsWithOrigin
+    PathEndsWithSelf
+    EmbargoFilter
+    ProjectIsolation
+    ChainIntactOrEmbargoGap
+    NoCommittedEntryLost
+    TypeOK

--- a/designdocs/tla/ReplicationTxnDeepMC.tla
+++ b/designdocs/tla/ReplicationTxnDeepMC.tla
@@ -1,0 +1,18 @@
+--------------------------- MODULE ReplicationTxnDeepMC ---------------------------
+(* Deeper model-checking run: MaxOps=10.  Runs for ~17s and explores      *)
+(* ~2.9M states.  Tagged manual so it doesn't run in every CI cycle;      *)
+(* run with `bazel test //designdocs/tla:replication_txn_deep_tlc_test`.  *)
+EXTENDS ReplicationTxn
+
+MCNodes == {"A", "B", "C"}
+MCProjects == {"P1"}
+MCResourceIds == {"r1"}
+MCTrust == [
+    n \in MCNodes |->
+        IF n = "A" THEN {"B"}
+        ELSE IF n = "B" THEN {"A"}
+        ELSE {}
+]
+MCMaxOps == 10
+
+=============================================================================

--- a/designdocs/tla/ReplicationTxnMC.tla
+++ b/designdocs/tla/ReplicationTxnMC.tla
@@ -1,0 +1,15 @@
+--------------------------- MODULE ReplicationTxnMC ---------------------------
+EXTENDS ReplicationTxn
+
+MCNodes == {"A", "B", "C"}
+MCProjects == {"P1"}
+MCResourceIds == {"r1"}
+MCTrust == [
+    n \in MCNodes |->
+        IF n = "A" THEN {"B"}
+        ELSE IF n = "B" THEN {"A"}
+        ELSE {}
+]
+MCMaxOps == 9
+
+=============================================================================

--- a/infra/tla/BUILD.bazel
+++ b/infra/tla/BUILD.bazel
@@ -1,0 +1,6 @@
+load("//tools/lint:format_check.bzl", "format_srcs")
+
+# The hermetic TLC runner script — invoked by tla_test rules across the repo.
+exports_files(["run_tlc.sh"])
+
+format_srcs()

--- a/infra/tla/defs.bzl
+++ b/infra/tla/defs.bzl
@@ -1,0 +1,39 @@
+"""Macros for running TLC against TLA+ specs hermetically under Bazel."""
+
+load("@rules_shell//shell:sh_test.bzl", "sh_test")
+
+def tla_test(name, srcs, entry, config, tags = None, **kwargs):
+    """Run TLC against a TLA+ specification as a bazel test.
+
+    Args:
+        name: test target name.
+        srcs: all .tla files needed (entry + EXTENDed modules).
+        entry: the .tla file to model-check.
+        config: the .cfg file describing constants and invariants.
+        tags: extra tags (e.g. ["manual"] for slow specs).
+        **kwargs: additional sh_test kwargs.
+    """
+    if entry not in srcs:
+        fail("entry %r must be in srcs" % entry)
+    if not config.endswith(".cfg"):
+        fail("config %r must end in .cfg" % config)
+
+    # Compute repo-prefixed paths so the runner can rlocation() them.
+    # `_main` is the workspace name in bzlmod.
+    pkg = native.package_name()
+    cfg_rlocation = "_main/{}/{}".format(pkg, config)
+    tla_rlocation = "_main/{}/{}".format(pkg, entry)
+
+    sh_test(
+        name = name,
+        srcs = ["//infra/tla:run_tlc.sh"],
+        args = [cfg_rlocation, tla_rlocation],
+        data = srcs + [
+            config,
+            "@bazel_tools//tools/bash/runfiles",
+            "@temurin_jre_linux_amd64//:files",
+            "@tla2tools//file",
+        ],
+        tags = tags,
+        **kwargs
+    )

--- a/infra/tla/run_tlc.sh
+++ b/infra/tla/run_tlc.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+# Hermetic TLC runner.  Used by both `bazel run //infra/tla:tlc` and
+# `tla_test` rules in //designdocs/tla:BUILD.bazel.
+#
+# Arguments:
+#   $1: relative path to the .cfg file (resolved via runfiles)
+#   $2: relative path to the entry .tla file
+#   remaining: additional TLC flags
+#
+# Resolves the JRE and tla2tools.jar from runfiles so the entire toolchain
+# is hermetic.
+
+set -euo pipefail
+
+# Standard Bazel 3-way runfiles init.
+if [[ -f "${RUNFILES_DIR:-/dev/null}/bazel_tools/tools/bash/runfiles/runfiles.bash" ]]; then
+	# shellcheck source=/dev/null
+	source "${RUNFILES_DIR}/bazel_tools/tools/bash/runfiles/runfiles.bash"
+elif [[ -f "${BASH_SOURCE[0]}.runfiles/bazel_tools/tools/bash/runfiles/runfiles.bash" ]]; then
+	# shellcheck source=/dev/null
+	source "${BASH_SOURCE[0]}.runfiles/bazel_tools/tools/bash/runfiles/runfiles.bash"
+elif [[ -f "${RUNFILES_MANIFEST_FILE:-/dev/null}" ]]; then
+	# shellcheck source=/dev/null
+	source "$(grep -m1 "^bazel_tools/tools/bash/runfiles/runfiles.bash " \
+		"$RUNFILES_MANIFEST_FILE" | cut -d ' ' -f2-)"
+else
+	echo >&2 "ERROR: cannot find Bazel runfiles library"
+	exit 1
+fi
+
+JAVA="$(rlocation +http_archive+temurin_jre_linux_amd64/bin/java)"
+JAR="$(rlocation +http_file+tla2tools/file/tla2tools.jar)"
+
+if [[ ! -x "${JAVA}" ]]; then
+	echo "ERROR: java not found in runfiles at ${JAVA}" >&2
+	exit 1
+fi
+if [[ ! -f "${JAR}" ]]; then
+	echo "ERROR: tla2tools.jar not found in runfiles at ${JAR}" >&2
+	exit 1
+fi
+
+CFG_REL="$1"
+TLA_REL="$2"
+shift 2
+
+CFG="$(rlocation "${CFG_REL}")"
+TLA="$(rlocation "${TLA_REL}")"
+if [[ ! -f "${CFG}" || ! -f "${TLA}" ]]; then
+	echo "ERROR: spec files not found: cfg=${CFG_REL} tla=${TLA_REL}" >&2
+	exit 1
+fi
+
+# TLC reads the .cfg with the same basename as the .tla unless told otherwise,
+# and resolves modules from the cwd.  Stage everything into a temp dir.
+WORK="$(mktemp -d)"
+trap 'rm -rf "${WORK}"' EXIT
+
+# Copy the entry .tla and .cfg into work dir; also copy any sibling .tla files
+# the entry might EXTEND (we copy all .tla files in the same directory as the
+# entry to keep this simple).
+TLA_DIR="$(dirname "${TLA}")"
+cp "${TLA_DIR}"/*.tla "${WORK}/"
+cp "${CFG}" "${WORK}/$(basename "${TLA}" .tla).cfg"
+
+cd "${WORK}"
+exec "${JAVA}" -XX:+UseParallelGC -cp "${JAR}" tlc2.TLC \
+	-deadlock \
+	-workers auto \
+	"$@" \
+	"$(basename "${TLA}")"


### PR DESCRIPTION
## Summary

Two changes in one PR (related — the txn model needed the bazel toolchain to iterate quickly):

### 1. Hermetic TLA+ toolchain in Bazel

- Temurin JRE 21 fetched via \`http_archive\`
- \`tla2tools.jar\` 1.8.0 fetched via \`http_file\`
- New \`//infra/tla\` package with a \`tla_test\` macro that wraps \`sh_test\`
- Both run from runfiles — no Java in the devcontainer required

### 2. Protocol-faithful txn model

The original \`Replication.tla\` modelled atomic per-node version assignment. As discussed, this didn't validate the watermark mechanism at all — it assumed a stricter property than the protocol requires.

\`ReplicationTxn.tla\` adds:

- Transaction lifecycle: \`BeginNew\`/\`BeginEdit\` allocate a txid and write an uncommitted entry; \`Commit(n, v)\` makes it visible
- Per-row \`watermark\` = \`min(in-flight at insert)\`
- Per-row \`localVersion\` = the receiver's own txid (assigned at \`Pull\` time for replicated entries)
- \`Pull\` filters on \`localVersion\` (per-instance commit order), advances cursor to \`max(watermark)\`
- New invariant \`NoCommittedEntryLost\`: for any committed entry on upstream U with \`localVersion < cursor[r][U][p]\`, the receiver has it (or is the origin, or is filtered by embargo)

### TLC found a modelling bug

While building the txn model, I initially used \`ver\` (the origin's version) for the cursor filter rather than \`localVersion\`. TLC produced a counterexample at MaxOps=8 showing that when A pulls C's entry into A's store and B then pulls from A, B's cursor advances past the C-originated entry on A and never picks it up. The fix — splitting \`ver\` (federated identity) from \`localVersion\` (per-instance commit order) — matches the reference implementation. The catch validates the choice of building the txn model.

### Stacked on #234

### Test targets

| Target                                | Tags    | States   | Time   |
|---------------------------------------|---------|----------|--------|
| \`replication_tlc_test\`              |         | 34 504   | ~2 s   |
| \`replication_txn_tlc_test\`          |         | 540 853  | ~5 s   |
| \`replication_txn_deep_tlc_test\`     | manual  | 2 883 330| ~17 s  |

## Test plan

- [x] \`bazel test //designdocs/tla/...\` — three tests pass
- [x] \`bazel test //designdocs/tla:replication_txn_deep_tlc_test\` — manual deep run passes (16.3s)
- [x] \`bazel test //:pymarkdown\` — markdown lint passes
- [x] \`tools/coverage.sh //...\` — unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)