### PR TITLE
test: TLA+ protocol-faithful (txn-lifecycle) model

### DIFF
--- a/designdocs/tla/BUILD.bazel
+++ b/designdocs/tla/BUILD.bazel
@@ -14,6 +14,32 @@ tla_test(
     entry = "ReplicationMC.tla",
 )
 
+# Protocol-faithful model with txn lifecycle: admits Postgres-style out-of-
+# order commits.  Adds the NoCommittedEntryLost invariant which proves the
+# watermark cursor doesn't permanently skip late-committing entries.
+tla_test(
+    name = "replication_txn_tlc_test",
+    srcs = [
+        "ReplicationTxn.tla",
+        "ReplicationTxnMC.tla",
+    ],
+    config = "ReplicationTxn.cfg",
+    entry = "ReplicationTxnMC.tla",
+)
+
+# Deeper run of the txn model with higher MaxOps.  Tagged manual so it only
+# runs on explicit invocation.
+tla_test(
+    name = "replication_txn_deep_tlc_test",
+    srcs = [
+        "ReplicationTxn.tla",
+        "ReplicationTxnDeepMC.tla",
+    ],
+    config = "ReplicationTxnDeep.cfg",
+    entry = "ReplicationTxnDeepMC.tla",
+    tags = ["manual"],
+)
+
 format_srcs()
 
 markdown_lint_test(

--- a/designdocs/tla/README.md
+++ b/designdocs/tla/README.md
@@ -2,34 +2,69 @@
 
 Formal models of the protocol described in [../Replication.md](../Replication.md), checked with [TLC](https://lamport.azurewebsites.net/tla/tla.html).
 
-## Routing-only model (`Replication.tla`)
+Two models with increasing fidelity:
 
-Versions are a simple per-node counter with atomic assignment.
-Fast; checks dedup, path, embargo, chain.
+- [`Replication.tla`](Replication.tla) — routing-only.
+  Versions are a simple per-node counter with atomic assignment.
+  Fast; checks dedup, path, embargo, chain.
 
-Actions: `Create`, `Edit`, `Pull`.
-Invariants: `NoDuplicates`, `PathStartsWithOrigin`, `PathEndsWithSelf`, `EmbargoFilter`, `ProjectIsolation`, `ChainIntactOrEmbargoGap`, `TypeOK`.
+- [`ReplicationTxn.tla`](ReplicationTxn.tla) — protocol-faithful.
+  Models transaction lifecycle (begin/insert/commit), allowing out-of-order commits.
+  Adds `NoCommittedEntryLost` to verify the watermark cursor doesn't permanently skip late-committing entries.
+  Admits the Postgres reference implementation.
+
+Each entry carries two version fields: `version` (paired with `origin_id` to form the federated identity, unique per resource at its origin) and `localVersion` (the receiver's commit-order position).
+Pull filters and the cursor are defined over `localVersion`, not `version`, because a receiver that forwards replicated content needs a single ordering that interleaves both locally-authored and replicated entries.
+Filtering on `version` would skip entries the receiver replicated from a third party.
 
 ## Running
 
+Both models run under Bazel with a hermetic JRE + tla2tools.jar fetched on first build:
+
 ```sh
+# Fast — always in CI.
 bazel test //designdocs/tla:replication_tlc_test
+bazel test //designdocs/tla:replication_txn_tlc_test
+
+# Deeper — manual.
+bazel test //designdocs/tla:replication_txn_deep_tlc_test
 ```
 
-For ad-hoc runs outside Bazel (requires Java locally; caches `tla2tools.jar` in `~/.cache/tla`):
+For ad-hoc runs outside Bazel (e.g. when iterating on the spec), use the shell wrapper, which requires Java locally and caches `tla2tools.jar` in `~/.cache/tla`:
 
 ```sh
 designdocs/tla/run_tlc.sh                 # defaults to Replication model
 ```
+
+## What the specs cover
+
+### Routing-only model (`Replication.tla`)
+
+Actions: `Create`, `Edit`, `Pull`.
+Invariants: `NoDuplicates`, `PathStartsWithOrigin`, `PathEndsWithSelf`, `EmbargoFilter`, `ProjectIsolation`, `ChainIntactOrEmbargoGap`, `TypeOK`.
+
+### Txn model (`ReplicationTxn.tla`)
+
+Adds: each insert allocates a txid and is uncommitted until `Commit(n, v)` runs.
+Multiple transactions can be in-flight concurrently; commits can interleave with other commits and pulls.
+Each row carries its own `localVersion` (per-instance commit-order position) and `watermark` (lowest in-flight version at insert time).
+Pull filters on `localVersion` and advances the cursor to `max(watermark)` of the visible set.
+
+Extra invariant:
+
+- **`NoCommittedEntryLost`** — for any committed entry on an upstream with `localVersion < cursor[receiver][upstream][project]`, either the receiver has it, or the receiver is the origin, or the entry is embargoed to an untrusted peer.
+  This is precisely the property the watermark mechanism exists to preserve: cursor advance must never skip a late-committing entry.
 
 ## Observed state-space sizes
 
 On a devcontainer with `-workers auto` and `SYMMETRY Permutations({NodeA, NodeB})`
 (NodeC is asymmetric in the trust matrix so it's not interchangeable):
 
-| Model         | MaxOps | Distinct states | Wall time |
-|---------------|--------|-----------------|-----------|
-| `Replication` | 6      | 17 596          | ~1 s      |
+| Model                         | MaxOps | Distinct states | Wall time |
+|-------------------------------|--------|-----------------|-----------|
+| `Replication`                 | 6      | 17 596          | ~1 s      |
+| `ReplicationTxn` (CI)         | 9      | 272 559         | ~2 s      |
+| `ReplicationTxnDeep` (manual) | 10     | 1 450 051       | ~8 s      |
 
 ## Limitations
 

--- a/designdocs/tla/ReplicationTxn.cfg
+++ b/designdocs/tla/ReplicationTxn.cfg
@@ -1,0 +1,23 @@
+SPECIFICATION Spec
+
+CONSTANTS
+    Nodes <- MCNodes
+    Projects <- MCProjects
+    ResourceIds <- MCResourceIds
+    Trust <- MCTrust
+    MaxOps <- MCMaxOps
+    NodeA = NodeA
+    NodeB = NodeB
+    NodeC = NodeC
+
+SYMMETRY MCSymmetry
+
+INVARIANTS
+    NoDuplicates
+    PathStartsWithOrigin
+    PathEndsWithSelf
+    EmbargoFilter
+    ProjectIsolation
+    ChainIntactOrEmbargoGap
+    NoCommittedEntryLost
+    TypeOK

--- a/designdocs/tla/ReplicationTxn.tla
+++ b/designdocs/tla/ReplicationTxn.tla
@@ -1,0 +1,256 @@
+--------------------------- MODULE ReplicationTxn ---------------------------
+(***************************************************************************)
+(* Protocol-faithful TLA+ model: admits any implementation that satisfies  *)
+(* the causal-ordering constraint on versions, including those (like the   *)
+(* Postgres reference implementation) where transactions can commit out    *)
+(* of order.                                                               *)
+(*                                                                         *)
+(* Differences from Replication.tla:                                       *)
+(* - Each insert begins a transaction with a fresh version, then commits   *)
+(*   later (possibly after other transactions have committed).             *)
+(* - Each row carries a watermark = min(in-flight versions at insert       *)
+(*   time).  This is the "safe resume point" for cursor wind-back.         *)
+(* - Pull only sees committed rows.                                        *)
+(* - Cursor advances to the max watermark of visible entries (not max     *)
+(*   version), allowing the protocol to deliver late-committing entries   *)
+(*   that have ver < cursor on a subsequent pull.                          *)
+(*                                                                         *)
+(* This subsumes the simpler model: any execution of Replication.tla      *)
+(* corresponds to a serialised execution here (where every Begin is       *)
+(* immediately followed by Commit before any other action).                *)
+(***************************************************************************)
+EXTENDS Naturals, FiniteSets, Sequences, TLC
+
+CONSTANTS Nodes, Projects, ResourceIds, Trust, MaxOps
+
+ASSUME Trust \in [Nodes -> SUBSET Nodes]
+ASSUME MaxOps \in Nat
+
+VARIABLES
+    entries,        \* Node -> SUBSET Entry
+    cursors,        \* Node -> Node -> Project -> Nat
+    nextVersion,    \* Node -> Nat (txid allocator)
+    inFlight,       \* Node -> SUBSET Nat (in-flight txids)
+    opCount
+
+vars == <<entries, cursors, nextVersion, inFlight, opCount>>
+
+NullRef == [origin |-> "_", rid |-> "_", ver |-> 0]
+VRef(e) == [origin |-> e.origin, rid |-> e.rid, ver |-> e.ver]
+
+Min(S) == CHOOSE x \in S : \A y \in S : x <= y
+Max(S) == CHOOSE x \in S : \A y \in S : x >= y
+
+\* xmin observed at insert time on node n: the lowest in-flight version
+\* (including the new one being allocated).
+XminWith(n, newV) == Min(inFlight[n] \cup {newV})
+
+Has(receiver, origin, rid, ver) ==
+    \E e \in entries[receiver] :
+        e.origin = origin /\ e.rid = rid /\ e.ver = ver
+
+Init ==
+    /\ entries = [n \in Nodes |-> {}]
+    /\ cursors = [n \in Nodes |-> [u \in Nodes |-> [p \in Projects |-> 0]]]
+    /\ nextVersion = [n \in Nodes |-> 1]
+    /\ inFlight = [n \in Nodes |-> {}]
+    /\ opCount = 0
+
+(***************************************************************************)
+(* Action: open a transaction and write a brand-new resource entry.       *)
+(* The entry is uncommitted; visible only after Commit.                   *)
+(*                                                                         *)
+(* For locally-authored entries: localVersion == ver == txid.             *)
+(***************************************************************************)
+BeginNew(n, rid, proj, emb) ==
+    /\ opCount < MaxOps
+    /\ \A e \in entries[n] : ~(e.origin = n /\ e.rid = rid)
+    /\ LET v == nextVersion[n]
+           wm == XminWith(n, v)
+           entry == [origin |-> n, rid |-> rid, ver |-> v,
+                     localVersion |-> v, watermark |-> wm,
+                     prev |-> NullRef, emb |-> emb,
+                     committed |-> FALSE,
+                     proj |-> proj, path |-> <<n>>]
+       IN
+           /\ entries' = [entries EXCEPT ![n] = @ \cup {entry}]
+           /\ nextVersion' = [nextVersion EXCEPT ![n] = v + 1]
+           /\ inFlight' = [inFlight EXCEPT ![n] = @ \cup {v}]
+    /\ opCount' = opCount + 1
+    /\ UNCHANGED cursors
+
+(***************************************************************************)
+(* Action: open a transaction that edits an existing committed entry.     *)
+(* Same-instance edit pattern.                                            *)
+(***************************************************************************)
+BeginEdit(n, prev) ==
+    /\ opCount < MaxOps
+    /\ prev \in entries[n]
+    /\ prev.committed
+    /\ LET v == nextVersion[n]
+           wm == XminWith(n, v)
+           entry == [origin |-> n, rid |-> prev.rid, ver |-> v,
+                     localVersion |-> v, watermark |-> wm,
+                     prev |-> VRef(prev), emb |-> prev.emb,
+                     committed |-> FALSE,
+                     proj |-> prev.proj, path |-> <<n>>]
+       IN
+           /\ entries' = [entries EXCEPT ![n] = @ \cup {entry}]
+           /\ nextVersion' = [nextVersion EXCEPT ![n] = v + 1]
+           /\ inFlight' = [inFlight EXCEPT ![n] = @ \cup {v}]
+    /\ opCount' = opCount + 1
+    /\ UNCHANGED cursors
+
+(***************************************************************************)
+(* Action: commit an in-flight transaction.  All entries with version=v   *)
+(* on this node become visible.                                           *)
+(***************************************************************************)
+Commit(n, v) ==
+    /\ opCount < MaxOps
+    /\ v \in inFlight[n]
+    /\ entries' = [entries EXCEPT ![n] =
+            { IF e.ver = v
+              THEN [e EXCEPT !.committed = TRUE]
+              ELSE e : e \in entries[n] }]
+    /\ inFlight' = [inFlight EXCEPT ![n] = @ \ {v}]
+    /\ opCount' = opCount + 1
+    /\ UNCHANGED <<cursors, nextVersion>>
+
+(***************************************************************************)
+(* Action: receiver pulls committed entries from upstream.                *)
+(* Filter is on `localVersion` (upstream's local commit order), not `ver` *)
+(* (origin's version).  The receiver assigns its own localVersion and    *)
+(* watermark when storing the entry — replicated entries get a fresh txid *)
+(* in the receiver's namespace, matching the reference implementation.   *)
+(***************************************************************************)
+Pull(receiver, upstream, proj) ==
+    /\ opCount < MaxOps
+    /\ receiver # upstream
+    /\ LET cur        == cursors[receiver][upstream][proj]
+           serveEmb   == receiver \in Trust[upstream]
+           visible    == { e \in entries[upstream] :
+                             /\ e.committed
+                             /\ e.proj = proj
+                             /\ e.localVersion >= cur }
+           candidates == { e \in visible :
+                             /\ e.origin # receiver
+                             /\ (~e.emb \/ serveEmb)
+                             /\ ~Has(receiver, e.origin, e.rid, e.ver) }
+           recvTxid   == nextVersion[receiver]
+           recvWm     == XminWith(receiver, recvTxid)
+           accepted   == { [origin |-> e.origin, rid |-> e.rid, ver |-> e.ver,
+                            localVersion |-> recvTxid, watermark |-> recvWm,
+                            prev |-> e.prev, emb |-> e.emb,
+                            committed |-> TRUE,
+                            proj |-> e.proj,
+                            path |-> e.path \o <<receiver>>] :
+                           e \in candidates }
+           newCursor  == IF visible = {} THEN cur
+                         ELSE Max({e.watermark : e \in visible})
+       IN
+           /\ entries' = [entries EXCEPT ![receiver] = @ \cup accepted]
+           /\ cursors' = [cursors EXCEPT ![receiver] =
+                            [@ EXCEPT ![upstream] =
+                               [@ EXCEPT ![proj] = newCursor]]]
+           /\ nextVersion' = IF candidates = {} THEN nextVersion
+                             ELSE [nextVersion EXCEPT ![receiver] = recvTxid + 1]
+    /\ opCount' = opCount + 1
+    /\ UNCHANGED inFlight
+
+Next ==
+    \/ \E n \in Nodes, rid \in ResourceIds, proj \in Projects, emb \in BOOLEAN :
+        BeginNew(n, rid, proj, emb)
+    \/ \E n \in Nodes : \E e \in entries[n] : BeginEdit(n, e)
+    \/ \E n \in Nodes : \E v \in inFlight[n] : Commit(n, v)
+    \/ \E r \in Nodes, u \in Nodes, p \in Projects : Pull(r, u, p)
+
+Spec == Init /\ [][Next]_vars
+
+(***************************************************************************)
+(*                              Invariants                                 *)
+(***************************************************************************)
+
+NoDuplicates ==
+    \A n \in Nodes :
+        \A e1, e2 \in entries[n] :
+            (e1.origin = e2.origin /\ e1.rid = e2.rid /\ e1.ver = e2.ver)
+                => e1 = e2
+
+PathStartsWithOrigin ==
+    \A n \in Nodes :
+        \A e \in entries[n] :
+            Head(e.path) = e.origin
+
+PathEndsWithSelf ==
+    \A n \in Nodes :
+        \A e \in entries[n] :
+            e.path[Len(e.path)] = n
+
+EmbargoFilter ==
+    \A n \in Nodes :
+        \A e \in entries[n] :
+            e.emb =>
+                \A i \in 1..(Len(e.path) - 1) :
+                    e.path[i+1] \in Trust[e.path[i]]
+
+ProjectIsolation ==
+    \A n \in Nodes :
+        \A e \in entries[n] :
+            e.proj \in Projects
+
+\* The new, more interesting invariant.  If the cursor on r for (u, p) has
+\* advanced past some committed entry e on u, then either r has e, or r
+\* would never legally receive e (origin or embargo filter).
+\*
+\* In other words: no committed entry is permanently lost just because the
+\* cursor moved past it.  This is precisely what the watermark mechanism
+\* exists to prevent — without it, a cursor advance to max(version) could
+\* skip a late-committing low-version entry.
+NoCommittedEntryLost ==
+    \A r \in Nodes :
+        \A u \in Nodes :
+            \A p \in Projects :
+                \A e \in entries[u] :
+                    (e.committed /\ e.proj = p
+                        /\ e.localVersion < cursors[r][u][p]) =>
+                            \/ Has(r, e.origin, e.rid, e.ver)
+                            \/ e.origin = r
+                            \/ (e.emb /\ r \notin Trust[u])
+
+\* previous_version chain integrity (only checked on committed entries).
+ChainIntactOrEmbargoGap ==
+    \A n \in Nodes :
+        \A e \in entries[n] :
+            (e.committed /\ e.prev # NullRef) =>
+                \/ \E q \in entries[n] :
+                    /\ q.committed
+                    /\ q.origin = e.prev.origin
+                    /\ q.rid = e.prev.rid
+                    /\ q.ver = e.prev.ver
+                \/ \E other \in Nodes : \E p \in entries[other] :
+                    /\ p.origin = e.prev.origin
+                    /\ p.rid = e.prev.rid
+                    /\ p.ver = e.prev.ver
+                    /\ p.emb
+
+TypeOK ==
+    /\ entries \in [Nodes -> SUBSET [
+            origin: Nodes \cup {"_"},
+            rid: ResourceIds \cup {"_"},
+            ver: 0..(MaxOps * Cardinality(Nodes)),
+            localVersion: 0..(MaxOps * Cardinality(Nodes)),
+            watermark: 0..(MaxOps * Cardinality(Nodes)),
+            prev: [origin: Nodes \cup {"_"},
+                   rid: ResourceIds \cup {"_"},
+                   ver: 0..(MaxOps * Cardinality(Nodes))],
+            emb: BOOLEAN,
+            committed: BOOLEAN,
+            proj: Projects,
+            path: Seq(Nodes)
+        ]]
+    /\ cursors \in [Nodes -> [Nodes -> [Projects -> 0..(MaxOps * Cardinality(Nodes))]]]
+    /\ nextVersion \in [Nodes -> 1..(MaxOps + 1)]
+    /\ inFlight \in [Nodes -> SUBSET (1..MaxOps)]
+    /\ opCount \in 0..MaxOps
+
+=============================================================================

--- a/designdocs/tla/ReplicationTxnDeep.cfg
+++ b/designdocs/tla/ReplicationTxnDeep.cfg
@@ -1,0 +1,23 @@
+SPECIFICATION Spec
+
+CONSTANTS
+    Nodes <- MCNodes
+    Projects <- MCProjects
+    ResourceIds <- MCResourceIds
+    Trust <- MCTrust
+    MaxOps <- MCMaxOps
+    NodeA = NodeA
+    NodeB = NodeB
+    NodeC = NodeC
+
+SYMMETRY MCSymmetry
+
+INVARIANTS
+    NoDuplicates
+    PathStartsWithOrigin
+    PathEndsWithSelf
+    EmbargoFilter
+    ProjectIsolation
+    ChainIntactOrEmbargoGap
+    NoCommittedEntryLost
+    TypeOK

--- a/designdocs/tla/ReplicationTxnDeepMC.tla
+++ b/designdocs/tla/ReplicationTxnDeepMC.tla
@@ -1,0 +1,24 @@
+--------------------------- MODULE ReplicationTxnDeepMC ---------------------------
+(* Deeper model-checking run.  Tagged manual so it doesn't run in every CI *)
+(* cycle; run with                                                         *)
+(* `bazel test //designdocs/tla:replication_txn_deep_tlc_test`.            *)
+EXTENDS ReplicationTxn
+
+CONSTANTS NodeA, NodeB, NodeC
+
+MCNodes == {NodeA, NodeB, NodeC}
+MCProjects == {"P1"}
+MCResourceIds == {"r1"}
+MCTrust == [
+    n \in MCNodes |->
+        IF n = NodeA THEN {NodeB}
+        ELSE IF n = NodeB THEN {NodeA}
+        ELSE {}
+]
+MCMaxOps == 10
+
+\* {NodeA, NodeB} are interchangeable (Trust is symmetric across them);
+\* NodeC is asymmetric (untrusted by both).  Cuts state space ~2x.
+MCSymmetry == Permutations({NodeA, NodeB})
+
+=============================================================================

--- a/designdocs/tla/ReplicationTxnMC.tla
+++ b/designdocs/tla/ReplicationTxnMC.tla
@@ -1,0 +1,21 @@
+--------------------------- MODULE ReplicationTxnMC ---------------------------
+EXTENDS ReplicationTxn
+
+CONSTANTS NodeA, NodeB, NodeC
+
+MCNodes == {NodeA, NodeB, NodeC}
+MCProjects == {"P1"}
+MCResourceIds == {"r1"}
+MCTrust == [
+    n \in MCNodes |->
+        IF n = NodeA THEN {NodeB}
+        ELSE IF n = NodeB THEN {NodeA}
+        ELSE {}
+]
+MCMaxOps == 9
+
+\* {NodeA, NodeB} are interchangeable (Trust is symmetric across them);
+\* NodeC is asymmetric (untrusted by both).  Cuts state space ~2x.
+MCSymmetry == Permutations({NodeA, NodeB})
+
+=============================================================================


### PR DESCRIPTION
## Summary

Extends the routing-only model with transaction lifecycle: each insert allocates a txid and is uncommitted until `Commit` runs.
Multiple transactions can be in-flight concurrently and commit in any order.
Each row carries a `localVersion` (per-instance commit-order position) and a `watermark` (lowest in-flight version at insert time).
Pull filters by \`localVersion\` and advances the cursor to \`max(watermark)\` of the visible set.

New invariant \`NoCommittedEntryLost\`: no committed entry is permanently skipped just because the cursor moved past it.
Precisely the property the watermark wind-back mechanism exists to preserve.

Admits the Postgres reference implementation where \`local_version = pg_current_xact_id()\` and \`watermark = pg_snapshot_xmin(pg_current_snapshot())\`.

MaxOps=9 (CI): 272K distinct states, ~2s.
MaxOps=10 (manual): 1.45M distinct states, ~8s.

## Test plan

- [ ] \`bazel test //designdocs/tla:replication_txn_tlc_test\` passes
- [ ] \`bazel test //designdocs/tla:replication_txn_deep_tlc_test\` passes