### PR TITLE
build: enforce --lockfile_mode=error so coverage matches CI

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -19,6 +19,11 @@ build:ci --build_metadata=ROLE=CI
 build:ci --remote_cache=grpcs://remote.buildbuddy.io
 build:ci --bes_backend=grpcs://remote.buildbuddy.io
 build:ci --bes_results_url=https://app.buildbuddy.io/invocation/
+# Fail CI if MODULE.bazel.lock would be updated — every dep change must be
+# committed alongside the lockfile. The renovate-lockfile workflow handles
+# Renovate PRs; for human PRs that add deps, run
+# `bazel mod deps --lockfile_mode=update` locally and commit the result.
+build:ci --lockfile_mode=error
 
 # Rust: use the experimental platform so the toolchain glibc constraint is satisfied.
 # Without this, rules_rs toolchains (which embed gnu.2.28) cannot match the default

--- a/tools/coverage.sh
+++ b/tools/coverage.sh
@@ -47,7 +47,13 @@ SKIP_FILES=(
 # Runs every test in one bazel invocation, including the format_check_auto
 # tagged sh_tests. Those produce no Rust coverage data — they're bundled
 # here so the hook pays only one bazel analysis phase instead of two.
-bazel coverage "$@"
+#
+# --lockfile_mode=error makes this script predict CI: if a dep was added
+# without committing the regenerated MODULE.bazel.lock, bazel fails here
+# rather than silently churning the lockfile (which would also break the
+# patch-diff cache above). To regenerate after adding a dep, run
+# `bazel mod deps --lockfile_mode=update` and commit the result.
+bazel coverage --lockfile_mode=error "$@"
 
 if [[ ! -f "$REPORT" ]]; then
 	echo "error: coverage report not found at $REPORT" >&2


### PR DESCRIPTION
## Summary

Makes `tools/coverage.sh` and CI fail fast if `MODULE.bazel.lock` would be updated, while leaving ad-hoc `bazel build`/`bazel test` at bazel's default `update` mode locally. So:

- Local `tools/coverage.sh ...` predicts CI exactly.
- Local `bazel build`, `bazel test`, etc. still populate the lockfile transparently — adding a dep doesn't block your edit-build loop.
- CI (any invocation passing `--config=ci`, including `format.check`) refuses to merge a change that left `MODULE.bazel.lock` out of sync.

## Implementation

- `.bazelrc`: add `build:ci --lockfile_mode=error` next to the existing `build:ci` block.
- `tools/coverage.sh`: pass `--lockfile_mode=error` to its `bazel coverage` invocation.

## Workflow when a PR adds a dep

1. Edit `MODULE.bazel` (or `Cargo.toml` for a rules_rs crate add).
2. `bazel build //...` → succeeds, populates `MODULE.bazel.lock`.
3. `tools/coverage.sh //...` → succeeds, lockfile already in sync.
4. `jj status` → shows `MODULE.bazel.lock` as a working-copy change; commit it alongside the dep change.
5. CI verifies the lockfile is committed by re-running with `--lockfile_mode=error`.

If step 3 is run before step 2, it fails with `MODULE.bazel.lock would be updated but lockfile_mode=error` — the fix is the same: run `bazel build` (or `bazel mod deps --lockfile_mode=update`) once, commit the lockfile.

The renovate-lockfile workflow already passes `--lockfile_mode=update` explicitly, so it's unaffected.

## Test plan

- [x] `tools/coverage.sh -- //... -//tla/...` cold: green, MODULE.bazel.lock unchanged after the run
- [x] Same args, second run: short-circuits via the patch-diff cache (#256) in 0.6–0.9s
- [x] `jj status` after coverage shows only the two intended files modified
- [ ] `//tla:replication_tlc_test` excluded — pre-existing `tla2tools.jar` checksum mismatch on master, unrelated