### PR TITLE
test: TLA+ batched pulls and batch-boundary invariants

### DIFF
--- a/designdocs/Replication.md
+++ b/designdocs/Replication.md
@@ -5,6 +5,7 @@ It is the specification for implementors building a Causes-compatible instance o
 
 For the design rationale behind these decisions, see [ADR-013](Decisions.md#adr-013-replication-protocol) in Decisions.md.
 For the broader federation strategy, see [ADR-006](Decisions.md#adr-006-federation-strategy--distribute-dont-federate-by-default).
+For a machine-checked TLA+ model of the protocol's safety properties, see [tla/Replication.tla](tla/Replication.tla).
 
 ## Overview
 
@@ -137,7 +138,11 @@ When a resource references another (e.g. a comment on a plan), the reference car
 The replication stream's topological ordering guarantees that referenced entries precede referencing entries.
 A downstream processing a replication stream in order will always have the referenced entry before the referencing entry.
 
+This guarantee follows from a precondition on writes: an instance can only write an entry that references another entry if it already has the referenced entry locally and committed.
+Combined with monotonic local commit order, this ensures that the parent's `local_version` on any node is strictly less than the child's, so any pull serving entries in `local_version` order naturally delivers parent before child.
+
 See [Ordering guarantees](#ordering-guarantees) for the proof.
+The TLA+ model in [tla/ReplicationTxn.tla](tla/ReplicationTxn.tla) verifies this property as `ParentRefIntactOrEmbargoGap`.
 
 ## Replication protocol
 
@@ -329,6 +334,7 @@ loop:
     batch = query entries WHERE local_version >= watermark
                             AND project_id = project
                           ORDER BY local_version
+                          FETCH FIRST N ROWS WITH TIES
 
     if batch is empty:
         wait for notification or timeout
@@ -346,8 +352,38 @@ loop:
     watermark = batch.last().watermark
 ```
 
+`WITH TIES` is the same-`local_version` atomicity from the batch-boundaries section above.
+
 The seen buffer is bounded.
 Entries can be evicted from the buffer once the watermark advances past their `local_version` — they will not appear in future queries.
+
+### Batch boundaries
+
+A `Pull` may stream entries across multiple batches.
+For correctness, **a child entry must never be sent in a batch that strictly precedes its parent's batch**.
+Otherwise a receiver applying batches in arrival order would briefly hold a child without its parent.
+
+Two ancestor relationships count as parent-child:
+
+- `previous_version` — same-resource chain on `JournalEntry`.
+- Cross-resource references such as a comment's parent, transmitted in the resource-typed payload.
+
+A receiver pulling from a relay can encounter same-`local_version` parent-child pairs, because a relay assigns the same receive-side `local_version` to all entries committed in one replicating transaction.
+A naive batch boundary inside such a group splits the chain.
+
+The protocol contract: items crossing batch boundaries are topologically ordered.
+Implementations have two valid strategies for same-`local_version` groups:
+
+- **Atomic same-`local_version` groups.**
+  Every batch includes all rows sharing the last row's `local_version`.
+  In SQL this is `LIMIT N WITH TIES` semantics — after the cut, fetch any remaining rows whose `local_version` matches the last row's.
+
+- **Topo-sort within a `local_version`.**
+  When a same-`local_version` group is split across batches, order rows within the group so parents precede children.
+  Requires the sender to know in-batch parent/child relationships.
+
+The first strategy is simpler and matches Postgres's `WITH TIES` clause directly.
+References that resolve to entries embargoed-out of the receiver's view do not need to be in any batch — the embargo gap is permitted by the protocol.
 
 ### Receiving pseudocode
 

--- a/designdocs/tla/README.md
+++ b/designdocs/tla/README.md
@@ -26,7 +26,7 @@ Both models run under Bazel with a hermetic JRE + tla2tools.jar fetched on first
 bazel test //designdocs/tla:replication_tlc_test
 bazel test //designdocs/tla:replication_txn_tlc_test
 
-# Deeper — manual.
+# Deeper — manual (~30s).
 bazel test //designdocs/tla:replication_txn_deep_tlc_test
 ```
 
@@ -35,6 +35,8 @@ For ad-hoc runs outside Bazel (e.g. when iterating on the spec), use the shell w
 ```sh
 designdocs/tla/run_tlc.sh                 # defaults to Replication model
 ```
+
+Or run `bazel test` as above for the Bazel-hermetic path.
 
 ## What the specs cover
 
@@ -48,7 +50,9 @@ Invariants: `NoDuplicates`, `PathStartsWithOrigin`, `PathEndsWithSelf`, `Embargo
 Adds: each insert allocates a txid and is uncommitted until `Commit(n, v)` runs.
 Multiple transactions can be in-flight concurrently; commits can interleave with other commits and pulls.
 Each row carries its own `localVersion` (per-instance commit-order position) and `watermark` (lowest in-flight version at insert time).
-Pull filters on `localVersion` and advances the cursor to `max(watermark)` of the visible set.
+`BatchPull` selects a subset of visible entries up to `BatchSize` that is (a) a prefix in `localVersion` order and (b) ancestor-closed for both `prev` and `parentRef` references.
+The cursor advances to `max(watermark)` of the chosen batch; subsequent pulls pick up the rest.
+This admits both implementation strategies for same-`localVersion` groups (atomic `WITH TIES`, or topo-sort-within-version).
 
 Two ResourceIds (`plan`, `comment`).
 A `BeginNewComment` action writes a comment-style entry whose `parentRef` points at a committed plan entry on this node.
@@ -69,11 +73,11 @@ Extra invariants:
 On a devcontainer with `-workers auto` and `SYMMETRY Permutations({NodeA, NodeB})`
 (NodeC is asymmetric in the trust matrix so it's not interchangeable):
 
-| Model                         | MaxOps | Distinct states | Wall time |
-|-------------------------------|--------|-----------------|-----------|
-| `Replication`                 | 6      | 17 596          | ~1 s      |
-| `ReplicationTxn` (CI)         | 7      | 797 856         | ~10 s     |
-| `ReplicationTxnDeep` (manual) | 8      | 5 731 370       | ~40 s     |
+| Model                          | MaxOps | BatchSize | Distinct states | Wall time |
+|--------------------------------|--------|-----------|-----------------|-----------|
+| `Replication`                  | 6      | n/a       | 17 596          | ~1 s      |
+| `ReplicationTxn` (CI)          | 7      | 2         | 807 367         | ~6 s      |
+| `ReplicationTxnDeep` (manual)  | 8      | 1         | 4 626 498       | ~30 s     |
 
 ## Limitations
 

--- a/designdocs/tla/ReplicationTxn.cfg
+++ b/designdocs/tla/ReplicationTxn.cfg
@@ -6,6 +6,7 @@ CONSTANTS
     ResourceIds <- MCResourceIds
     Trust <- MCTrust
     MaxOps <- MCMaxOps
+    BatchSize <- MCBatchSize
     NodeA = NodeA
     NodeB = NodeB
     NodeC = NodeC
@@ -19,5 +20,6 @@ INVARIANTS
     EmbargoFilter
     ProjectIsolation
     ChainIntactOrEmbargoGap
+    ParentRefIntactOrEmbargoGap
     NoCommittedEntryLost
     TypeOK

--- a/designdocs/tla/ReplicationTxn.tla
+++ b/designdocs/tla/ReplicationTxn.tla
@@ -21,10 +21,11 @@
 (***************************************************************************)
 EXTENDS Naturals, FiniteSets, Sequences, TLC
 
-CONSTANTS Nodes, Projects, ResourceIds, Trust, MaxOps
+CONSTANTS Nodes, Projects, ResourceIds, Trust, MaxOps, BatchSize
 
 ASSUME Trust \in [Nodes -> SUBSET Nodes]
 ASSUME MaxOps \in Nat
+ASSUME BatchSize \in Nat \ {0}
 
 VARIABLES
     entries,        \* Node -> SUBSET Entry
@@ -174,22 +175,63 @@ Commit(n, v) ==
     /\ UNCHANGED <<cursors, nextVersion>>
 
 (***************************************************************************)
-(* Action: receiver pulls committed entries from upstream.                *)
+(* Validity of a batch.  A batch is the subset of visible entries selected *)
+(* by one Pull RPC; subsequent Pulls fetch the rest.  Two constraints:     *)
+(*                                                                         *)
+(*   1. PREFIX: batch is a prefix in localVersion order.  Equivalent to    *)
+(*      the Postgres `ORDER BY local_version LIMIT N` query semantics.     *)
+(*      Required for cursor advance (max watermark of batch) to never      *)
+(*      skip a committed entry — see NoCommittedEntryLost.                 *)
+(*                                                                         *)
+(*   2. ANCESTOR-CLOSED: for every entry e in batch and every ancestor    *)
+(*      reference r in {e.prev, e.parentRef} that resolves to a visible    *)
+(*      entry q, q is in batch or already at the receiver.  Without this   *)
+(*      the receiver could briefly hold an entry whose ancestor (prev for  *)
+(*      same-resource chain, parentRef for cross-resource) is in a         *)
+(*      strictly later batch.                                              *)
+(*                                                                         *)
+(*      Note: multiple entries can share localVersion on a receiver — when *)
+(*      a batch is pulled and committed in one txn, all entries get the    *)
+(*      same recvTxid.  Two such entries could have a prev/parent link     *)
+(*      between them, so same-localVersion groups must respect the         *)
+(*      ancestor closure as well.                                          *)
+(*                                                                         *)
+(* Implementations satisfy (2) by either shipping same-localVersion        *)
+(* groups atomically (LIMIT N WITH TIES) or topo-sorting within a group.   *)
+(***************************************************************************)
+ValidBatch(receiver, upstream, proj, batch) ==
+    LET cur     == cursors[receiver][upstream][proj]
+        visible == { e \in entries[upstream] :
+                       /\ e.committed
+                       /\ e.proj = proj
+                       /\ e.localVersion >= cur }
+    IN /\ batch # {}
+       /\ batch \subseteq visible
+       /\ Cardinality(batch) <= BatchSize
+       /\ \A e \in batch : \A f \in visible :
+            f.localVersion < e.localVersion => f \in batch
+       /\ \A e \in batch :
+            \A ref \in {e.prev, e.parentRef} \ {NullRef} :
+              \A p \in visible :
+                (p.origin = ref.origin /\ p.rid = ref.rid /\ p.ver = ref.ver) =>
+                  \/ p \in batch
+                  \/ Has(receiver, p.origin, p.rid, p.ver)
+
+(***************************************************************************)
+(* Action: receiver pulls a batch of committed entries from upstream.     *)
 (* Filter is on `localVersion` (upstream's local commit order), not `ver` *)
 (* (origin's version).  The receiver assigns its own localVersion and    *)
 (* watermark when storing the entry — replicated entries get a fresh txid *)
 (* in the receiver's namespace, matching the reference implementation.   *)
+(* Cursor advances to max(watermark) of the batch; subsequent pulls pick *)
+(* up entries whose localVersion >= that watermark.                      *)
 (***************************************************************************)
-Pull(receiver, upstream, proj) ==
+BatchPull(receiver, upstream, proj, batch) ==
     /\ opCount < MaxOps
     /\ receiver # upstream
-    /\ LET cur        == cursors[receiver][upstream][proj]
-           serveEmb   == receiver \in Trust[upstream]
-           visible    == { e \in entries[upstream] :
-                             /\ e.committed
-                             /\ e.proj = proj
-                             /\ e.localVersion >= cur }
-           candidates == { e \in visible :
+    /\ ValidBatch(receiver, upstream, proj, batch)
+    /\ LET serveEmb   == receiver \in Trust[upstream]
+           candidates == { e \in batch :
                              /\ e.origin # receiver
                              /\ (~e.emb \/ serveEmb)
                              /\ ~Has(receiver, e.origin, e.rid, e.ver) }
@@ -203,8 +245,7 @@ Pull(receiver, upstream, proj) ==
                             proj |-> e.proj,
                             path |-> e.path \o <<receiver>>] :
                            e \in candidates }
-           newCursor  == IF visible = {} THEN cur
-                         ELSE Max({e.watermark : e \in visible})
+           newCursor  == Max({e.watermark : e \in batch})
        IN
            /\ entries' = [entries EXCEPT ![receiver] = @ \cup accepted]
            /\ cursors' = [cursors EXCEPT ![receiver] =
@@ -224,7 +265,8 @@ Next ==
         \E parent \in entries[n] : WriteCommentInOpenPlanTxn(n, parent, rid, emb)
     \/ \E n \in Nodes : \E e \in entries[n] : BeginEdit(n, e)
     \/ \E n \in Nodes : \E v \in inFlight[n] : Commit(n, v)
-    \/ \E r \in Nodes, u \in Nodes, p \in Projects : Pull(r, u, p)
+    \/ \E r \in Nodes, u \in Nodes, p \in Projects :
+        \E batch \in SUBSET entries[u] : BatchPull(r, u, p, batch)
 
 Spec == Init /\ [][Next]_vars
 

--- a/designdocs/tla/ReplicationTxnDeep.cfg
+++ b/designdocs/tla/ReplicationTxnDeep.cfg
@@ -6,6 +6,7 @@ CONSTANTS
     ResourceIds <- MCResourceIds
     Trust <- MCTrust
     MaxOps <- MCMaxOps
+    BatchSize <- MCBatchSize
     NodeA = NodeA
     NodeB = NodeB
     NodeC = NodeC
@@ -19,5 +20,6 @@ INVARIANTS
     EmbargoFilter
     ProjectIsolation
     ChainIntactOrEmbargoGap
+    ParentRefIntactOrEmbargoGap
     NoCommittedEntryLost
     TypeOK

--- a/designdocs/tla/ReplicationTxnDeepMC.tla
+++ b/designdocs/tla/ReplicationTxnDeepMC.tla
@@ -1,6 +1,6 @@
 --------------------------- MODULE ReplicationTxnDeepMC ---------------------------
-(* Deeper model-checking run.  Tagged manual so it doesn't run in every CI *)
-(* cycle; run with                                                         *)
+(* Deeper model-checking run: MaxOps=8.  Tagged manual so it doesn't run   *)
+(* in every CI cycle; run with                                             *)
 (* `bazel test //designdocs/tla:replication_txn_deep_tlc_test`.            *)
 EXTENDS ReplicationTxn
 
@@ -16,6 +16,10 @@ MCTrust == [
         ELSE {}
 ]
 MCMaxOps == 8
+\* BatchSize=1 forces every batch to a single entry, maximally stressing
+\* the parent-closure constraint: a child can only be shipped once its
+\* parent is at the receiver.
+MCBatchSize == 1
 
 \* {NodeA, NodeB} are interchangeable (Trust is symmetric across them);
 \* NodeC is asymmetric (untrusted by both).  Cuts state space ~2x.

--- a/designdocs/tla/ReplicationTxnMC.tla
+++ b/designdocs/tla/ReplicationTxnMC.tla
@@ -13,6 +13,10 @@ MCTrust == [
         ELSE {}
 ]
 MCMaxOps == 7
+\* BatchSize=2 stresses partial batches without exploding state space.
+\* Same-localVersion plan+comment groups (size 2) just barely fit;
+\* larger same-V groups would force topo-sorted within-V splits.
+MCBatchSize == 2
 
 \* {NodeA, NodeB} are interchangeable (Trust is symmetric across them);
 \* NodeC is asymmetric (untrusted by both).  Cuts state space ~2x.


### PR DESCRIPTION
## Summary

Introduces `BatchPull` as a refinement of `Pull` that models partial replication batches.
A Pull RPC may stream entries across multiple batches; each batch must respect two invariants:

1. **Prefix** in \`localVersion\` order (matches Postgres \`ORDER BY local_version LIMIT N\` semantics).
2. **Ancestor-closed** for both \`prev\` (same-resource chain) and \`parentRef\` (cross-resource).
   Without this, a batch boundary could split a same-\`localVersion\` group and deliver a child whose parent is in a strictly later batch.

The protocol contract — items crossing batch boundaries are topologically ordered — is satisfied by two equivalent implementation strategies:

- Atomic same-\`localVersion\` groups (\`LIMIT N WITH TIES\`).
- Topo-sort within a \`localVersion\`.

\`Replication.md\`'s new **Batch boundaries** section documents both, and the serving pseudocode uses \`FETCH FIRST N ROWS WITH TIES\`.

MaxOps=7, BatchSize=2 (CI): 807K distinct states, ~6s.
MaxOps=8, BatchSize=1 (manual): 4.6M distinct states, ~30s.

## Test plan

- [ ] \`bazel test //designdocs/tla:replication_txn_tlc_test\` passes
- [ ] \`bazel test //designdocs/tla:replication_txn_deep_tlc_test\` passes