### PR TITLE
test: TLA+ cross-resource references (plan↔comment)

### DIFF
--- a/designdocs/Replication.md
+++ b/designdocs/Replication.md
@@ -138,7 +138,11 @@ When a resource references another (e.g. a comment on a plan), the reference car
 The replication stream's topological ordering guarantees that referenced entries precede referencing entries.
 A downstream processing a replication stream in order will always have the referenced entry before the referencing entry.
 
+This guarantee follows from a precondition on writes: an instance can only write an entry that references another entry if it already has the referenced entry locally and committed.
+Combined with monotonic local commit order, this ensures that the parent's `local_version` on any node is strictly less than the child's, so any pull serving entries in `local_version` order naturally delivers parent before child.
+
 See [Ordering guarantees](#ordering-guarantees) for the proof.
+The TLA+ model in [tla/ReplicationTxn.tla](tla/ReplicationTxn.tla) verifies this property as `ParentRefIntactOrEmbargoGap`.
 
 ## Replication protocol
 

--- a/designdocs/tla/README.md
+++ b/designdocs/tla/README.md
@@ -52,25 +52,33 @@ Multiple transactions can be in-flight concurrently; commits can interleave with
 Each row carries its own `localVersion` (per-instance commit-order position) and `watermark` (lowest in-flight version at insert time).
 Pull filters on `localVersion` and advances the cursor to `max(watermark)` of the visible set.
 
-Extra invariant: **`NoCommittedEntryLost`** — for any committed entry on an upstream with `localVersion < cursor[receiver][upstream][project]`, either the receiver has it, or the receiver is the origin, or the entry is embargoed to an untrusted peer.
-This is precisely the property the watermark mechanism exists to preserve: cursor advance must never skip a late-committing entry.
+Two ResourceIds (`plan`, `comment`).
+A `BeginNewComment` action writes a comment-style entry whose `parentRef` points at a plan entry; the writer must have the parent locally and committed.
+This precondition is what gives the protocol its cross-resource ordering guarantee: a node can only write a comment for a plan it has, so when it serves to others, the plan has lower `localVersion` than the comment and arrives first.
+Without this precondition, parent-before-child would not hold under arbitrary relay topologies.
+
+Extra invariants:
+
+- **`NoCommittedEntryLost`** — for any committed entry on an upstream with `localVersion < cursor[receiver][upstream][project]`, either the receiver has it, or the receiver is the origin, or the entry is embargoed to an untrusted peer.
+  This is precisely the property the watermark mechanism exists to preserve: cursor advance must never skip a late-committing entry.
+- **`ParentRefIntactOrEmbargoGap`** — every comment's `parentRef` resolves to a local entry, or the parent is embargoed (acceptable gap).
+  This is the cross-resource analogue of `ChainIntactOrEmbargoGap`.
 
 ## Observed state-space sizes
 
 On a devcontainer with `-workers auto`:
 
-| Model                          | MaxOps | Distinct states | Wall time |
-|--------------------------------|--------|-----------------|-----------|
-| `Replication`                  | 4      | 1 147           | < 1 s     |
-| `Replication`                  | 6      | 34 504          | ~2 s      |
-| `ReplicationTxn`               | 7      | 15 011          | ~3 s      |
-| `ReplicationTxn`               | 8      | 109 184         | ~3 s      |
-| `ReplicationTxn`               | 9 (CI) | 540 853         | ~5 s      |
-| `ReplicationTxnDeep`           | 10     | 2 883 330       | ~17 s     |
+| Model                          | MaxOps | ResourceIds        | Distinct states | Wall time |
+|--------------------------------|--------|--------------------|-----------------|-----------|
+| `Replication`                  | 4      | `{r1}`             | 1 147           | < 1 s     |
+| `Replication`                  | 6      | `{r1}`             | 34 504          | ~2 s      |
+| `ReplicationTxn` (CI)          | 7      | `{plan, comment}`  | 1 074 738       | ~7 s      |
+| `ReplicationTxnDeep` (manual)  | 8      | `{plan, comment}`  | 7 773 021       | ~39 s     |
 
 ## Limitations
 
-- Single project, single resource id — combinations of multiple projects/resources are modelled by the Rust `replication_sim` instead, which is faster to iterate
+- Single project — multi-project behaviour is modelled by the Rust `replication_sim` instead, which is faster to iterate
 - No tombstone op (entries are either present or not)
 - No liveness (TLC `[]<>` supported but not used — eventual-consistency assertions live in the Rust sim's quiescence checks)
 - Trust matrix is static
+- One depth level of cross-resource references (comments reference plans, not other comments)

--- a/designdocs/tla/ReplicationTxn.cfg
+++ b/designdocs/tla/ReplicationTxn.cfg
@@ -14,5 +14,6 @@ INVARIANTS
     EmbargoFilter
     ProjectIsolation
     ChainIntactOrEmbargoGap
+    ParentRefIntactOrEmbargoGap
     NoCommittedEntryLost
     TypeOK

--- a/designdocs/tla/ReplicationTxn.tla
+++ b/designdocs/tla/ReplicationTxn.tla
@@ -57,19 +57,47 @@ Init ==
     /\ opCount = 0
 
 (***************************************************************************)
-(* Action: open a transaction and write a brand-new resource entry.       *)
-(* The entry is uncommitted; visible only after Commit.                   *)
+(* Action: open a transaction and write a brand-new resource entry        *)
+(* (plan-style: no parent reference).                                     *)
 (*                                                                         *)
 (* For locally-authored entries: localVersion == ver == txid.             *)
 (***************************************************************************)
-BeginNew(n, rid, proj, emb) ==
+BeginNewPlan(n, rid, proj, emb) ==
     /\ opCount < MaxOps
     /\ \A e \in entries[n] : ~(e.origin = n /\ e.rid = rid)
     /\ LET v == nextVersion[n]
            wm == XminWith(n, v)
            entry == [origin |-> n, rid |-> rid, ver |-> v,
                      localVersion |-> v, watermark |-> wm,
-                     prev |-> NullRef, emb |-> emb,
+                     prev |-> NullRef, parentRef |-> NullRef,
+                     emb |-> emb,
+                     committed |-> FALSE,
+                     proj |-> proj, path |-> <<n>>]
+       IN
+           /\ entries' = [entries EXCEPT ![n] = @ \cup {entry}]
+           /\ nextVersion' = [nextVersion EXCEPT ![n] = v + 1]
+           /\ inFlight' = [inFlight EXCEPT ![n] = @ \cup {v}]
+    /\ opCount' = opCount + 1
+    /\ UNCHANGED cursors
+
+(***************************************************************************)
+(* Action: open a transaction and write a comment-style entry that        *)
+(* references a parent plan.  The parent must be committed and present    *)
+(* on this node (you can't reference what you can't see).                 *)
+(***************************************************************************)
+BeginNewComment(n, rid, proj, parent, emb) ==
+    /\ opCount < MaxOps
+    /\ \A e \in entries[n] : ~(e.origin = n /\ e.rid = rid)
+    /\ parent \in entries[n]
+    /\ parent.committed
+    /\ parent.parentRef = NullRef    \* parent is itself a plan (not a comment)
+    /\ parent.proj = proj            \* parent in same project
+    /\ LET v == nextVersion[n]
+           wm == XminWith(n, v)
+           entry == [origin |-> n, rid |-> rid, ver |-> v,
+                     localVersion |-> v, watermark |-> wm,
+                     prev |-> NullRef, parentRef |-> VRef(parent),
+                     emb |-> emb,
                      committed |-> FALSE,
                      proj |-> proj, path |-> <<n>>]
        IN
@@ -81,7 +109,7 @@ BeginNew(n, rid, proj, emb) ==
 
 (***************************************************************************)
 (* Action: open a transaction that edits an existing committed entry.     *)
-(* Same-instance edit pattern.                                            *)
+(* Same-instance edit pattern.  Preserves the parentRef of the previous.  *)
 (***************************************************************************)
 BeginEdit(n, prev) ==
     /\ opCount < MaxOps
@@ -91,7 +119,8 @@ BeginEdit(n, prev) ==
            wm == XminWith(n, v)
            entry == [origin |-> n, rid |-> prev.rid, ver |-> v,
                      localVersion |-> v, watermark |-> wm,
-                     prev |-> VRef(prev), emb |-> prev.emb,
+                     prev |-> VRef(prev), parentRef |-> prev.parentRef,
+                     emb |-> prev.emb,
                      committed |-> FALSE,
                      proj |-> prev.proj, path |-> <<n>>]
        IN
@@ -140,7 +169,8 @@ Pull(receiver, upstream, proj) ==
            recvWm     == XminWith(receiver, recvTxid)
            accepted   == { [origin |-> e.origin, rid |-> e.rid, ver |-> e.ver,
                             localVersion |-> recvTxid, watermark |-> recvWm,
-                            prev |-> e.prev, emb |-> e.emb,
+                            prev |-> e.prev, parentRef |-> e.parentRef,
+                            emb |-> e.emb,
                             committed |-> TRUE,
                             proj |-> e.proj,
                             path |-> e.path \o <<receiver>>] :
@@ -159,7 +189,9 @@ Pull(receiver, upstream, proj) ==
 
 Next ==
     \/ \E n \in Nodes, rid \in ResourceIds, proj \in Projects, emb \in BOOLEAN :
-        BeginNew(n, rid, proj, emb)
+        BeginNewPlan(n, rid, proj, emb)
+    \/ \E n \in Nodes, rid \in ResourceIds, proj \in Projects, emb \in BOOLEAN :
+        \E parent \in entries[n] : BeginNewComment(n, rid, proj, parent, emb)
     \/ \E n \in Nodes : \E e \in entries[n] : BeginEdit(n, e)
     \/ \E n \in Nodes : \E v \in inFlight[n] : Commit(n, v)
     \/ \E r \in Nodes, u \in Nodes, p \in Projects : Pull(r, u, p)
@@ -233,6 +265,26 @@ ChainIntactOrEmbargoGap ==
                     /\ p.ver = e.prev.ver
                     /\ p.emb
 
+\* Cross-resource references resolve locally OR have a known embargo gap.
+\* If a comment-style entry refers to a parent plan, that parent must be on
+\* the same node, OR be embargoed (acceptable gap when we couldn't legally
+\* see it).  The protocol's topological-ordering claim is what's being
+\* verified here: a relay that delivers a comment must have the parent.
+ParentRefIntactOrEmbargoGap ==
+    \A n \in Nodes :
+        \A e \in entries[n] :
+            (e.committed /\ e.parentRef # NullRef) =>
+                \/ \E q \in entries[n] :
+                    /\ q.committed
+                    /\ q.origin = e.parentRef.origin
+                    /\ q.rid = e.parentRef.rid
+                    /\ q.ver = e.parentRef.ver
+                \/ \E other \in Nodes : \E p \in entries[other] :
+                    /\ p.origin = e.parentRef.origin
+                    /\ p.rid = e.parentRef.rid
+                    /\ p.ver = e.parentRef.ver
+                    /\ p.emb
+
 TypeOK ==
     /\ entries \in [Nodes -> SUBSET [
             origin: Nodes \cup {"_"},
@@ -243,6 +295,9 @@ TypeOK ==
             prev: [origin: Nodes \cup {"_"},
                    rid: ResourceIds \cup {"_"},
                    ver: 0..(MaxOps * Cardinality(Nodes))],
+            parentRef: [origin: Nodes \cup {"_"},
+                        rid: ResourceIds \cup {"_"},
+                        ver: 0..(MaxOps * Cardinality(Nodes))],
             emb: BOOLEAN,
             committed: BOOLEAN,
             proj: Projects,

--- a/designdocs/tla/ReplicationTxnDeep.cfg
+++ b/designdocs/tla/ReplicationTxnDeep.cfg
@@ -14,5 +14,6 @@ INVARIANTS
     EmbargoFilter
     ProjectIsolation
     ChainIntactOrEmbargoGap
+    ParentRefIntactOrEmbargoGap
     NoCommittedEntryLost
     TypeOK

--- a/designdocs/tla/ReplicationTxnDeepMC.tla
+++ b/designdocs/tla/ReplicationTxnDeepMC.tla
@@ -6,13 +6,13 @@ EXTENDS ReplicationTxn
 
 MCNodes == {"A", "B", "C"}
 MCProjects == {"P1"}
-MCResourceIds == {"r1"}
+MCResourceIds == {"plan", "comment"}
 MCTrust == [
     n \in MCNodes |->
         IF n = "A" THEN {"B"}
         ELSE IF n = "B" THEN {"A"}
         ELSE {}
 ]
-MCMaxOps == 10
+MCMaxOps == 8
 
 =============================================================================

--- a/designdocs/tla/ReplicationTxnMC.tla
+++ b/designdocs/tla/ReplicationTxnMC.tla
@@ -3,13 +3,13 @@ EXTENDS ReplicationTxn
 
 MCNodes == {"A", "B", "C"}
 MCProjects == {"P1"}
-MCResourceIds == {"r1"}
+MCResourceIds == {"plan", "comment"}
 MCTrust == [
     n \in MCNodes |->
         IF n = "A" THEN {"B"}
         ELSE IF n = "B" THEN {"A"}
         ELSE {}
 ]
-MCMaxOps == 9
+MCMaxOps == 7
 
 =============================================================================


### PR DESCRIPTION
## Summary

Extend the TLA+ txn model with cross-resource references and verify the protocol's parent-before-child delivery guarantee.

Stacked on #236.

### Changes

- Add \`parentRef\` field to entries (NullRef for plans, set for comments)
- Add \`BeginNewComment(n, rid, proj, parent, emb)\` action — requires the writer to have the parent committed locally
- Add \`ParentRefIntactOrEmbargoGap\` invariant: every comment's parentRef resolves locally or the parent is globally embargoed
- Two ResourceIds: \`{plan, comment}\`
- Update model-checking sizes: CI MaxOps=7 (1.07M states, 7s), deep manual MaxOps=8 (7.77M states, 39s)

### Finding

The protocol's parent-before-child claim *holds*, but the reason isn't an ordering enforcement in the pull mechanism. It comes from a **writer-must-have-parent** precondition: an instance can only write a comment for a plan it already has and committed. That implies the parent has lower \`localVersion\` than the child on every node that holds both, which combined with localVersion-ordered serving means parent always arrives first.

Updated \`Replication.md\` to surface this precondition explicitly — it was implicit before.

## Test plan

- [x] \`bazel test //designdocs/tla/...\` — all 4 targets pass
- [x] Sanity-checked that comment-style entries are actually being explored (TLC violates a deliberately-false invariant on the first comment created)
- [x] Deep manual run at MaxOps=8 explores 7.77M states with all 9 invariants holding

🤖 Generated with [Claude Code](https://claude.com/claude-code)