### PR TITLE
journal: test_support module — seed_project + test_instance fixtures

### DIFF
--- a/lib/rust/api_db/.sqlx/query-43b865410788be6ba9aa7d8f34b000d1d6e7da5d245fdcf4d512d42ec0346537.json
+++ b/lib/rust/api_db/.sqlx/query-43b865410788be6ba9aa7d8f34b000d1d6e7da5d245fdcf4d512d42ec0346537.json
@@ -1,0 +1,22 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT count(*) AS \"c!\" FROM projects WHERE id = $1",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "c!",
+        "type_info": "Int8"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text"
+      ]
+    },
+    "nullable": [
+      null
+    ]
+  },
+  "hash": "43b865410788be6ba9aa7d8f34b000d1d6e7da5d245fdcf4d512d42ec0346537"
+}

--- a/lib/rust/api_db/src/lib.rs
+++ b/lib/rust/api_db/src/lib.rs
@@ -6,6 +6,8 @@ mod pending_login;
 mod project;
 mod role;
 mod session;
+#[cfg(test)]
+mod test_support;
 
 /// Re-export chrono types used in public structs (e.g. `SessionRow.expires_at`).
 pub use sqlx::types::chrono;

--- a/lib/rust/api_db/src/lib.rs
+++ b/lib/rust/api_db/src/lib.rs
@@ -5,6 +5,8 @@ mod pending_login;
 mod project;
 mod role;
 mod session;
+#[cfg(test)]
+mod test_support;
 
 /// Re-export chrono types used in public structs (e.g. `SessionRow.expires_at`).
 pub use sqlx::types::chrono;

--- a/lib/rust/api_db/src/test_support.rs
+++ b/lib/rust/api_db/src/test_support.rs
@@ -1,0 +1,60 @@
+//! Shared test fixtures for journal-table tests.
+//!
+//! Every per-resource journal table needs a `projects` row to satisfy its
+//! foreign key, and a fresh `InstanceId` to author entries with.  This
+//! module provides the two minimal helpers each test reaches for, so
+//! resource modules don't keep redefining them.
+
+use uuid::Uuid;
+
+use crate::db::DbPool;
+use crate::journal::InstanceId;
+use crate::role::ProjectId;
+
+/// A fresh randomized `InstanceId`, valid as a UUID.
+pub(crate) fn test_instance() -> InstanceId {
+    InstanceId::from_raw(&Uuid::new_v4().to_string()).unwrap()
+}
+
+/// Insert a minimal project row directly (bypassing `create_project`,
+/// which requires a user) and return its id.  Use to satisfy the
+/// `project_id` foreign key on journal tables in `#[sqlx::test]`-driven
+/// tests.
+pub(crate) async fn seed_project(pool: &DbPool) -> ProjectId {
+    let id = Uuid::new_v4().to_string();
+    sqlx::query!(
+        "INSERT INTO projects (id, name, visibility) VALUES ($1, $2, 'public')",
+        id,
+        format!("p-{}", &id[..8]),
+    )
+    .execute(&pool.pool())
+    .await
+    .expect("seed project");
+    ProjectId::new(id).unwrap()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_instance_returns_distinct_uuids() {
+        let a = test_instance();
+        let b = test_instance();
+        assert_ne!(a, b);
+    }
+
+    #[sqlx::test(migrator = "crate::db::MIGRATIONS")]
+    async fn seed_project_inserts_a_row(pool: sqlx::PgPool) {
+        let db = DbPool::from_pool(pool);
+        let project = seed_project(&db).await;
+        let count: i64 = sqlx::query_scalar!(
+            "SELECT count(*) AS \"c!\" FROM projects WHERE id = $1",
+            project.as_str()
+        )
+        .fetch_one(&db.pool())
+        .await
+        .unwrap();
+        assert_eq!(count, 1);
+    }
+}

--- a/lib/rust/api_db/src/test_support.rs
+++ b/lib/rust/api_db/src/test_support.rs
@@ -1,0 +1,60 @@
+//! Shared test fixtures for journal-table tests.
+//!
+//! Every per-resource journal table needs a `projects` row to satisfy its
+//! foreign key, and a fresh `InstanceId` to author entries with.  This
+//! module provides the two minimal helpers each test reaches for, so
+//! resource modules don't keep redefining them.
+
+use db_pool::{DbPool, QueryAccess};
+use uuid::Uuid;
+
+use crate::journal::InstanceId;
+use crate::role::ProjectId;
+
+/// A fresh randomized `InstanceId`, valid as a UUID.
+pub(crate) fn test_instance() -> InstanceId {
+    InstanceId::from_raw(&Uuid::new_v4().to_string()).unwrap()
+}
+
+/// Insert a minimal project row directly (bypassing `create_project`,
+/// which requires a user) and return its id.  Use to satisfy the
+/// `project_id` foreign key on journal tables in `#[sqlx::test]`-driven
+/// tests.
+pub(crate) async fn seed_project(pool: &DbPool) -> ProjectId {
+    let id = Uuid::new_v4().to_string();
+    sqlx::query!(
+        "INSERT INTO projects (id, name, visibility) VALUES ($1, $2, 'public')",
+        id,
+        format!("p-{}", &id[..8]),
+    )
+    .execute(&pool.pool())
+    .await
+    .expect("seed project");
+    ProjectId::new(id).unwrap()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_instance_returns_distinct_uuids() {
+        let a = test_instance();
+        let b = test_instance();
+        assert_ne!(a, b);
+    }
+
+    #[sqlx::test(migrator = "crate::db::MIGRATIONS")]
+    async fn seed_project_inserts_a_row(pool: sqlx::PgPool) {
+        let db = DbPool::from_pool(pool);
+        let project = seed_project(&db).await;
+        let count: i64 = sqlx::query_scalar!(
+            "SELECT count(*) AS \"c!\" FROM projects WHERE id = $1",
+            project.as_str()
+        )
+        .fetch_one(&db.pool())
+        .await
+        .unwrap();
+        assert_eq!(count, 1);
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `crate::test_support` module (cfg(test) only) with `seed_project(pool)` and `test_instance()`.
- `seed_project` bypasses normal project creation (which requires a user) by inserting a minimal row, so journal-table tests can satisfy the `project_id` foreign key.
- `test_instance` returns a fresh randomised `InstanceId`.

## Test plan

- [x] `test_instance_returns_distinct_uuids`.
- [x] `seed_project_inserts_a_row` against real Postgres.
- [x] `tools/coverage.sh //...` passes.