### PR TITLE
build: extract DbPool to db_pool crate; split AWS into db_aws + db_connect

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -87,12 +87,7 @@ name = "api_db"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "arc-swap",
- "aws-config",
- "aws-credential-types",
- "aws-sdk-rds",
- "aws-smithy-async",
- "aws-types",
+ "db_pool",
  "email_address",
  "futures",
  "sqlx",
@@ -899,6 +894,7 @@ dependencies = [
  "axum",
  "causes_proto",
  "clap",
+ "db_connect",
  "dotenvy",
  "futures",
  "mockall",
@@ -1271,6 +1267,45 @@ name = "data-encoding"
 version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
+
+[[package]]
+name = "db_aws"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "aws-config",
+ "aws-credential-types",
+ "aws-sdk-rds",
+ "aws-smithy-async",
+ "aws-types",
+ "db_pool",
+ "futures",
+ "sqlx",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "db_connect"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "db_aws",
+ "db_pool",
+ "tracing",
+]
+
+[[package]]
+name = "db_pool"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "arc-swap",
+ "futures",
+ "sqlx",
+ "tokio",
+ "tracing",
+]
 
 [[package]]
 name = "deadpool"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,9 @@
 members = [
   "lib/rust/api_db",
   "lib/rust/causes_mcp",
+  "lib/rust/db_aws",
+  "lib/rust/db_connect",
+  "lib/rust/db_pool",
   "lib/rust/causes_proto",
   "lib/rust/causes_session",
   "lib/rust/proto_ext",

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -393,6 +393,79 @@
         }
       }
     },
+    "@@protobuf+//python/dist:system_python.bzl%system_python_extension": {
+      "general": {
+        "bzlTransitiveDigest": "qh0n9IrXU/xS94wxKQrG1J63zrLkA1Wy2Y3BQxptPcI=",
+        "usagesDigest": "AF5a9lHFrJtHw1GTt3jJOs7ZYl1+N2bkn1LbPFLoguA=",
+        "recordedInputs": [],
+        "generatedRepoSpecs": {
+          "system_python": {
+            "repoRuleId": "@@protobuf+//python/dist:system_python.bzl%system_python",
+            "attributes": {
+              "minimum_python_version": "3.9"
+            }
+          }
+        }
+      }
+    },
+    "@@pybind11_bazel+//:internal_configure.bzl%internal_configure_extension": {
+      "general": {
+        "bzlTransitiveDigest": "06cynZ1bCvvy8zHPrrDlXq+Z68xmjctHpfFxi+zEpJY=",
+        "usagesDigest": "D1r3lfzMuUBFxgG8V6o0bQTLMk3GkaGOaPzw53wrwyw=",
+        "recordedInputs": [
+          "REPO_MAPPING:pybind11_bazel+,bazel_tools bazel_tools",
+          "FILE:@@pybind11_bazel+//MODULE.bazel e6f4c20442eaa7c90d7190d8dc539d0ab422f95c65a57cc59562170c58ae3d34"
+        ],
+        "generatedRepoSpecs": {
+          "pybind11": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "build_file": "@@pybind11_bazel+//:pybind11-BUILD.bazel",
+              "strip_prefix": "pybind11-2.12.0",
+              "urls": [
+                "https://github.com/pybind/pybind11/archive/v2.12.0.zip"
+              ]
+            }
+          }
+        }
+      }
+    },
+    "@@rules_android+//bzlmod_extensions:apksig.bzl%apksig_extension": {
+      "general": {
+        "bzlTransitiveDigest": "KrgiB8lWxqVdbipL9YIYOuGjS80xlZIM/EBvUg8SVd0=",
+        "usagesDigest": "zr/niBQ/s2fHozWAsg4vI70wAxcuFjG+QtM15qGkq9o=",
+        "recordedInputs": [
+          "REPO_MAPPING:rules_android+,bazel_tools bazel_tools"
+        ],
+        "generatedRepoSpecs": {
+          "apksig": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "url": "https://android.googlesource.com/platform/tools/apksig/+archive/24e3075e68ebe17c0b529bb24bfda819db5e2f3b.tar.gz",
+              "build_file": "@@rules_android+//bzlmod_extensions:apksig.BUILD"
+            }
+          }
+        }
+      }
+    },
+    "@@rules_android+//bzlmod_extensions:com_android_dex.bzl%com_android_dex_extension": {
+      "general": {
+        "bzlTransitiveDigest": "WYXjwqaZbEnV+ZWsKE3oDMpF5XVw8hxzet83NtyT8TM=",
+        "usagesDigest": "c1Y/KGGjUYCyd8zNIVTUh1bynVXRFz6xGKaSCBpQANM=",
+        "recordedInputs": [
+          "REPO_MAPPING:rules_android+,bazel_tools bazel_tools"
+        ],
+        "generatedRepoSpecs": {
+          "com_android_dex": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "url": "https://android.googlesource.com/platform/dalvik/+archive/5a81c499a569731e2395f7c8d13c0e0d4e17a2b6.tar.gz",
+              "build_file": "@@rules_android+//bzlmod_extensions:com_android_dex.BUILD"
+            }
+          }
+        }
+      }
+    },
     "@@rules_android+//rules/android_sdk_repository:rule.bzl%android_sdk_repository_extension": {
       "general": {
         "bzlTransitiveDigest": "+rMrzIrv7sImYmkbXJYv+gFpTJQ79X3MpwwMLI2A+oA=",
@@ -670,6 +743,106 @@
               "toolchain_target_settings": {}
             }
           }
+        }
+      }
+    },
+    "@@rules_rust+//crate_universe/private:internal_extensions.bzl%cu_nr": {
+      "general": {
+        "bzlTransitiveDigest": "3IZy+hjWeWCTUY0KTHxhtuibk64bqxHpPKOkyamkjFk=",
+        "usagesDigest": "qhmy4zrnFb6knNQRx2XBCVfHObom0vnflm+sibd7SA0=",
+        "recordedInputs": [
+          "REPO_MAPPING:bazel_features+,bazel_features_globals bazel_features++version_extension+bazel_features_globals",
+          "REPO_MAPPING:bazel_features+,bazel_features_version bazel_features++version_extension+bazel_features_version",
+          "REPO_MAPPING:rules_cc+,bazel_skylib bazel_skylib+",
+          "REPO_MAPPING:rules_cc+,bazel_tools bazel_tools",
+          "REPO_MAPPING:rules_cc+,cc_compatibility_proxy rules_cc++compatibility_proxy+cc_compatibility_proxy",
+          "REPO_MAPPING:rules_cc+,platforms platforms",
+          "REPO_MAPPING:rules_cc+,rules_cc rules_cc+",
+          "REPO_MAPPING:rules_cc++compatibility_proxy+cc_compatibility_proxy,rules_cc rules_cc+",
+          "REPO_MAPPING:rules_rust+,bazel_features bazel_features+",
+          "REPO_MAPPING:rules_rust+,bazel_skylib bazel_skylib+",
+          "REPO_MAPPING:rules_rust+,bazel_tools bazel_tools",
+          "REPO_MAPPING:rules_rust+,cargo_bazel_bootstrap rules_rust++cu_nr+cargo_bazel_bootstrap",
+          "REPO_MAPPING:rules_rust+,cui rules_rust++cu+cui",
+          "REPO_MAPPING:rules_rust+,rrc rules_rust++i2+rrc",
+          "REPO_MAPPING:rules_rust+,rules_cc rules_cc+",
+          "REPO_MAPPING:rules_rust+,rules_rust rules_rust+"
+        ],
+        "generatedRepoSpecs": {
+          "cargo_bazel_bootstrap": {
+            "repoRuleId": "@@rules_rust+//cargo/private:cargo_bootstrap.bzl%cargo_bootstrap_repository",
+            "attributes": {
+              "srcs": [
+                "@@rules_rust+//crate_universe:src/api.rs",
+                "@@rules_rust+//crate_universe:src/api/lockfile.rs",
+                "@@rules_rust+//crate_universe:src/cli.rs",
+                "@@rules_rust+//crate_universe:src/cli/generate.rs",
+                "@@rules_rust+//crate_universe:src/cli/query.rs",
+                "@@rules_rust+//crate_universe:src/cli/render.rs",
+                "@@rules_rust+//crate_universe:src/cli/splice.rs",
+                "@@rules_rust+//crate_universe:src/cli/vendor.rs",
+                "@@rules_rust+//crate_universe:src/config.rs",
+                "@@rules_rust+//crate_universe:src/context.rs",
+                "@@rules_rust+//crate_universe:src/context/crate_context.rs",
+                "@@rules_rust+//crate_universe:src/context/platforms.rs",
+                "@@rules_rust+//crate_universe:src/lib.rs",
+                "@@rules_rust+//crate_universe:src/lockfile.rs",
+                "@@rules_rust+//crate_universe:src/main.rs",
+                "@@rules_rust+//crate_universe:src/metadata.rs",
+                "@@rules_rust+//crate_universe:src/metadata/cargo_bin.rs",
+                "@@rules_rust+//crate_universe:src/metadata/cargo_tree_resolver.rs",
+                "@@rules_rust+//crate_universe:src/metadata/cargo_tree_rustc_wrapper.bat",
+                "@@rules_rust+//crate_universe:src/metadata/cargo_tree_rustc_wrapper.sh",
+                "@@rules_rust+//crate_universe:src/metadata/dependency.rs",
+                "@@rules_rust+//crate_universe:src/metadata/metadata_annotation.rs",
+                "@@rules_rust+//crate_universe:src/rendering.rs",
+                "@@rules_rust+//crate_universe:src/rendering/template_engine.rs",
+                "@@rules_rust+//crate_universe:src/rendering/templates/module_bzl.j2",
+                "@@rules_rust+//crate_universe:src/rendering/templates/partials/header.j2",
+                "@@rules_rust+//crate_universe:src/rendering/templates/partials/module/aliases_map.j2",
+                "@@rules_rust+//crate_universe:src/rendering/templates/partials/module/deps_map.j2",
+                "@@rules_rust+//crate_universe:src/rendering/templates/partials/module/repo_git.j2",
+                "@@rules_rust+//crate_universe:src/rendering/templates/partials/module/repo_http.j2",
+                "@@rules_rust+//crate_universe:src/rendering/templates/vendor_module.j2",
+                "@@rules_rust+//crate_universe:src/rendering/verbatim/alias_rules.bzl",
+                "@@rules_rust+//crate_universe:src/select.rs",
+                "@@rules_rust+//crate_universe:src/splicing.rs",
+                "@@rules_rust+//crate_universe:src/splicing/cargo_config.rs",
+                "@@rules_rust+//crate_universe:src/splicing/crate_index_lookup.rs",
+                "@@rules_rust+//crate_universe:src/splicing/splicer.rs",
+                "@@rules_rust+//crate_universe:src/test.rs",
+                "@@rules_rust+//crate_universe:src/utils.rs",
+                "@@rules_rust+//crate_universe:src/utils/starlark.rs",
+                "@@rules_rust+//crate_universe:src/utils/starlark/glob.rs",
+                "@@rules_rust+//crate_universe:src/utils/starlark/label.rs",
+                "@@rules_rust+//crate_universe:src/utils/starlark/select.rs",
+                "@@rules_rust+//crate_universe:src/utils/starlark/select_dict.rs",
+                "@@rules_rust+//crate_universe:src/utils/starlark/select_list.rs",
+                "@@rules_rust+//crate_universe:src/utils/starlark/select_scalar.rs",
+                "@@rules_rust+//crate_universe:src/utils/starlark/select_set.rs",
+                "@@rules_rust+//crate_universe:src/utils/starlark/serialize.rs",
+                "@@rules_rust+//crate_universe:src/utils/starlark/target_compatible_with.rs",
+                "@@rules_rust+//crate_universe:src/utils/symlink.rs",
+                "@@rules_rust+//crate_universe:src/utils/target_triple.rs"
+              ],
+              "binary": "cargo-bazel",
+              "cargo_lockfile": "@@rules_rust+//crate_universe:Cargo.lock",
+              "cargo_toml": "@@rules_rust+//crate_universe:Cargo.toml",
+              "version": "1.94.0",
+              "timeout": 900,
+              "rust_toolchain_cargo_template": "@rust_host_tools//:bin/{tool}",
+              "rust_toolchain_rustc_template": "@rust_host_tools//:bin/{tool}",
+              "compressed_windows_toolchain_names": false
+            }
+          }
+        },
+        "moduleExtensionMetadata": {
+          "explicitRootModuleDirectDeps": [
+            "cargo_bazel_bootstrap"
+          ],
+          "explicitRootModuleDirectDevDeps": [],
+          "useAllRepos": "NO",
+          "reproducible": false
         }
       }
     },

--- a/lib/rust/api_db/BUILD.bazel
+++ b/lib/rust/api_db/BUILD.bazel
@@ -16,11 +16,8 @@ rust_library(
     rustc_env = {"SQLX_OFFLINE": "true"},
     visibility = ["//visibility:public"],
     deps = [
+        "//lib/rust/db_pool",
         "@crates//:anyhow",
-        "@crates//:arc-swap",
-        "@crates//:aws-config",
-        "@crates//:aws-sdk-rds",
-        "@crates//:aws-types",
         "@crates//:email_address",
         "@crates//:futures",
         "@crates//:sqlx",
@@ -47,8 +44,6 @@ rust_test(
     rustc_env = {"SQLX_OFFLINE": "true"},
     tags = ["manual"],
     deps = [
-        "@crates//:aws-credential-types",
-        "@crates//:aws-smithy-async",
         "@crates//:tokio",
     ],
 )
@@ -106,6 +101,7 @@ sqlx_prepare(
         allow_empty = True,
     ),
     migrations = glob(["migrations/**"]),
+    path_deps = ["//lib/rust/db_pool"],
     visibility = ["//visibility:public"],
 )
 

--- a/lib/rust/api_db/src/admin.rs
+++ b/lib/rust/api_db/src/admin.rs
@@ -1,7 +1,8 @@
 use anyhow::Context;
+use db_pool::{DbPool, QueryAccess};
 use uuid::Uuid;
 
-use crate::db::DbPool;
+use crate::db::begin_txn;
 
 // ── Parameter newtypes ─────────────────────────────────────────────────────
 
@@ -206,7 +207,7 @@ pub async fn create_admin(
     subject: &Subject,
 ) -> anyhow::Result<UserId> {
     let user_id = UserId::new();
-    let mut tx = pool.begin_txn().await?;
+    let mut tx = begin_txn(pool).await?;
 
     sqlx::query!(
         "INSERT INTO users (id, display_name, email, auth_provider) VALUES ($1, $2, $3, $4)",
@@ -253,7 +254,7 @@ pub async fn create_user(
     subject: &Subject,
 ) -> anyhow::Result<UserId> {
     let user_id = UserId::new();
-    let mut tx = pool.begin_txn().await?;
+    let mut tx = begin_txn(pool).await?;
 
     sqlx::query!(
         "INSERT INTO users (id, display_name, email, auth_provider) VALUES ($1, $2, $3, $4)",

--- a/lib/rust/api_db/src/db.rs
+++ b/lib/rust/api_db/src/db.rs
@@ -1,200 +1,45 @@
-use std::sync::Arc;
-
 use anyhow::Context;
-use arc_swap::ArcSwap;
-use sqlx::postgres::PgPoolOptions;
-
-use crate::iam::IamParams;
+use db_pool::{DbPool, QueryAccess};
 
 /// Embedded migrations, compiled from `migrations/` at build time.
 pub(crate) static MIGRATIONS: sqlx::migrate::Migrator = sqlx::migrate!("./migrations");
 
-/// Opaque pool handle.
-/// sqlx types do not cross this boundary.
-///
-/// In static mode (dev/test), holds a fixed pool created from a `DATABASE_URL`.
-/// In IAM mode (production), holds a swappable pool that is periodically
-/// recreated with a fresh IAM auth token.
-#[derive(Clone)]
-pub struct DbPool {
-    inner: Arc<ArcSwap<sqlx::PgPool>>,
-    iam: Option<IamState>,
-}
-
-/// State needed to refresh the pool with a fresh IAM token.
-#[derive(Clone)]
-struct IamState {
-    params: IamParams,
-    sdk_config: aws_types::SdkConfig,
-}
-
-impl DbPool {
-    /// Create a connection pool from environment-style configuration.
-    ///
-    /// When `db_host` and `db_user` are both `Some`, uses IAM authentication
-    /// (production path).  Otherwise falls back to `database_url` which must
-    /// be `Some`.
-    #[tracing::instrument(skip(database_url), fields(db.system = "postgresql"))]
-    pub async fn from_config(
-        db_host: Option<&str>,
-        db_user: Option<&str>,
-        db_port: u16,
-        database_url: Option<&str>,
-    ) -> anyhow::Result<Self> {
-        match (db_host, db_user) {
-            (Some(host), Some(user)) => {
-                tracing::info!("using IAM database authentication");
-                let sdk_config =
-                    aws_config::load_defaults(aws_config::BehaviorVersion::latest()).await;
-                let params = IamParams::new(host.to_owned(), db_port, user.to_owned());
-                Self::connect_iam(params, sdk_config).await
-            }
-            _ => {
-                let url = database_url
-                    .context("DATABASE_URL is required when DB_HOST/DB_USER are not set")?;
-                Self::connect(url).await
-            }
-        }
-    }
-
-    /// Create a connection pool from a static database URL (dev/test path).
-    #[tracing::instrument(skip(database_url), fields(db.system = "postgresql"))]
-    pub async fn connect(database_url: &str) -> anyhow::Result<Self> {
-        let pool = PgPoolOptions::new()
-            .max_connections(5)
-            .connect(database_url)
-            .await
-            .context("connecting to PostgreSQL")?;
-        Ok(Self {
-            inner: Arc::new(ArcSwap::from_pointee(pool)),
-            iam: None,
-        })
-    }
-
-    /// Create a connection pool using IAM authentication (production path).
-    ///
-    /// Generates a short-lived auth token and connects. The pool can later
-    /// be refreshed by calling [`refresh`](Self::refresh).
-    #[tracing::instrument(skip(sdk_config), fields(db.system = "postgresql"))]
-    pub async fn connect_iam(
-        params: IamParams,
-        sdk_config: aws_types::SdkConfig,
-    ) -> anyhow::Result<Self> {
-        let pool = build_iam_pool(&params, &sdk_config).await?;
-        Ok(Self {
-            inner: Arc::new(ArcSwap::from_pointee(pool)),
-            iam: Some(IamState { params, sdk_config }),
-        })
-    }
-
-    /// Spawn a background task that periodically refreshes the IAM auth token.
-    ///
-    /// In static mode (no IAM params) returns `None`.
-    /// In IAM mode it regenerates the token every 6 hours, builds a new pool,
-    /// and atomically swaps it in.  Existing connections drain naturally.
-    ///
-    /// The caller owns the returned `JoinHandle`; dropping it does **not**
-    /// cancel the task, but [`JoinHandle::abort`] will.
-    pub fn start_background_refresh(&self) -> Option<tokio::task::JoinHandle<()>> {
-        let iam = self.iam.clone()?;
-        let inner = self.inner.clone();
-        Some(tokio::spawn(async move {
-            let mut interval = tokio::time::interval(std::time::Duration::from_secs(6 * 3600));
-            // Skip the immediate first tick — the pool was just created.
-            interval.tick().await;
-            loop {
-                interval.tick().await;
-                match build_iam_pool(&iam.params, &iam.sdk_config).await {
-                    Ok(new_pool) => {
-                        inner.store(Arc::new(new_pool));
-                        tracing::info!("database pool refreshed with new IAM token");
-                    }
-                    Err(e) => {
-                        tracing::warn!("database pool refresh failed: {e}");
-                    }
-                }
-            }
-        }))
-    }
-
-    /// Wrap an existing sqlx pool (used by `#[sqlx::test]` harness).
-    #[cfg(test)]
-    pub(crate) fn from_pool(pool: sqlx::PgPool) -> Self {
-        Self {
-            inner: Arc::new(ArcSwap::from_pointee(pool)),
-            iam: None,
-        }
-    }
-
-    /// Get the current connection pool.
-    ///
-    /// `sqlx::PgPool` is internally reference-counted, so cloning is cheap.
-    /// In IAM mode the underlying pool may be swapped at any time; callers
-    /// get a snapshot that remains valid until dropped.
-    pub(crate) fn pool(&self) -> sqlx::PgPool {
-        (**self.inner.load()).clone()
-    }
-
-    /// Begin a transaction at REPEATABLE READ isolation.
-    /// All transactions in this codebase run at REPEATABLE READ — journal
-    /// writes require it (the trigger from migration 009 rejects lower
-    /// isolation) and non-journal transactions use it for consistent
-    /// snapshot reads across multi-statement operations.  Call this instead
-    /// of `pool().begin()`; clippy's `disallowed_methods` lint rejects
-    /// direct `.begin()` calls elsewhere.
-    #[allow(clippy::disallowed_methods)] // The one legitimate caller of sqlx::Pool::begin.
-    pub(crate) async fn begin_txn(&self) -> anyhow::Result<sqlx::Transaction<'_, sqlx::Postgres>> {
-        let mut tx = self.pool().begin().await.context("beginning transaction")?;
-        sqlx::query!("SET TRANSACTION ISOLATION LEVEL REPEATABLE READ")
-            .execute(&mut *tx)
-            .await
-            .context("setting isolation level")?;
-        Ok(tx)
-    }
-
-    /// Run all pending migrations.
-    #[tracing::instrument(skip(self), fields(db.system = "postgresql"))]
-    pub async fn migrate(&self) -> anyhow::Result<()> {
-        MIGRATIONS
-            .run(&self.pool())
-            .await
-            .context("running database migrations")
-    }
-
-    /// Return this instance's stable identity (UUID v4).
-    ///
-    /// Generated once during migration 007 and stored in `instance_config`.
-    /// This value never changes for the lifetime of the database.
-    pub async fn instance_id(&self) -> anyhow::Result<String> {
-        let row =
-            sqlx::query_scalar!("SELECT value FROM instance_config WHERE key = 'instance_id'")
-                .fetch_one(&self.pool())
-                .await
-                .context("reading instance_id from instance_config")?;
-        Ok(row)
-    }
-}
-
-/// Build a new `PgPool` using a freshly generated IAM auth token.
-async fn build_iam_pool(
-    params: &IamParams,
-    sdk_config: &aws_types::SdkConfig,
-) -> anyhow::Result<sqlx::PgPool> {
-    let token = params.generate_token(sdk_config).await?;
-
-    let options = sqlx::postgres::PgConnectOptions::new()
-        .host(&params.hostname)
-        .port(params.port)
-        .username(&params.username)
-        .password(&token)
-        .database("causes")
-        .ssl_mode(sqlx::postgres::PgSslMode::Require);
-
-    PgPoolOptions::new()
-        .max_connections(5)
-        .connect_with(options)
+/// Run all pending migrations.
+#[tracing::instrument(skip(pool), fields(db.system = "postgresql"))]
+pub async fn migrate(pool: &DbPool) -> anyhow::Result<()> {
+    MIGRATIONS
+        .run(&pool.pool())
         .await
-        .context("connecting to PostgreSQL with IAM token")
+        .context("running database migrations")
+}
+
+/// Return this instance's stable identity (UUID v4).
+///
+/// Generated once during migration 007 and stored in `instance_config`.
+/// This value never changes for the lifetime of the database.
+pub async fn instance_id(pool: &DbPool) -> anyhow::Result<String> {
+    let row = sqlx::query_scalar!("SELECT value FROM instance_config WHERE key = 'instance_id'")
+        .fetch_one(&pool.pool())
+        .await
+        .context("reading instance_id from instance_config")?;
+    Ok(row)
+}
+
+/// Begin a transaction at REPEATABLE READ isolation. The journal trigger
+/// from migration 009 rejects lower isolation; non-journal transactions
+/// also use it for consistent snapshot reads. Call this instead of
+/// `pool.pool().begin()`; clippy's `disallowed_methods` lint rejects
+/// direct `.begin()` calls elsewhere.
+#[allow(clippy::disallowed_methods)] // The one legitimate caller of sqlx::Pool::begin.
+pub(crate) async fn begin_txn(
+    pool: &DbPool,
+) -> anyhow::Result<sqlx::Transaction<'_, sqlx::Postgres>> {
+    let mut tx = pool.pool().begin().await.context("beginning transaction")?;
+    sqlx::query!("SET TRANSACTION ISOLATION LEVEL REPEATABLE READ")
+        .execute(&mut *tx)
+        .await
+        .context("setting isolation level")?;
+    Ok(tx)
 }
 
 #[cfg(test)]
@@ -202,7 +47,7 @@ mod tests {
     use super::*;
 
     /// An empty migrator — gives us a bare database from `#[sqlx::test]` so we
-    /// can exercise `DbPool::connect` and `DbPool::migrate` ourselves.
+    /// can exercise `DbPool::connect` and `migrate` ourselves.
     static EMPTY: sqlx::migrate::Migrator = sqlx::migrate::Migrator {
         migrations: std::borrow::Cow::Borrowed(&[]),
         ignore_missing: false,
@@ -225,7 +70,7 @@ mod tests {
         let url = format!("postgresql://localhost:{port}/{db}");
 
         let pool = DbPool::connect(&url).await.expect("DbPool::connect failed");
-        pool.migrate().await.expect("migrate failed");
+        migrate(&pool).await.expect("migrate failed");
     }
 
     /// Runs migrations against a real PostgreSQL instance and asserts that all
@@ -255,19 +100,11 @@ mod tests {
         }
     }
 
-    /// Verify that `start_background_refresh` returns `None` when the pool
-    /// was created in static mode (no IAM params) — no task is spawned.
-    #[sqlx::test(migrator = "crate::db::tests::EMPTY")]
-    async fn background_refresh_is_noop_in_static_mode(pool: sqlx::PgPool) {
-        let db = DbPool::from_pool(pool);
-        assert!(db.start_background_refresh().is_none());
-    }
-
     /// Verify that instance_id is generated during migration and is a valid UUID.
     #[sqlx::test(migrator = "crate::db::MIGRATIONS")]
     async fn instance_id_is_generated(pool: sqlx::PgPool) {
         let db = DbPool::from_pool(pool);
-        let id = db.instance_id().await.expect("instance_id failed");
+        let id = instance_id(&db).await.expect("instance_id failed");
         id.parse::<uuid::Uuid>()
             .expect("instance_id is not a valid UUID");
     }
@@ -278,10 +115,10 @@ mod tests {
         let db = DbPool::from_pool(pool);
 
         MIGRATIONS.run(&db.pool()).await.expect("first run failed");
-        let original = db.instance_id().await.expect("instance_id failed");
+        let original = instance_id(&db).await.expect("instance_id failed");
 
         MIGRATIONS.run(&db.pool()).await.expect("second run failed");
-        let after = db.instance_id().await.expect("instance_id failed");
+        let after = instance_id(&db).await.expect("instance_id failed");
 
         assert_eq!(original, after);
     }
@@ -290,7 +127,7 @@ mod tests {
     #[sqlx::test(migrator = "crate::db::tests::EMPTY")]
     async fn begin_txn_sets_repeatable_read(pool: sqlx::PgPool) {
         let db = DbPool::from_pool(pool);
-        let mut tx = db.begin_txn().await.expect("begin_txn failed");
+        let mut tx = begin_txn(&db).await.expect("begin_txn failed");
         let level: String =
             sqlx::query_scalar!("SELECT current_setting('transaction_isolation') AS \"v!\"")
                 .fetch_one(&mut *tx)

--- a/lib/rust/api_db/src/lib.rs
+++ b/lib/rust/api_db/src/lib.rs
@@ -1,6 +1,5 @@
 mod admin;
 mod db;
-pub mod iam;
 pub mod journal;
 mod pending_login;
 mod project;
@@ -14,7 +13,7 @@ pub use admin::{
     AuthProvider, DisplayName, Email, ServiceAccountId, Subject, UserId, create_admin, create_user,
     user_count,
 };
-pub use db::DbPool;
+pub use db::{instance_id, migrate};
 pub use pending_login::{
     LoginNonce, PendingLoginRow, create_pending_login, delete_pending_login, gc_pending_logins,
     lookup_pending_login,

--- a/lib/rust/api_db/src/pending_login.rs
+++ b/lib/rust/api_db/src/pending_login.rs
@@ -1,7 +1,6 @@
 use anyhow::Context;
+use db_pool::{DbPool, QueryAccess};
 use uuid::Uuid;
-
-use crate::DbPool;
 
 // ── Newtypes ──────────────────────────────────────────────────────────────
 

--- a/lib/rust/api_db/src/project.rs
+++ b/lib/rust/api_db/src/project.rs
@@ -5,8 +5,10 @@ use futures::StreamExt;
 use sqlx::types::chrono;
 use uuid::Uuid;
 
-use crate::DbPool;
+use db_pool::{DbPool, QueryAccess};
+
 use crate::admin::UserId;
+use crate::db::begin_txn;
 use crate::role::{ProjectId, Role};
 use crate::session::SessionRow;
 
@@ -161,7 +163,7 @@ pub async fn create_project(
     creator_user_id: &UserId,
 ) -> Result<ProjectRow, ProjectError> {
     let id = Uuid::new_v4().to_string();
-    let mut tx = pool.begin_txn().await?;
+    let mut tx = begin_txn(pool).await?;
 
     let row = sqlx::query!(
         "INSERT INTO projects (id, name, description, visibility, embargoed_by_default) \
@@ -488,7 +490,7 @@ pub async fn rename_project(
 
 /// Delete a project and its role assignments. Returns false if not found.
 pub async fn delete_project(pool: &DbPool, project_id: &ProjectId) -> anyhow::Result<bool> {
-    let mut tx = pool.begin_txn().await?;
+    let mut tx = begin_txn(pool).await?;
 
     sqlx::query!(
         "DELETE FROM role_assignments WHERE project_id = $1",

--- a/lib/rust/api_db/src/role.rs
+++ b/lib/rust/api_db/src/role.rs
@@ -1,7 +1,7 @@
 use anyhow::Context;
+use db_pool::{DbPool, QueryAccess};
 use uuid::Uuid;
 
-use crate::DbPool;
 use crate::admin::UserId;
 
 // ── Role ─────────────────────────────────────────────────────────────────

--- a/lib/rust/api_db/src/session.rs
+++ b/lib/rust/api_db/src/session.rs
@@ -1,8 +1,8 @@
 use anyhow::Context;
+use db_pool::{DbPool, QueryAccess};
 use sqlx::types::chrono;
 use uuid::Uuid;
 
-use crate::DbPool;
 use crate::admin::{DisplayName, Email, UserId};
 
 // ── Newtypes ──────────────────────────────────────────────────────────────

--- a/lib/rust/db_aws/BUILD.bazel
+++ b/lib/rust/db_aws/BUILD.bazel
@@ -1,0 +1,29 @@
+load("//build:rust.bzl", "rust_library", "rust_test")
+load("//tools/lint:format_check.bzl", "format_srcs")
+
+rust_library(
+    name = "db_aws",
+    srcs = glob(["src/**/*.rs"]),
+    visibility = ["//visibility:public"],
+    deps = [
+        "//lib/rust/db_pool",
+        "@crates//:anyhow",
+        "@crates//:aws-config",
+        "@crates//:aws-sdk-rds",
+        "@crates//:aws-types",
+        "@crates//:sqlx",
+        "@crates//:tracing",
+    ],
+)
+
+rust_test(
+    name = "db_aws_test",
+    crate = ":db_aws",
+    deps = [
+        "@crates//:aws-credential-types",
+        "@crates//:aws-smithy-async",
+        "@crates//:tokio",
+    ],
+)
+
+format_srcs()

--- a/lib/rust/db_aws/Cargo.toml
+++ b/lib/rust/db_aws/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "api_db"
+name = "db_aws"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
@@ -7,10 +7,14 @@ license.workspace = true
 [dependencies]
 db_pool = { path = "../db_pool" }
 sqlx.workspace = true
-futures.workspace = true
 anyhow.workspace = true
-uuid.workspace = true
-url.workspace = true
-email_address.workspace = true
 tracing.workspace = true
+aws-config.workspace = true
+aws-sdk-rds.workspace = true
+aws-types.workspace = true
+futures.workspace = true
+
+[dev-dependencies]
+aws-credential-types.workspace = true
+aws-smithy-async.workspace = true
 tokio.workspace = true

--- a/lib/rust/db_aws/README.md
+++ b/lib/rust/db_aws/README.md
@@ -1,0 +1,12 @@
+## db\_aws
+
+AWS-aware connection setup for `api_db::DbPool`.
+
+Key decisions:
+
+- **Split from `api_db` to keep the AWS SDK off the SQL crate's compile graph.**
+  `sqlx prepare` runs `cargo check` on `api_db` to validate query macros against the database; pulling in `aws-sdk-rds` + `aws-config` + their transitive crates roughly doubled cold compile time.
+  Anything that talks to AWS lives here, behind the same `api_db::DbPool` opaque handle.
+- **Token rotation via a refresher closure on `DbPool`.**
+  `connect_iam` returns an `api_db::DbPool` whose `start_background_refresh` periodically regenerates the IAM auth token and atomically swaps in a new pool.
+  `api_db` defines the `PoolRefresher` type alias and the slot to hold one; this crate is the only producer.

--- a/lib/rust/db_aws/src/iam.rs
+++ b/lib/rust/db_aws/src/iam.rs
@@ -1,7 +1,7 @@
 use aws_sdk_rds::auth_token;
 
 /// Parameters needed to generate an IAM auth token for RDS.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct IamParams {
     pub hostname: String,
     pub port: u16,

--- a/lib/rust/db_aws/src/lib.rs
+++ b/lib/rust/db_aws/src/lib.rs
@@ -1,0 +1,95 @@
+//! AWS-aware connection setup for `db_pool::DbPool`. Kept out of `api_db`
+//! so `sqlx prepare`'s `cargo check` doesn't pull in the AWS SDK.
+
+mod iam;
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use anyhow::Context;
+use sqlx::postgres::{PgConnectOptions, PgPoolOptions, PgSslMode};
+
+pub use iam::IamParams;
+
+/// Build a `DbPool` using IAM authentication, loading default AWS SDK
+/// configuration (env vars, instance profile, etc). The returned pool has
+/// a refresher closure attached so [`db_pool::DbPool::start_background_refresh`]
+/// rotates the IAM token on the production schedule.
+#[tracing::instrument(fields(db.system = "postgresql"))]
+pub async fn connect_iam(host: &str, port: u16, user: &str) -> anyhow::Result<db_pool::DbPool> {
+    let sdk_config = aws_config::load_defaults(aws_config::BehaviorVersion::latest()).await;
+    let params = IamParams::new(host.to_owned(), port, user.to_owned());
+    connect_iam_with_sdk(params, sdk_config).await
+}
+
+/// Same as [`connect_iam`] but takes a pre-built [`aws_types::SdkConfig`].
+/// Use this when integrating with code that already has an SDK config
+/// (shared credentials provider, custom region, test overrides).
+#[tracing::instrument(skip(sdk_config), fields(db.system = "postgresql"))]
+pub async fn connect_iam_with_sdk(
+    params: IamParams,
+    sdk_config: aws_types::SdkConfig,
+) -> anyhow::Result<db_pool::DbPool> {
+    let pool = build_iam_pool(&params, &sdk_config).await?;
+
+    // SdkConfig and IamParams are both Clone+Send+Sync, so the closure is too.
+    let p = params.clone();
+    let s = sdk_config.clone();
+    let refresher: db_pool::PoolRefresher = Arc::new(move || {
+        let p = p.clone();
+        let s = s.clone();
+        Box::pin(async move { build_iam_pool(&p, &s).await })
+    });
+
+    Ok(db_pool::DbPool::from_pool_with_refresher(
+        pool,
+        Duration::from_secs(6 * 3600),
+        refresher,
+    ))
+}
+
+/// Construct the `PgConnectOptions` for an IAM-authenticated connection.
+/// Pulled out of [`build_iam_pool`] so the field-construction logic is
+/// directly testable; the actual `PgPoolOptions::connect_with` call is a
+/// thin sqlx pass-through that needs a live database to exercise.
+fn iam_connect_options(params: &IamParams, token: &str) -> PgConnectOptions {
+    PgConnectOptions::new()
+        .host(&params.hostname)
+        .port(params.port)
+        .username(&params.username)
+        .password(token)
+        .database("causes")
+        .ssl_mode(PgSslMode::Require)
+}
+
+async fn build_iam_pool(
+    params: &IamParams,
+    sdk_config: &aws_types::SdkConfig,
+) -> anyhow::Result<sqlx::PgPool> {
+    let token = params.generate_token(sdk_config).await?;
+    PgPoolOptions::new()
+        .max_connections(5)
+        .connect_with(iam_connect_options(params, &token))
+        .await
+        .context("connecting to PostgreSQL with IAM token")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn iam_connect_options_carries_params_through() {
+        let params = IamParams::new(
+            "mydb.us-east-1.rds.amazonaws.com".into(),
+            5432,
+            "svc".into(),
+        );
+        let opts = iam_connect_options(&params, "iam-token-123");
+        assert_eq!(opts.get_host(), "mydb.us-east-1.rds.amazonaws.com");
+        assert_eq!(opts.get_port(), 5432);
+        assert_eq!(opts.get_username(), "svc");
+        assert_eq!(opts.get_database(), Some("causes"));
+        assert!(matches!(opts.get_ssl_mode(), PgSslMode::Require));
+    }
+}

--- a/lib/rust/db_connect/BUILD.bazel
+++ b/lib/rust/db_connect/BUILD.bazel
@@ -1,0 +1,21 @@
+load("//build:rust.bzl", "rust_library", "rust_test")
+load("//tools/lint:format_check.bzl", "format_srcs")
+
+rust_library(
+    name = "db_connect",
+    srcs = glob(["src/**/*.rs"]),
+    visibility = ["//visibility:public"],
+    deps = [
+        "//lib/rust/db_aws",
+        "//lib/rust/db_pool",
+        "@crates//:anyhow",
+        "@crates//:tracing",
+    ],
+)
+
+rust_test(
+    name = "db_connect_test",
+    crate = ":db_connect",
+)
+
+format_srcs()

--- a/lib/rust/db_connect/Cargo.toml
+++ b/lib/rust/db_connect/Cargo.toml
@@ -1,16 +1,11 @@
 [package]
-name = "api_db"
+name = "db_connect"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
 
 [dependencies]
+db_aws = { path = "../db_aws" }
 db_pool = { path = "../db_pool" }
-sqlx.workspace = true
-futures.workspace = true
 anyhow.workspace = true
-uuid.workspace = true
-url.workspace = true
-email_address.workspace = true
 tracing.workspace = true
-tokio.workspace = true

--- a/lib/rust/db_connect/README.md
+++ b/lib/rust/db_connect/README.md
@@ -1,0 +1,12 @@
+## db\_connect
+
+Cloud-agnostic dispatch to the right `api_db::DbPool` constructor.
+
+Key decisions:
+
+- **Routing lives above the provider crates, not inside them.**
+  Each `db_<cloud>` crate (currently just `db_aws`) exposes only its own connect functions.
+  This crate decides which to call based on the four config knobs (`db_host`, `db_user`, `db_port`, `database_url`).
+  Adding `db_azure` is a new variant on the internal `ConnectMode` enum + a new match arm — no changes to existing provider crates.
+- **Binaries depend only on `db_connect`, not on individual provider crates.**
+  Keeps `services/causes_api`, `services/causes_cli`, etc. from having to know about cloud-specific deps.

--- a/lib/rust/db_connect/src/lib.rs
+++ b/lib/rust/db_connect/src/lib.rs
@@ -1,0 +1,129 @@
+//! Cloud-agnostic dispatch to the right `db_pool::DbPool` constructor.
+//!
+//! Binaries pass the same four `Option`s they parse from env/CLI; this
+//! crate decides whether to use a cloud-IAM auth flow or a static
+//! `DATABASE_URL`. Adding a new cloud (e.g. Azure managed identity) is a
+//! new variant on [`ConnectMode`] + a new arm in [`connect`].
+
+use anyhow::Context;
+
+/// Re-export so binaries can `use db_connect::DbPool` without depending on
+/// `db_pool` directly. The sealed `QueryAccess` trait is not re-exported,
+/// which means business-logic crates cannot reach the underlying sqlx pool.
+pub use db_pool::DbPool;
+
+/// The auth flow chosen from configuration. Pulled out of [`connect`] so
+/// the routing decision is unit-testable without a cloud provider chain.
+#[derive(Debug, PartialEq, Eq)]
+enum ConnectMode {
+    AwsIam {
+        host: String,
+        user: String,
+        port: u16,
+    },
+    Static {
+        url: String,
+    },
+}
+
+fn connect_mode(
+    db_host: Option<&str>,
+    db_user: Option<&str>,
+    db_port: u16,
+    database_url: Option<&str>,
+) -> anyhow::Result<ConnectMode> {
+    match (db_host, db_user) {
+        (Some(host), Some(user)) => Ok(ConnectMode::AwsIam {
+            host: host.to_owned(),
+            user: user.to_owned(),
+            port: db_port,
+        }),
+        _ => {
+            let url = database_url
+                .context("DATABASE_URL is required when DB_HOST/DB_USER are not set")?;
+            Ok(ConnectMode::Static {
+                url: url.to_owned(),
+            })
+        }
+    }
+}
+
+/// Build a [`db_pool::DbPool`] from environment-style configuration.
+#[tracing::instrument(skip(database_url), fields(db.system = "postgresql"))]
+pub async fn connect(
+    db_host: Option<&str>,
+    db_user: Option<&str>,
+    db_port: u16,
+    database_url: Option<&str>,
+) -> anyhow::Result<db_pool::DbPool> {
+    match connect_mode(db_host, db_user, db_port, database_url)? {
+        ConnectMode::AwsIam { host, user, port } => {
+            tracing::info!("using AWS IAM database authentication");
+            db_aws::connect_iam(&host, port, &user).await
+        }
+        ConnectMode::Static { url } => db_pool::DbPool::connect(&url).await,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn picks_aws_iam_when_host_and_user_are_set() {
+        let mode = connect_mode(Some("db.example"), Some("svc"), 5432, None).unwrap();
+        assert_eq!(
+            mode,
+            ConnectMode::AwsIam {
+                host: "db.example".into(),
+                user: "svc".into(),
+                port: 5432,
+            }
+        );
+    }
+
+    #[test]
+    fn picks_aws_iam_even_when_database_url_also_set() {
+        // IAM takes precedence — production sets all three.
+        let mode =
+            connect_mode(Some("db.example"), Some("svc"), 5432, Some("postgres://x")).unwrap();
+        assert!(matches!(mode, ConnectMode::AwsIam { .. }));
+    }
+
+    #[test]
+    fn falls_back_to_static_url_when_host_missing() {
+        let mode = connect_mode(None, Some("svc"), 5432, Some("postgres://localhost/db")).unwrap();
+        assert_eq!(
+            mode,
+            ConnectMode::Static {
+                url: "postgres://localhost/db".into()
+            }
+        );
+    }
+
+    #[test]
+    fn falls_back_to_static_url_when_user_missing() {
+        let mode = connect_mode(
+            Some("db.example"),
+            None,
+            5432,
+            Some("postgres://localhost/db"),
+        )
+        .unwrap();
+        assert_eq!(
+            mode,
+            ConnectMode::Static {
+                url: "postgres://localhost/db".into()
+            }
+        );
+    }
+
+    #[test]
+    fn errors_when_no_credentials_and_no_url() {
+        let err = connect_mode(None, None, 5432, None).unwrap_err();
+        assert!(
+            err.to_string().contains("DATABASE_URL is required"),
+            "unexpected error: {err}"
+        );
+    }
+}

--- a/lib/rust/db_pool/BUILD.bazel
+++ b/lib/rust/db_pool/BUILD.bazel
@@ -1,0 +1,24 @@
+load("//build:rust.bzl", "rust_library")
+load("//tools/lint:format_check.bzl", "format_srcs")
+
+# Sources + manifest, exposed for sqlx_prepare staging in path-dep crates.
+filegroup(
+    name = "all_srcs",
+    srcs = ["Cargo.toml"] + glob(["src/**/*.rs"]),
+    visibility = ["//visibility:public"],
+)
+
+rust_library(
+    name = "db_pool",
+    srcs = glob(["src/**/*.rs"]),
+    visibility = ["//visibility:public"],
+    deps = [
+        "@crates//:anyhow",
+        "@crates//:arc-swap",
+        "@crates//:sqlx",
+        "@crates//:tokio",
+        "@crates//:tracing",
+    ],
+)
+
+format_srcs()

--- a/lib/rust/db_pool/Cargo.toml
+++ b/lib/rust/db_pool/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "db_pool"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+
+[dependencies]
+sqlx.workspace = true
+anyhow.workspace = true
+arc-swap.workspace = true
+tokio.workspace = true
+tracing.workspace = true
+futures.workspace = true

--- a/lib/rust/db_pool/README.md
+++ b/lib/rust/db_pool/README.md
@@ -1,0 +1,14 @@
+## db\_pool
+
+Opaque database pool handle for the Causes API stack.
+
+Key decisions:
+
+- **AI guardrail: sqlx access requires both this crate AND the sealed `QueryAccess` trait in scope.**
+  Crates that legitimately write SQL (api_db today; future analytics_db etc.) depend on this crate and `use db_pool::QueryAccess` to reach `pool()` / the underlying `sqlx::PgPool`.
+  Business-logic crates (services/causes_api etc.) depend on `db_connect` for the type only and never see the trait, so they cannot construct queries even if an AI tries to write them.
+- **The pool type is opaque to consumers.**
+  `DbPool` wraps `sqlx::PgPool` in an `ArcSwap` so the connection can be atomically swapped (production IAM token rotation does this).
+  Consumers see `Clone`, `start_background_refresh`, and the type's existence — nothing about sqlx.
+- **No transaction policy here.**
+  Isolation level is a schema concern (e.g. api_db's journal trigger requires REPEATABLE READ); each query crate owns its own `begin_txn` helper.

--- a/lib/rust/db_pool/src/lib.rs
+++ b/lib/rust/db_pool/src/lib.rs
@@ -1,0 +1,135 @@
+//! Opaque pool handle. See README.md for the AI-guardrail rationale.
+
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::Arc;
+use std::time::Duration;
+
+use anyhow::Context;
+use arc_swap::ArcSwap;
+use sqlx::postgres::PgPoolOptions;
+
+mod sealed {
+    pub trait Sealed {}
+}
+
+/// Closure that rebuilds the underlying pool. Supplied by provider crates
+/// (e.g. `db_aws`) for IAM auth token rotation; called by
+/// [`DbPool::start_background_refresh`].
+pub type PoolRefresher = Arc<
+    dyn Fn() -> Pin<Box<dyn Future<Output = anyhow::Result<sqlx::PgPool>> + Send>> + Send + Sync,
+>;
+
+/// Opaque pool handle.
+///
+/// Static mode: a fixed pool, [`Self::start_background_refresh`] returns `None`.
+///
+/// Refreshing mode: `ArcSwap`-wrapped pool with a refresher closure attached;
+/// the background task periodically calls the refresher and atomically swaps
+/// in the new pool.
+#[derive(Clone)]
+pub struct DbPool {
+    inner: Arc<ArcSwap<sqlx::PgPool>>,
+    refresher: Option<PoolRefresher>,
+    refresh_interval: Duration,
+}
+
+impl sealed::Sealed for DbPool {}
+
+impl DbPool {
+    /// Create a connection pool from a static database URL.
+    #[tracing::instrument(skip(database_url), fields(db.system = "postgresql"))]
+    pub async fn connect(database_url: &str) -> anyhow::Result<Self> {
+        let pool = PgPoolOptions::new()
+            .max_connections(5)
+            .connect(database_url)
+            .await
+            .context("connecting to PostgreSQL")?;
+        Ok(Self::from_pool(pool))
+    }
+
+    /// Wrap an existing pool with a refresher closure. Provider crates use
+    /// this to attach token-rotation logic (e.g. `db_aws::connect_iam`).
+    pub fn from_pool_with_refresher(
+        pool: sqlx::PgPool,
+        refresh_interval: Duration,
+        refresher: PoolRefresher,
+    ) -> Self {
+        Self {
+            inner: Arc::new(ArcSwap::from_pointee(pool)),
+            refresher: Some(refresher),
+            refresh_interval,
+        }
+    }
+
+    /// Wrap an existing pool with no refresher. Use [`Self::connect`] for
+    /// the static URL path; this is mainly for `#[sqlx::test]` fixtures
+    /// and other scenarios where the pool already exists.
+    pub fn from_pool(pool: sqlx::PgPool) -> Self {
+        Self {
+            inner: Arc::new(ArcSwap::from_pointee(pool)),
+            refresher: None,
+            refresh_interval: Duration::from_secs(6 * 3600),
+        }
+    }
+
+    /// Spawn a background task that periodically rebuilds the pool via
+    /// the refresher closure. Returns `None` for pools created via
+    /// [`Self::connect`] / [`Self::from_pool`] (no refresher attached).
+    pub fn start_background_refresh(&self) -> Option<tokio::task::JoinHandle<()>> {
+        let refresher = self.refresher.clone()?;
+        let inner = self.inner.clone();
+        let interval_dur = self.refresh_interval;
+        Some(tokio::spawn(async move {
+            let mut interval = tokio::time::interval(interval_dur);
+            // Skip the immediate first tick — the pool was just created.
+            interval.tick().await;
+            loop {
+                interval.tick().await;
+                match refresher().await {
+                    Ok(new_pool) => {
+                        inner.store(Arc::new(new_pool));
+                        tracing::info!("database pool refreshed");
+                    }
+                    Err(e) => {
+                        tracing::warn!("database pool refresh failed: {e}");
+                    }
+                }
+            }
+        }))
+    }
+}
+
+/// Sealed trait that exposes the underlying `sqlx::PgPool`. Only crates
+/// that legitimately write SQL should `use db_pool::QueryAccess` to bring
+/// these methods into scope. Business-logic crates that depend on
+/// `db_connect` (which re-exports `DbPool` but not this trait) cannot
+/// reach the pool.
+pub trait QueryAccess: sealed::Sealed {
+    /// Return a `sqlx::PgPool` snapshot. Cheap (internally Arc-counted).
+    /// In refreshing mode the underlying pool may be swapped at any time;
+    /// callers get a snapshot that remains valid until dropped.
+    fn pool(&self) -> sqlx::PgPool;
+}
+
+impl QueryAccess for DbPool {
+    fn pool(&self) -> sqlx::PgPool {
+        (**self.inner.load()).clone()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn from_pool_has_no_refresher() {
+        // Construct a sentinel pool via PgPoolOptions::new() — never connected,
+        // but proves the type construction path. start_background_refresh
+        // should be None when no refresher is attached.
+        let pool = sqlx::postgres::PgPool::connect_lazy("postgresql://invalid")
+            .expect("lazy connect builds options");
+        let db = DbPool::from_pool(pool);
+        assert!(db.start_background_refresh().is_none());
+    }
+}

--- a/services/causes_api/BUILD.bazel
+++ b/services/causes_api/BUILD.bazel
@@ -10,6 +10,7 @@ rust_binary(
     deps = [
         "//lib/rust/api_db",
         "//lib/rust/causes_proto",
+        "//lib/rust/db_connect",
         "@crates//:anyhow",
         "@crates//:axum",
         "@crates//:clap",

--- a/services/causes_api/Cargo.toml
+++ b/services/causes_api/Cargo.toml
@@ -7,6 +7,7 @@ license.workspace = true
 [dependencies]
 api_db = { path = "../../lib/rust/api_db" }
 causes_proto = { path = "../../lib/rust/causes_proto" }
+db_connect = { path = "../../lib/rust/db_connect" }
 futures.workspace = true
 prost-types.workspace = true
 tokio.workspace = true

--- a/services/causes_api/src/main.rs
+++ b/services/causes_api/src/main.rs
@@ -26,7 +26,7 @@ async fn main() -> anyhow::Result<()> {
     let cfg = config::Config::parse();
 
     info!("connecting to database");
-    let pool = api_db::DbPool::from_config(
+    let pool = db_connect::connect(
         cfg.db_host.as_deref(),
         cfg.db_user.as_deref(),
         cfg.db_port,

--- a/services/causes_api/src/store.rs
+++ b/services/causes_api/src/store.rs
@@ -1,5 +1,5 @@
 /// Abstraction over database operations needed by this service.
-/// Implemented by [`api_db::DbPool`] in production; in tests, use
+/// Implemented by [`db_connect::DbPool`] in production; in tests, use
 /// [`mockall::automock`]-generated `MockStore`.
 #[allow(dead_code)]
 #[cfg_attr(test, mockall::automock)]
@@ -103,9 +103,9 @@ pub trait Store: Send + Sync + 'static {
 }
 
 #[tonic::async_trait]
-impl Store for api_db::DbPool {
+impl Store for db_connect::DbPool {
     async fn migrate(&self) -> anyhow::Result<()> {
-        api_db::DbPool::migrate(self).await
+        api_db::migrate(self).await
     }
 
     async fn user_count(&self) -> anyhow::Result<i64> {

--- a/tools/coverage.sh
+++ b/tools/coverage.sh
@@ -39,6 +39,10 @@ fi
 # Files excluded from the per-file coverage threshold.
 # "Hard to test" is NOT a valid reason — only exclude files where the code
 # is entirely constrained by the type system with no alternative implementations.
+#
+# Adding entries to this list requires explicit human approval. Automation
+# (or AI assistants) must not append entries unprompted; ask first, then
+# extract testable logic before reaching for the skip list.
 SKIP_FILES=(
 	"lib/rust/causes_proto/src/generated/causes.v1.rs" # machine-generated
 	"services/causes_api/src/store.rs"                 # trait delegation to api_db

--- a/tools/sqlx_prepare.bzl
+++ b/tools/sqlx_prepare.bzl
@@ -15,7 +15,7 @@ _TOOL_DATA = [
     "@rust_host_tools//:sysroot_path.txt",
 ]
 
-def sqlx_prepare(name, migrations, srcs, visibility = None):
+def sqlx_prepare(name, migrations, srcs, path_deps = None, visibility = None):
     """Generates sqlx offline query-metadata targets for a Rust crate.
 
     Run from the calling package's directory so that sqlx writes .sqlx/ there.
@@ -32,23 +32,38 @@ def sqlx_prepare(name, migrations, srcs, visibility = None):
       migrations: migration file labels — glob(["migrations/**"])
       srcs:       source + .sqlx labels for the check test —
                   glob(["src/**/*.rs"]) + glob([".sqlx/**"])
+      path_deps:  bazel labels of in-workspace crates this crate depends on
+                  via path. Each must expose an `:all_srcs` filegroup. The
+                  impl script stages them next to the prepared crate so
+                  cargo can resolve the path-deps inside the isolated
+                  workspace.
       visibility: optional visibility for the sh_binary update target
     """
-    pkg = native.package_name()  # e.g. "lib/rust/api_db"
+    pkg = native.package_name()
+    path_deps = path_deps or []
+
+    extra_data = []
+    extra_args = []
+    for dep in path_deps:
+        # "//lib/rust/db_pool" → bazel pkg "lib/rust/db_pool", crate name "db_pool"
+        bazel_pkg = dep.lstrip("/").partition(":")[0]
+        crate_name = bazel_pkg.rpartition("/")[2]
+        extra_data.append(dep + ":all_srcs")
+        extra_args.append("--path-dep=" + crate_name + "=" + bazel_pkg)
 
     sh_binary(
         name = name,
         srcs = [_IMPL],
-        args = [pkg],
-        data = _TOOL_DATA + migrations,
+        args = [pkg] + extra_args,
+        data = _TOOL_DATA + migrations + extra_data,
         visibility = visibility,
     )
 
     sh_test(
         name = name + "_test",
         srcs = [_IMPL],
-        args = ["--check", pkg],
-        data = _TOOL_DATA + migrations + srcs + [
+        args = ["--check", pkg] + extra_args,
+        data = _TOOL_DATA + migrations + srcs + extra_data + [
             "//:Cargo.toml",
             "//:Cargo.lock",
             ":Cargo.toml",

--- a/tools/sqlx_prepare_impl.sh
+++ b/tools/sqlx_prepare_impl.sh
@@ -13,6 +13,22 @@ if [[ "${1:-}" == "--check" ]]; then
 	shift
 fi
 BAZEL_PACKAGE="${1:?bazel package path required}"
+shift
+
+# Parse --path-dep=NAME=BAZEL_PKG occurrences; each names an in-workspace
+# crate whose source must be staged so cargo can resolve `path = "..."`
+# deps from this crate's Cargo.toml.
+PATH_DEPS=()
+while [[ $# -gt 0 ]]; do
+	case "$1" in
+	--path-dep=*) PATH_DEPS+=("${1#--path-dep=}") ;;
+	*)
+		echo >&2 "unknown arg: $1"
+		exit 2
+		;;
+	esac
+	shift
+done
 
 # Standard Bazel 3-way runfiles init.
 if [[ -f "${RUNFILES_DIR:-/dev/null}/bazel_tools/tools/bash/runfiles/runfiles.bash" ]]; then
@@ -131,6 +147,17 @@ PYEOF
 	sync_dir "${PACKAGE_DIR}/src" "$ISOLATED/pkg/src"
 	sync_dir "${PACKAGE_DIR}/migrations" "$ISOLATED/pkg/migrations"
 	sync_dir "${PACKAGE_DIR}/.sqlx" "$ISOLATED/pkg/.sqlx"
+
+	# Stage path-dep crates as siblings of pkg/ so cargo can resolve
+	# `path = "../<name>"` from pkg/Cargo.toml.
+	local pd name bazel_pkg src_root
+	for pd in "${PATH_DEPS[@]}"; do
+		name="${pd%%=*}"
+		bazel_pkg="${pd#*=}"
+		src_root="${WORKSPACE_ROOT}/${bazel_pkg}"
+		sync_file "${src_root}/Cargo.toml" "$ISOLATED/${name}/Cargo.toml"
+		sync_dir "${src_root}/src" "$ISOLATED/${name}/src"
+	done
 
 	chmod -R u+w "$ISOLATED"
 }


### PR DESCRIPTION
Stacked on #270.

Two concerns rolled together because they touch the same files:

1. **db_aws + db_connect**: removes the AWS SDK from `api_db`'s dep graph. Cold `bazel test //lib/rust/api_db:sqlx_prepare_test` drops from ~40s to ~20s.
2. **db_pool with sealed QueryAccess**: extracts the pool handle out of `api_db` so `db_connect` doesn't depend on the query layer. Sealed trait gates `pool()` so business-logic crates can hold a `DbPool` but cannot reach the underlying `sqlx::PgPool`.

## Crate layout

- **db_pool** — `DbPool`, `PoolRefresher`, `connect`, `from_pool_with_refresher`, `start_background_refresh`, sealed `QueryAccess` trait with `pool()`.
- **db_aws** — `IamParams`, `connect_iam`. Depends on `db_pool` only.
- **db_connect** — routes between AWS-IAM and static `DATABASE_URL`. Depends on `db_pool` + `db_aws`. Re-exports `DbPool`.
- **api_db** — query layer. Depends on `db_pool` (uses `QueryAccess` internally). `begin_txn`, `migrate`, `instance_id` are free functions taking `&DbPool`. `REPEATABLE READ` policy stays here — it's tied to migration 009's trigger, not generic pool concern.
- **services/causes_api** — depends on `api_db` + `db_connect`. No `sqlx`, no `db_pool`. Cannot import `QueryAccess` → cannot reach `sqlx::PgPool`.

## sqlx_prepare changes

api_db's path dep on `db_pool` broke the isolated single-member workspace (`cargo metadata` couldn't resolve the path). Macro gains `path_deps = [...]`; impl script stages each named crate as a sibling of `pkg/`.

## Test plan

- [x] `bazel build //...`
- [x] `tools/coverage.sh -- //... -//tla/...` (40 files ≥ 25%)
- [x] Cold `sqlx_prepare_test` ~17s
- [x] `db_connect::connect` routing matrix tested in `db_connect`'s tests
- [x] `db_pool::from_pool` no-refresher path tested
- [x] All existing api_db DB tests still pass via the test wrapper