### PR TITLE
db: convert runtime sqlx::query calls to typed bang form

### DIFF
--- a/lib/rust/api_db/.sqlx/query-3df2f29cd023795b6515c845c7feb27785aaca783c1a95efc5cccd5e52e3b5ca.json
+++ b/lib/rust/api_db/.sqlx/query-3df2f29cd023795b6515c845c7feb27785aaca783c1a95efc5cccd5e52e3b5ca.json
@@ -1,0 +1,15 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "INSERT INTO projects (id, name, description, visibility, embargoed_by_default, created_at) SELECT id, name, '', 'public', false, now() FROM UNNEST($1::text[], $2::text[]) AS t(id, name)",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "TextArray",
+        "TextArray"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "3df2f29cd023795b6515c845c7feb27785aaca783c1a95efc5cccd5e52e3b5ca"
+}

--- a/lib/rust/api_db/.sqlx/query-5ec274a882caf4cd95ab49458cf727efddfd5d3c454d32cf9d2696ba5ba8c89d.json
+++ b/lib/rust/api_db/.sqlx/query-5ec274a882caf4cd95ab49458cf727efddfd5d3c454d32cf9d2696ba5ba8c89d.json
@@ -1,0 +1,12 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "ANALYZE projects",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": []
+    },
+    "nullable": []
+  },
+  "hash": "5ec274a882caf4cd95ab49458cf727efddfd5d3c454d32cf9d2696ba5ba8c89d"
+}

--- a/lib/rust/api_db/.sqlx/query-9293ebae602164104e17bd715e4aaa3a209d91a7c3f99225aa8f50180263a480.json
+++ b/lib/rust/api_db/.sqlx/query-9293ebae602164104e17bd715e4aaa3a209d91a7c3f99225aa8f50180263a480.json
@@ -1,0 +1,20 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT current_setting('transaction_isolation') AS \"v!\"",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "v!",
+        "type_info": "Text"
+      }
+    ],
+    "parameters": {
+      "Left": []
+    },
+    "nullable": [
+      null
+    ]
+  },
+  "hash": "9293ebae602164104e17bd715e4aaa3a209d91a7c3f99225aa8f50180263a480"
+}

--- a/lib/rust/api_db/.sqlx/query-e288087827103c5affbb2ea58064987b2943f81bbd3f6389e718953cfb723fe2.json
+++ b/lib/rust/api_db/.sqlx/query-e288087827103c5affbb2ea58064987b2943f81bbd3f6389e718953cfb723fe2.json
@@ -1,0 +1,20 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "EXPLAIN (ANALYZE, BUFFERS) SELECT id, name, description, visibility, embargoed_by_default, created_at FROM projects",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "QUERY PLAN",
+        "type_info": "Text"
+      }
+    ],
+    "parameters": {
+      "Left": []
+    },
+    "nullable": [
+      null
+    ]
+  },
+  "hash": "e288087827103c5affbb2ea58064987b2943f81bbd3f6389e718953cfb723fe2"
+}

--- a/lib/rust/api_db/.sqlx/query-e67fda05dacea7a0b6290e8b69932ad27e5a0dd128af9273d1d6179e60f9ea0b.json
+++ b/lib/rust/api_db/.sqlx/query-e67fda05dacea7a0b6290e8b69932ad27e5a0dd128af9273d1d6179e60f9ea0b.json
@@ -1,0 +1,12 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SET TRANSACTION ISOLATION LEVEL REPEATABLE READ",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": []
+    },
+    "nullable": []
+  },
+  "hash": "e67fda05dacea7a0b6290e8b69932ad27e5a0dd128af9273d1d6179e60f9ea0b"
+}

--- a/lib/rust/api_db/src/db.rs
+++ b/lib/rust/api_db/src/db.rs
@@ -145,7 +145,7 @@ impl DbPool {
     #[allow(clippy::disallowed_methods)] // The one legitimate caller of sqlx::Pool::begin.
     pub(crate) async fn begin_txn(&self) -> anyhow::Result<sqlx::Transaction<'_, sqlx::Postgres>> {
         let mut tx = self.pool().begin().await.context("beginning transaction")?;
-        sqlx::query("SET TRANSACTION ISOLATION LEVEL REPEATABLE READ")
+        sqlx::query!("SET TRANSACTION ISOLATION LEVEL REPEATABLE READ")
             .execute(&mut *tx)
             .await
             .context("setting isolation level")?;
@@ -291,10 +291,11 @@ mod tests {
     async fn begin_txn_sets_repeatable_read(pool: sqlx::PgPool) {
         let db = DbPool::from_pool(pool);
         let mut tx = db.begin_txn().await.expect("begin_txn failed");
-        let level: String = sqlx::query_scalar("SELECT current_setting('transaction_isolation')")
-            .fetch_one(&mut *tx)
-            .await
-            .expect("query failed");
+        let level: String =
+            sqlx::query_scalar!("SELECT current_setting('transaction_isolation') AS \"v!\"")
+                .fetch_one(&mut *tx)
+                .await
+                .expect("query failed");
         assert_eq!(level, "repeatable read");
     }
 }

--- a/lib/rust/api_db/src/project.rs
+++ b/lib/rust/api_db/src/project.rs
@@ -1136,55 +1136,56 @@ mod tests {
             let add = next_add;
             next_add = (next_add * 50).max(next_add + 1);
 
-            // Bulk-insert projects in batches of up to 1000 rows.
+            // Bulk-insert projects in batches of up to 1000 rows using
+            // UNNEST: one fixed-shape INSERT with arrays of column values.
+            // sqlx::query! validates the SQL at compile time; the batch
+            // size varies via the array length, not the SQL text.
             let insert_start = total;
             let target = total + add;
             while total < target {
                 let batch_end = (total + 1000).min(target);
-                let mut query = String::from(
+                let n = (batch_end - total) as usize;
+                let ids: Vec<String> = (0..n).map(|_| Uuid::new_v4().to_string()).collect();
+                let names: Vec<String> = (total..batch_end).map(|i| format!("p-{i:08}")).collect();
+                sqlx::query!(
                     "INSERT INTO projects \
-                     (id, name, description, visibility, embargoed_by_default, created_at) VALUES ",
-                );
-                let mut first = true;
-                for i in total..batch_end {
-                    if !first {
-                        query.push(',');
-                    }
-                    first = false;
-                    let id = Uuid::new_v4();
-                    let name = format!("p-{i:08}");
-                    // Safety: name is alphanumeric + hyphen, no SQL injection.
-                    query.push_str(&format!("('{id}', '{name}', '', 'public', false, now())"));
-                }
-                sqlx::query(&query)
-                    .execute(&pool.pool())
-                    .await
-                    .unwrap_or_else(|e| {
-                        panic!(
-                            "bulk insert failed at {total}..{batch_end} \
-                             (added {} since step start): {e}",
-                            total - insert_start,
-                        )
-                    });
+                         (id, name, description, visibility, embargoed_by_default, created_at) \
+                     SELECT id, name, '', 'public', false, now() \
+                     FROM UNNEST($1::text[], $2::text[]) AS t(id, name)",
+                    &ids,
+                    &names,
+                )
+                .execute(&pool.pool())
+                .await
+                .unwrap_or_else(|e| {
+                    panic!(
+                        "bulk insert failed at {total}..{batch_end} \
+                         (added {} since step start): {e}",
+                        total - insert_start,
+                    )
+                });
                 total = batch_end;
             }
 
             // Update planner statistics after bulk insert so Postgres
             // doesn't fall back to sequential scan + sort.
-            sqlx::query("ANALYZE projects")
+            sqlx::query!("ANALYZE projects")
                 .execute(&pool.pool())
                 .await
                 .expect("ANALYZE failed");
 
             // Show query plan for this step.
-            let plan: Vec<String> = sqlx::query_scalar(
+            let plan: Vec<String> = sqlx::query_scalar!(
                 "EXPLAIN (ANALYZE, BUFFERS) \
                  SELECT id, name, description, visibility, embargoed_by_default, created_at \
-                 FROM projects",
+                 FROM projects"
             )
             .fetch_all(&pool.pool())
             .await
-            .expect("EXPLAIN failed");
+            .expect("EXPLAIN failed")
+            .into_iter()
+            .flatten()
+            .collect();
             log!("\n-- EXPLAIN at {total} projects --");
             for line in &plan {
                 log!("{line}");


### PR DESCRIPTION
## Summary

- `db.rs` `begin_txn`: `SET TRANSACTION ISOLATION LEVEL REPEATABLE READ` → `sqlx::query!`.
- `db.rs` `begin_txn_sets_repeatable_read` test: `current_setting('transaction_isolation')` → `sqlx::query_scalar!`.
- `project.rs` scaling test: `ANALYZE projects` and `EXPLAIN (ANALYZE, BUFFERS) SELECT …` → bang form; the bulk INSERT becomes a single `sqlx::query!` over `UNNEST($1::text[], $2::text[])` instead of a runtime-built VALUES list.
- `bazel run //lib/rust/api_db:sqlx_prepare` regenerated the offline cache.

No production runtime `sqlx::query` calls remain.

## Test plan

- [x] `tools/coverage.sh //...` passes