### PR TITLE
infra: hermetic TLA+ toolchain for TLC

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -59,6 +59,32 @@ http_file(
     url = "https://github.com/theseus-rs/postgresql-binaries/releases/download/17.9.0/postgresql-17.9.0-x86_64-unknown-linux-gnu.tar.gz",
 )
 
+# Eclipse Temurin JRE 21 for Linux x86_64.  Used by //infra/tla to run TLC.
+# Update by checking https://github.com/adoptium/temurin21-binaries/releases
+# and recomputing sha256.
+http_archive(
+    name = "temurin_jre_linux_amd64",
+    build_file_content = """
+filegroup(
+    name = "files",
+    srcs = glob(["**"]),
+    visibility = ["//visibility:public"],
+)
+""",
+    sha256 = "553dda64b3b1c3c16f8afe402377ffebe64fb4a1721a46ed426a91fd18185e62",
+    strip_prefix = "jdk-21.0.5+11-jre",
+    url = "https://github.com/adoptium/temurin21-binaries/releases/download/jdk-21.0.5%2B11/OpenJDK21U-jre_x64_linux_hotspot_21.0.5_11.tar.gz",
+)
+
+# TLA+ tools (TLC model checker, SANY parser, etc.) bundled as a single jar.
+# Update: check https://github.com/tlaplus/tlaplus/releases for new versions.
+http_file(
+    name = "tla2tools",
+    downloaded_file_path = "tla2tools.jar",
+    sha256 = "af03b2baae73b523fe162c0ff195c5adeed42cd1d092200b0bde2cd15914f624",
+    url = "https://github.com/tlaplus/tlaplus/releases/download/v1.8.0/tla2tools.jar",
+)
+
 # AWS CLI 2.34.14 Linux amd64, used by //infra:aws.
 # Update: download new zip, run sha256sum, update version and sha256 here.
 # https://awscli.amazonaws.com/awscli-exe-linux-x86_64-VERSION.zip

--- a/infra/tla/BUILD.bazel
+++ b/infra/tla/BUILD.bazel
@@ -1,0 +1,12 @@
+load("//tools/lint:format_check.bzl", "format_srcs")
+load("//tools/lint:linters.bzl", "markdown_lint_test")
+
+# The hermetic TLC runner script — invoked by tla_test rules across the repo.
+exports_files(["run_tlc.sh"])
+
+format_srcs()
+
+markdown_lint_test(
+    name = "pymarkdown",
+    srcs = ["README.md"],
+)

--- a/infra/tla/README.md
+++ b/infra/tla/README.md
@@ -1,0 +1,29 @@
+# TLA+ toolchain
+
+Hermetic Bazel integration for the [TLA+ TLC model checker](https://lamport.azurewebsites.net/tla/tla.html).
+Fetches a Temurin JRE and `tla2tools.jar` at build time so `bazel test` runs TLC with no local Java install.
+
+## Using the `tla_test` macro
+
+```starlark
+load("//infra/tla:defs.bzl", "tla_test")
+
+tla_test(
+    name = "my_spec_tlc_test",
+    srcs = [
+        "MySpec.tla",
+        "MySpecMC.tla",
+    ],
+    config = "MySpec.cfg",
+    entry = "MySpecMC.tla",
+)
+```
+
+`srcs` lists the `.tla` modules TLC needs (the entry module and anything it `EXTENDS`).
+`config` is the `.cfg` file specifying the spec, constants, and invariants.
+`entry` is the `.tla` file TLC starts from — typically the MC module that binds concrete values.
+
+## Ad-hoc runs
+
+For iteration outside Bazel, `run_tlc.sh` is a standalone wrapper that caches `tla2tools.jar` in `~/.cache/tla` and exec's TLC directly.
+Requires Java locally (`sudo apt install openjdk-21-jre-headless`).

--- a/infra/tla/defs.bzl
+++ b/infra/tla/defs.bzl
@@ -1,0 +1,39 @@
+"""Macros for running TLC against TLA+ specs hermetically under Bazel."""
+
+load("@rules_shell//shell:sh_test.bzl", "sh_test")
+
+def tla_test(name, srcs, entry, config, tags = None, **kwargs):
+    """Run TLC against a TLA+ specification as a bazel test.
+
+    Args:
+        name: test target name.
+        srcs: all .tla files needed (entry + EXTENDed modules).
+        entry: the .tla file to model-check.
+        config: the .cfg file describing constants and invariants.
+        tags: extra tags (e.g. ["manual"] for slow specs).
+        **kwargs: additional sh_test kwargs.
+    """
+    if entry not in srcs:
+        fail("entry %r must be in srcs" % entry)
+    if not config.endswith(".cfg"):
+        fail("config %r must end in .cfg" % config)
+
+    # Compute repo-prefixed paths so the runner can rlocation() them.
+    # `_main` is the workspace name in bzlmod.
+    pkg = native.package_name()
+    cfg_rlocation = "_main/{}/{}".format(pkg, config)
+    tla_rlocation = "_main/{}/{}".format(pkg, entry)
+
+    sh_test(
+        name = name,
+        srcs = ["//infra/tla:run_tlc.sh"],
+        args = [cfg_rlocation, tla_rlocation],
+        data = srcs + [
+            config,
+            "@bazel_tools//tools/bash/runfiles",
+            "@temurin_jre_linux_amd64//:files",
+            "@tla2tools//file",
+        ],
+        tags = tags,
+        **kwargs
+    )

--- a/infra/tla/run_tlc.sh
+++ b/infra/tla/run_tlc.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+# Hermetic TLC runner.  Used by both `bazel run //infra/tla:tlc` and
+# `tla_test` rules in //designdocs/tla:BUILD.bazel.
+#
+# Arguments:
+#   $1: relative path to the .cfg file (resolved via runfiles)
+#   $2: relative path to the entry .tla file
+#   remaining: additional TLC flags
+#
+# Resolves the JRE and tla2tools.jar from runfiles so the entire toolchain
+# is hermetic.
+
+set -euo pipefail
+
+# Standard Bazel 3-way runfiles init.
+if [[ -f "${RUNFILES_DIR:-/dev/null}/bazel_tools/tools/bash/runfiles/runfiles.bash" ]]; then
+	# shellcheck source=/dev/null
+	source "${RUNFILES_DIR}/bazel_tools/tools/bash/runfiles/runfiles.bash"
+elif [[ -f "${BASH_SOURCE[0]}.runfiles/bazel_tools/tools/bash/runfiles/runfiles.bash" ]]; then
+	# shellcheck source=/dev/null
+	source "${BASH_SOURCE[0]}.runfiles/bazel_tools/tools/bash/runfiles/runfiles.bash"
+elif [[ -f "${RUNFILES_MANIFEST_FILE:-/dev/null}" ]]; then
+	# shellcheck source=/dev/null
+	source "$(grep -m1 "^bazel_tools/tools/bash/runfiles/runfiles.bash " \
+		"$RUNFILES_MANIFEST_FILE" | cut -d ' ' -f2-)"
+else
+	echo >&2 "ERROR: cannot find Bazel runfiles library"
+	exit 1
+fi
+
+JAVA="$(rlocation +http_archive+temurin_jre_linux_amd64/bin/java)"
+JAR="$(rlocation +http_file+tla2tools/file/tla2tools.jar)"
+
+if [[ ! -x "${JAVA}" ]]; then
+	echo "ERROR: java not found in runfiles at ${JAVA}" >&2
+	exit 1
+fi
+if [[ ! -f "${JAR}" ]]; then
+	echo "ERROR: tla2tools.jar not found in runfiles at ${JAR}" >&2
+	exit 1
+fi
+
+CFG_REL="$1"
+TLA_REL="$2"
+shift 2
+
+CFG="$(rlocation "${CFG_REL}")"
+TLA="$(rlocation "${TLA_REL}")"
+if [[ ! -f "${CFG}" || ! -f "${TLA}" ]]; then
+	echo "ERROR: spec files not found: cfg=${CFG_REL} tla=${TLA_REL}" >&2
+	exit 1
+fi
+
+# TLC reads the .cfg with the same basename as the .tla unless told otherwise,
+# and resolves modules from the cwd.  Stage everything into a temp dir.
+WORK="$(mktemp -d)"
+trap 'rm -rf "${WORK}"' EXIT
+
+# Copy the entry .tla and .cfg into work dir; also copy any sibling .tla files
+# the entry might EXTEND (we copy all .tla files in the same directory as the
+# entry to keep this simple).
+TLA_DIR="$(dirname "${TLA}")"
+cp "${TLA_DIR}"/*.tla "${WORK}/"
+cp "${CFG}" "${WORK}/$(basename "${TLA}" .tla).cfg"
+
+cd "${WORK}"
+exec "${JAVA}" -XX:+UseParallelGC -cp "${JAR}" tlc2.TLC \
+	-deadlock \
+	-workers auto \
+	"$@" \
+	"$(basename "${TLA}")"


### PR DESCRIPTION
## Summary

- `MODULE.bazel` additions: Temurin JRE 21 and `tla2tools.jar` fetched via `http_archive` / `http_file`.
- `//infra/tla` provides a `tla_test` macro that runs TLC under `sh_test` using bazel runfiles for both the JRE and the spec sources — fully hermetic, no local Java install required.
- Standalone shell wrapper for ad-hoc TLC runs outside Bazel, caching `tla2tools.jar` in `~/.cache/tla`.

No specs land in this PR; the macro is ready for the model that follows.

## Test plan

- [ ] \`bazel build //infra/tla/...\` succeeds