### PR TITLE
build: pin TLA+ to stable v1.7.4 release

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -77,12 +77,15 @@ filegroup(
 )
 
 # TLA+ tools (TLC model checker, SANY parser, etc.) bundled as a single jar.
+# Pinned to the stable v1.7.4 release.  v1.8.0 is published as a rolling
+# pre-release: artifacts are re-uploaded under the same tag, breaking sha256
+# pinning.  Stay on v1.7.4 until upstream cuts a new immutable stable tag.
 # Update: check https://github.com/tlaplus/tlaplus/releases for new versions.
 http_file(
     name = "tla2tools",
     downloaded_file_path = "tla2tools.jar",
-    sha256 = "af03b2baae73b523fe162c0ff195c5adeed42cd1d092200b0bde2cd15914f624",
-    url = "https://github.com/tlaplus/tlaplus/releases/download/v1.8.0/tla2tools.jar",
+    sha256 = "936a262061c914694dfd669a543be24573c45d5aa0ff20a8b96b23d01e050e88",
+    url = "https://github.com/tlaplus/tlaplus/releases/download/v1.7.4/tla2tools.jar",
 )
 
 # AWS CLI 2.34.14 Linux amd64, used by //infra:aws.


### PR DESCRIPTION
## Summary

- Switch `tla2tools.jar` pin from `v1.8.0` to `v1.7.4` and update sha256 per https://github.com/tlaplus/tlaplus/issues/1380
- v1.8.0 is published as a rolling pre-release on GitHub: artifacts get re-uploaded under the same tag, breaking sha256 pinning. v1.7.4 is the latest immutable stable release.
- Our specs use only standard TLA+ features (`Naturals`, `FiniteSets`, `Sequences`, `TLC`, `Permutations`, `SYMMETRY`) — nothing v1.8.0-specific.

## Test plan

- [x] `bazel test //tla:replication_tlc_test` passes
- [x] `bazel test //tla:replication_deep_tlc_test` passes
- [x] `tools/coverage.sh //...` passes