### PR TITLE
test: TLA+ cross-resource references (plan/comment)

### DIFF
--- a/designdocs/tla/README.md
+++ b/designdocs/tla/README.md
@@ -50,10 +50,19 @@ Multiple transactions can be in-flight concurrently; commits can interleave with
 Each row carries its own `localVersion` (per-instance commit-order position) and `watermark` (lowest in-flight version at insert time).
 Pull filters on `localVersion` and advances the cursor to `max(watermark)` of the visible set.
 
-Extra invariant:
+Two ResourceIds (`plan`, `comment`).
+A `BeginNewComment` action writes a comment-style entry whose `parentRef` points at a committed plan entry on this node.
+A `WriteCommentInOpenPlanTxn` action covers the Postgres read-your-writes case: a comment can reference a parent plan in the same open transaction (sharing its `ver`/`localVersion`), since both will commit atomically.
+The general precondition is "writer must have read the parent" — committed locally, or visible within the same open transaction.
+This is what gives the protocol its cross-resource ordering guarantee: a node can only write a comment for a plan it has, so when it serves to others, the plan has `localVersion <= comment.localVersion` and arrives first (or together).
+Without this precondition, parent-before-child would not hold under arbitrary relay topologies.
+
+Extra invariants:
 
 - **`NoCommittedEntryLost`** — for any committed entry on an upstream with `localVersion < cursor[receiver][upstream][project]`, either the receiver has it, or the receiver is the origin, or the entry is embargoed to an untrusted peer.
   This is precisely the property the watermark mechanism exists to preserve: cursor advance must never skip a late-committing entry.
+- **`ParentRefIntactOrEmbargoGap`** — every comment's `parentRef` resolves to a local entry, or the parent is embargoed (acceptable gap).
+  This is the cross-resource analogue of `ChainIntactOrEmbargoGap`.
 
 ## Observed state-space sizes
 
@@ -63,8 +72,8 @@ On a devcontainer with `-workers auto` and `SYMMETRY Permutations({NodeA, NodeB}
 | Model                         | MaxOps | Distinct states | Wall time |
 |-------------------------------|--------|-----------------|-----------|
 | `Replication`                 | 6      | 17 596          | ~1 s      |
-| `ReplicationTxn` (CI)         | 9      | 272 559         | ~2 s      |
-| `ReplicationTxnDeep` (manual) | 10     | 1 450 051       | ~8 s      |
+| `ReplicationTxn` (CI)         | 7      | 797 856         | ~10 s     |
+| `ReplicationTxnDeep` (manual) | 8      | 5 731 370       | ~40 s     |
 
 ## Limitations
 
@@ -72,3 +81,4 @@ On a devcontainer with `-workers auto` and `SYMMETRY Permutations({NodeA, NodeB}
 - No tombstone op (entries are either present or not)
 - No liveness (TLC `[]<>` supported but not used — eventual-consistency assertions live in the Rust sim's quiescence checks)
 - Trust matrix is static
+- One depth level of cross-resource references (comments reference plans, not other comments)

--- a/designdocs/tla/ReplicationTxn.tla
+++ b/designdocs/tla/ReplicationTxn.tla
@@ -57,19 +57,20 @@ Init ==
     /\ opCount = 0
 
 (***************************************************************************)
-(* Action: open a transaction and write a brand-new resource entry.       *)
-(* The entry is uncommitted; visible only after Commit.                   *)
+(* Action: open a transaction and write a brand-new resource entry        *)
+(* (plan-style: no parent reference).                                     *)
 (*                                                                         *)
 (* For locally-authored entries: localVersion == ver == txid.             *)
 (***************************************************************************)
-BeginNew(n, rid, proj, emb) ==
+BeginNewPlan(n, rid, proj, emb) ==
     /\ opCount < MaxOps
     /\ \A e \in entries[n] : ~(e.origin = n /\ e.rid = rid)
     /\ LET v == nextVersion[n]
            wm == XminWith(n, v)
            entry == [origin |-> n, rid |-> rid, ver |-> v,
                      localVersion |-> v, watermark |-> wm,
-                     prev |-> NullRef, emb |-> emb,
+                     prev |-> NullRef, parentRef |-> NullRef,
+                     emb |-> emb,
                      committed |-> FALSE,
                      proj |-> proj, path |-> <<n>>]
        IN
@@ -80,8 +81,63 @@ BeginNew(n, rid, proj, emb) ==
     /\ UNCHANGED cursors
 
 (***************************************************************************)
+(* Action: open a transaction and write a comment-style entry that        *)
+(* references a parent plan.  The parent must be committed and present    *)
+(* on this node (you can't reference what you can't see).                 *)
+(***************************************************************************)
+BeginNewComment(n, rid, proj, parent, emb) ==
+    /\ opCount < MaxOps
+    /\ \A e \in entries[n] : ~(e.origin = n /\ e.rid = rid)
+    /\ parent \in entries[n]
+    /\ parent.committed
+    /\ parent.parentRef = NullRef    \* parent is itself a plan (not a comment)
+    /\ parent.proj = proj            \* parent in same project
+    /\ LET v == nextVersion[n]
+           wm == XminWith(n, v)
+           entry == [origin |-> n, rid |-> rid, ver |-> v,
+                     localVersion |-> v, watermark |-> wm,
+                     prev |-> NullRef, parentRef |-> VRef(parent),
+                     emb |-> emb,
+                     committed |-> FALSE,
+                     proj |-> proj, path |-> <<n>>]
+       IN
+           /\ entries' = [entries EXCEPT ![n] = @ \cup {entry}]
+           /\ nextVersion' = [nextVersion EXCEPT ![n] = v + 1]
+           /\ inFlight' = [inFlight EXCEPT ![n] = @ \cup {v}]
+    /\ opCount' = opCount + 1
+    /\ UNCHANGED cursors
+
+(***************************************************************************)
+(* Action: write a comment-style entry into an EXISTING open transaction  *)
+(* whose first entry was a plan.  Models Postgres read-your-writes within *)
+(* a transaction: the comment can reference its parent before the parent  *)
+(* is committed, because both will commit atomically together.            *)
+(*                                                                         *)
+(* The new comment shares ver and localVersion with the parent (same      *)
+(* transaction = same txid).                                              *)
+(***************************************************************************)
+WriteCommentInOpenPlanTxn(n, parent, rid, emb) ==
+    /\ opCount < MaxOps
+    /\ parent \in entries[n]
+    /\ parent.parentRef = NullRef    \* parent is a plan
+    /\ ~parent.committed             \* parent's txn still open
+    /\ parent.ver \in inFlight[n]
+    /\ \A e \in entries[n] : ~(e.origin = n /\ e.rid = rid)
+    /\ LET txid == parent.ver
+           wm == XminWith(n, txid)
+           entry == [origin |-> n, rid |-> rid, ver |-> txid,
+                     localVersion |-> txid, watermark |-> wm,
+                     prev |-> NullRef, parentRef |-> VRef(parent),
+                     emb |-> emb,
+                     committed |-> FALSE,
+                     proj |-> parent.proj, path |-> <<n>>]
+       IN entries' = [entries EXCEPT ![n] = @ \cup {entry}]
+    /\ opCount' = opCount + 1
+    /\ UNCHANGED <<cursors, nextVersion, inFlight>>
+
+(***************************************************************************)
 (* Action: open a transaction that edits an existing committed entry.     *)
-(* Same-instance edit pattern.                                            *)
+(* Same-instance edit pattern.  Preserves the parentRef of the previous.  *)
 (***************************************************************************)
 BeginEdit(n, prev) ==
     /\ opCount < MaxOps
@@ -91,7 +147,8 @@ BeginEdit(n, prev) ==
            wm == XminWith(n, v)
            entry == [origin |-> n, rid |-> prev.rid, ver |-> v,
                      localVersion |-> v, watermark |-> wm,
-                     prev |-> VRef(prev), emb |-> prev.emb,
+                     prev |-> VRef(prev), parentRef |-> prev.parentRef,
+                     emb |-> prev.emb,
                      committed |-> FALSE,
                      proj |-> prev.proj, path |-> <<n>>]
        IN
@@ -140,7 +197,8 @@ Pull(receiver, upstream, proj) ==
            recvWm     == XminWith(receiver, recvTxid)
            accepted   == { [origin |-> e.origin, rid |-> e.rid, ver |-> e.ver,
                             localVersion |-> recvTxid, watermark |-> recvWm,
-                            prev |-> e.prev, emb |-> e.emb,
+                            prev |-> e.prev, parentRef |-> e.parentRef,
+                            emb |-> e.emb,
                             committed |-> TRUE,
                             proj |-> e.proj,
                             path |-> e.path \o <<receiver>>] :
@@ -159,7 +217,11 @@ Pull(receiver, upstream, proj) ==
 
 Next ==
     \/ \E n \in Nodes, rid \in ResourceIds, proj \in Projects, emb \in BOOLEAN :
-        BeginNew(n, rid, proj, emb)
+        BeginNewPlan(n, rid, proj, emb)
+    \/ \E n \in Nodes, rid \in ResourceIds, proj \in Projects, emb \in BOOLEAN :
+        \E parent \in entries[n] : BeginNewComment(n, rid, proj, parent, emb)
+    \/ \E n \in Nodes, rid \in ResourceIds, emb \in BOOLEAN :
+        \E parent \in entries[n] : WriteCommentInOpenPlanTxn(n, parent, rid, emb)
     \/ \E n \in Nodes : \E e \in entries[n] : BeginEdit(n, e)
     \/ \E n \in Nodes : \E v \in inFlight[n] : Commit(n, v)
     \/ \E r \in Nodes, u \in Nodes, p \in Projects : Pull(r, u, p)
@@ -233,6 +295,26 @@ ChainIntactOrEmbargoGap ==
                     /\ p.ver = e.prev.ver
                     /\ p.emb
 
+\* Cross-resource references resolve locally OR have a known embargo gap.
+\* If a comment-style entry refers to a parent plan, that parent must be on
+\* the same node, OR be embargoed (acceptable gap when we couldn't legally
+\* see it).  The protocol's topological-ordering claim is what's being
+\* verified here: a relay that delivers a comment must have the parent.
+ParentRefIntactOrEmbargoGap ==
+    \A n \in Nodes :
+        \A e \in entries[n] :
+            (e.committed /\ e.parentRef # NullRef) =>
+                \/ \E q \in entries[n] :
+                    /\ q.committed
+                    /\ q.origin = e.parentRef.origin
+                    /\ q.rid = e.parentRef.rid
+                    /\ q.ver = e.parentRef.ver
+                \/ \E other \in Nodes : \E p \in entries[other] :
+                    /\ p.origin = e.parentRef.origin
+                    /\ p.rid = e.parentRef.rid
+                    /\ p.ver = e.parentRef.ver
+                    /\ p.emb
+
 TypeOK ==
     /\ entries \in [Nodes -> SUBSET [
             origin: Nodes \cup {"_"},
@@ -243,6 +325,9 @@ TypeOK ==
             prev: [origin: Nodes \cup {"_"},
                    rid: ResourceIds \cup {"_"},
                    ver: 0..(MaxOps * Cardinality(Nodes))],
+            parentRef: [origin: Nodes \cup {"_"},
+                        rid: ResourceIds \cup {"_"},
+                        ver: 0..(MaxOps * Cardinality(Nodes))],
             emb: BOOLEAN,
             committed: BOOLEAN,
             proj: Projects,

--- a/designdocs/tla/ReplicationTxnDeepMC.tla
+++ b/designdocs/tla/ReplicationTxnDeepMC.tla
@@ -8,14 +8,14 @@ CONSTANTS NodeA, NodeB, NodeC
 
 MCNodes == {NodeA, NodeB, NodeC}
 MCProjects == {"P1"}
-MCResourceIds == {"r1"}
+MCResourceIds == {"plan", "comment"}
 MCTrust == [
     n \in MCNodes |->
         IF n = NodeA THEN {NodeB}
         ELSE IF n = NodeB THEN {NodeA}
         ELSE {}
 ]
-MCMaxOps == 10
+MCMaxOps == 8
 
 \* {NodeA, NodeB} are interchangeable (Trust is symmetric across them);
 \* NodeC is asymmetric (untrusted by both).  Cuts state space ~2x.

--- a/designdocs/tla/ReplicationTxnMC.tla
+++ b/designdocs/tla/ReplicationTxnMC.tla
@@ -5,14 +5,14 @@ CONSTANTS NodeA, NodeB, NodeC
 
 MCNodes == {NodeA, NodeB, NodeC}
 MCProjects == {"P1"}
-MCResourceIds == {"r1"}
+MCResourceIds == {"plan", "comment"}
 MCTrust == [
     n \in MCNodes |->
         IF n = NodeA THEN {NodeB}
         ELSE IF n = NodeB THEN {NodeA}
         ELSE {}
 ]
-MCMaxOps == 9
+MCMaxOps == 7
 
 \* {NodeA, NodeB} are interchangeable (Trust is symmetric across them);
 \* NodeC is asymmetric (untrusted by both).  Cuts state space ~2x.


### PR DESCRIPTION
## Summary

Extends the txn-lifecycle model with cross-resource `parentRef`: an entry may reference another entry on a different resource (e.g. a comment pointing at a plan).
Two writer actions cover the preconditions:

- `BeginNewComment`: parent must be committed and present on this node.
- `WriteCommentInOpenPlanTxn`: parent may be in the same open transaction (Postgres read-your-writes within a txn).

The general precondition "writer must have read the parent" is what gives the protocol its cross-resource ordering guarantee: a node can only write a comment for a plan it has, so when it serves that comment to others the plan has lower or equal `localVersion` and arrives first (or together).

New invariant \`ParentRefIntactOrEmbargoGap\` — the cross-resource analogue of \`ChainIntactOrEmbargoGap\`: a committed comment's \`parentRef\` resolves locally or the parent is embargoed on some node.

MaxOps=7 (CI): 798K distinct states, ~10s.
MaxOps=8 (manual): 5.7M distinct states, ~40s.

## Test plan

- [ ] \`bazel test //designdocs/tla:replication_txn_tlc_test\` passes
- [ ] \`bazel test //designdocs/tla:replication_txn_deep_tlc_test\` passes