### PR TITLE
db: trigger wrapper for journal isolation enforcement

### DIFF
--- a/lib/rust/api_db/migrations/009_journal_isolation_trigger.sql
+++ b/lib/rust/api_db/migrations/009_journal_isolation_trigger.sql
@@ -1,0 +1,10 @@
+-- Trigger-compatible wrapper around check_repeatable_read().
+-- Every journal table attaches a BEFORE INSERT OR UPDATE trigger that calls
+-- this wrapper, so writes outside REPEATABLE READ are rejected before any
+-- row is modified.
+CREATE FUNCTION check_repeatable_read_trigger() RETURNS trigger AS $$
+BEGIN
+    PERFORM check_repeatable_read();
+    RETURN NULL;
+END;
+$$ LANGUAGE plpgsql;


### PR DESCRIPTION
## Summary

Adds \`check_repeatable_read_trigger()\` — a BEFORE INSERT/UPDATE trigger function wrapping \`check_repeatable_read()\` from migration 007.

Every journal table will attach this trigger so writes outside REPEATABLE READ are rejected before any row is modified.
This matches the replication protocol's requirement for snapshot isolation on writes that create cross-resource references (see \`designdocs/Replication.md\`).

Generic infrastructure — not tied to any particular resource type.

## Test plan

- [ ] \`bazel test //lib/rust/api_db:api_db_db_test\` passes (migrations apply cleanly)