### PR TITLE
lint: format and lint Python with ruff

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -4,6 +4,7 @@ load("@rules_python//python:pip.bzl", "compile_pip_requirements")
 load(
     "//tools/lint:format_check.bzl",
     "buildifier_check",
+    "ruff_check",
     "shfmt_check",
     "taplo_check",
     "yamlfmt_check",
@@ -20,6 +21,7 @@ exports_files([
     ".yamllint",
     "Cargo.toml",
     "Cargo.lock",
+    "pyproject.toml",
     "rustfmt.toml",
 ])
 
@@ -47,6 +49,7 @@ filegroup(
 # Check formatting without edits:    bazel run //:format.check
 format_multirun(
     name = "format",
+    python = "//tools/lint:ruff_format",
     rust = "@rust_host_tools//:rustfmt",
     shell = "@aspect_rules_lint//format:shfmt",
     starlark = "@buildifier_prebuilt//:buildifier",
@@ -139,6 +142,15 @@ filegroup(
     visibility = ["//visibility:public"],
 )
 
+filegroup(
+    name = "python_format_srcs",
+    srcs = glob(
+        ["*.py"],
+        allow_empty = True,
+    ),
+    visibility = ["//visibility:public"],
+)
+
 # Every subpackage calls format_srcs() to emit its own per-language filegroups.
 # Adding a new package means appending it here — the only non-Rust commit
 # discipline this design costs.
@@ -191,6 +203,12 @@ filegroup(
            [p + "yaml_format_srcs" for p in _FORMAT_PACKAGES],
 )
 
+filegroup(
+    name = "_all_python_format_srcs",
+    srcs = [":python_format_srcs"] +
+           [p + "python_format_srcs" for p in _FORMAT_PACKAGES],
+)
+
 buildifier_check(
     name = "format_starlark_check",
     srcs = [":_all_starlark_format_srcs"],
@@ -209,4 +227,9 @@ shfmt_check(
 yamlfmt_check(
     name = "format_yaml_check",
     srcs = [":_all_yaml_format_srcs"],
+)
+
+ruff_check(
+    name = "format_python_check",
+    srcs = [":_all_python_format_srcs"],
 )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,18 @@
+# Ruff is the only Python tool we use; it formats and lints.
+# Run via Bazel: `bazel run //:format` (in-place) or `bazel test //...`.
+[tool.ruff]
+line-length = 100
+target-version = "py312"
+
+[tool.ruff.lint]
+# E/F (pycodestyle errors + pyflakes) are on by default.
+# I enables import sorting (the isort-equivalent rule); we want it because
+# it caught at least one unsorted import block during the rollout.
+extend-select = ["I"]
+
+[tool.ruff.lint.isort]
+# Sort imports purely alphabetically within each section, ignoring the
+# `import X` vs `from X import Y` distinction.  Without this, `from pathlib`
+# floats to the bottom of a stdlib block even when alphabetically earlier
+# than later `import` lines — which is what readers actually notice.
+force-sort-within-sections = true

--- a/tools/lint/BUILD.bazel
+++ b/tools/lint/BUILD.bazel
@@ -29,6 +29,8 @@ exports_files([
     "run_pymarkdown.sh",
     "run_rustfmt_check.sh",
     "run_buildifier_check.sh",
+    "run_ruff_check.sh",
+    "run_ruff_format.sh",
     "run_taplo_check.sh",
     "run_shfmt_check.sh",
     "run_yamlfmt_check.sh",
@@ -40,6 +42,21 @@ sh_binary(
     data = [
         ":pymarkdown",
         "//:.pymarkdown.json",
+        "@bazel_tools//tools/bash/runfiles",
+        "@rules_shell//shell/runfiles",
+    ],
+)
+
+# ── ruff (Python format + lint) ───────────────────────────────────────────────
+# Wrapper used by format_multirun's `python = ...` slot.  Runs `ruff format`
+# AND `ruff check --fix` so a single `bazel run //:format` covers whitespace
+# formatting and import sorting in one pass.  See run_ruff_format.sh.
+sh_binary(
+    name = "ruff_format",
+    srcs = ["run_ruff_format.sh"],
+    data = [
+        "//:pyproject.toml",
+        "@aspect_rules_lint//format:ruff",
         "@bazel_tools//tools/bash/runfiles",
         "@rules_shell//shell/runfiles",
     ],

--- a/tools/lint/format_check.bzl
+++ b/tools/lint/format_check.bzl
@@ -73,6 +73,11 @@ def format_srcs():
         ),
         visibility = ["//visibility:public"],
     )
+    native.filegroup(
+        name = "python_format_srcs",
+        srcs = native.glob(["*.py"], allow_empty = True),
+        visibility = ["//visibility:public"],
+    )
 
 def _formatter_check(name, driver, formatter_data, srcs, tags = [], **kwargs):
     sh_test(
@@ -122,6 +127,19 @@ def yamlfmt_check(name, srcs, **kwargs):
         formatter_data = [
             "@aspect_rules_lint//format:yamlfmt",
             "//:.yamlfmt",
+        ],
+        srcs = srcs,
+        **kwargs
+    )
+
+def ruff_check(name, srcs, **kwargs):
+    """sh_test that runs `ruff format --check` and `ruff check` over the .py files in srcs."""
+    _formatter_check(
+        name = name,
+        driver = "//tools/lint:run_ruff_check.sh",
+        formatter_data = [
+            "@aspect_rules_lint//format:ruff",
+            "//:pyproject.toml",
         ],
         srcs = srcs,
         **kwargs

--- a/tools/lint/run_ruff_check.sh
+++ b/tools/lint/run_ruff_check.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# Bazel sh_test driver: runs `ruff format --check` and `ruff check` over the
+# Python files passed as space-separated args.
+set -euo pipefail
+
+# shellcheck source=/dev/null
+if [[ -f "${RUNFILES_DIR:-/dev/null}/rules_shell/shell/runfiles/runfiles.bash" ]]; then
+	source "${RUNFILES_DIR}/rules_shell/shell/runfiles/runfiles.bash"
+elif [[ -f "${RUNFILES_DIR:-/dev/null}/bazel_tools/tools/bash/runfiles/runfiles.bash" ]]; then
+	source "${RUNFILES_DIR}/bazel_tools/tools/bash/runfiles/runfiles.bash"
+else
+	echo >&2 "ERROR: cannot find runfiles.bash"
+	exit 1
+fi
+
+RUFF="$(rlocation rules_multitool++multitool+multitool/tools/ruff/ruff)"
+CONF="$(rlocation _main/pyproject.toml)"
+
+files=()
+for arg in "$@"; do
+	for f in $arg; do
+		files+=("$(rlocation "_main/${f#./}")")
+	done
+done
+
+[[ ${#files[@]} -gt 0 ]] || exit 0
+"$RUFF" format --config "$CONF" --check "${files[@]}"
+exec "$RUFF" check --config "$CONF" "${files[@]}"

--- a/tools/lint/run_ruff_format.sh
+++ b/tools/lint/run_ruff_format.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# format_multirun driver: invoked by aspect_rules_lint as
+#   $0 format [--check] [--force-exclude] [files...]
+#
+# `ruff format` doesn't sort imports — that's the I rule on `ruff check`.
+# To make a single `bazel run //:format` cover both whitespace AND import
+# sorting, we run `ruff format` exactly as aspect_rules_lint asked, then
+# do a second pass with `ruff check --select I` (with --fix in fix mode,
+# without in --check mode).
+set -euo pipefail
+
+# shellcheck source=/dev/null
+if [[ -f "${RUNFILES_DIR:-/dev/null}/rules_shell/shell/runfiles/runfiles.bash" ]]; then
+	source "${RUNFILES_DIR}/rules_shell/shell/runfiles/runfiles.bash"
+elif [[ -f "${RUNFILES_DIR:-/dev/null}/bazel_tools/tools/bash/runfiles/runfiles.bash" ]]; then
+	source "${RUNFILES_DIR}/bazel_tools/tools/bash/runfiles/runfiles.bash"
+else
+	echo >&2 "ERROR: cannot find runfiles.bash"
+	exit 1
+fi
+
+RUFF="$(rlocation rules_multitool++multitool+multitool/tools/ruff/ruff)"
+
+[[ $# -gt 0 ]] || exit 0
+
+# Pass 1: ruff format (verbatim args).
+"$RUFF" "$@"
+
+# Pass 2: ruff check --select I to enforce import sort.
+# Drop the leading `format` subcommand, then translate flags:
+#   --check  →  no --fix (check mode, exit non-zero on issues)
+#   absent   →  --fix    (apply fixes in place)
+# Other format flags (e.g. --force-exclude) are forwarded.
+shift
+fix_flag="--fix"
+filtered=()
+for arg in "$@"; do
+	if [[ "$arg" == "--check" ]]; then
+		fix_flag=""
+	else
+		filtered+=("$arg")
+	fi
+done
+
+exec "$RUFF" check --select I ${fix_flag:+$fix_flag} "${filtered[@]}"

--- a/tools/show_coverage.py
+++ b/tools/show_coverage.py
@@ -55,9 +55,7 @@ def parse_lcov(path):
                     if len(parts) >= 2:
                         try:
                             lineno, hits = int(parts[0]), int(parts[1])
-                            records[current][lineno] = (
-                                records[current].get(lineno, 0) + hits
-                            )
+                            records[current][lineno] = records[current].get(lineno, 0) + hits
                         except ValueError:
                             pass
                 elif line == "end_of_record":
@@ -97,9 +95,7 @@ def file_html(rel: str, line_hits: dict[int, int]) -> str:
                     f'<td class="src">{html.escape(src_line.rstrip())}</td></tr>'
                 )
     except OSError:
-        rows = [
-            f'<tr><td colspan="3">Source not found: {html.escape(src_path)}</td></tr>'
-        ]
+        rows = [f'<tr><td colspan="3">Source not found: {html.escape(src_path)}</td></tr>']
     covered = sum(1 for h in line_hits.values() if h > 0)
     total = len(line_hits)
     pct = coverage_pct(covered, total)
@@ -110,7 +106,7 @@ def file_html(rel: str, line_hits: dict[int, int]) -> str:
         f'<p><a href="index.html">← index</a></p>'
         f"<h2>{html.escape(rel)}</h2>"
         f'<p class="{cls}">{covered}/{total} lines ({pct:.1f}%)</p>'
-        f'<table><tr><th>#</th><th>hits</th><th>source</th></tr>'
+        f"<table><tr><th>#</th><th>hits</th><th>source</th></tr>"
         f"{''.join(rows)}</table></body></html>"
     )
 
@@ -135,7 +131,7 @@ def index_html(stats: dict[str, tuple[int, int]]) -> str:
         f"<style>{CSS}</style></head><body>"
         "<h1>Coverage report</h1>"
         f'<p class="{cls}">Overall: {total_c}/{total_l} lines ({overall:.1f}%)</p>'
-        '<table><tr><th>File</th><th>Lines</th><th>Covered</th><th>%</th></tr>'
+        "<table><tr><th>File</th><th>Lines</th><th>Covered</th><th>%</th></tr>"
         f"{''.join(rows)}</table></body></html>"
     )
 
@@ -143,9 +139,7 @@ def index_html(stats: dict[str, tuple[int, int]]) -> str:
 def build_site(out: pathlib.Path) -> None:
     records = parse_lcov(REPORT)
     if not records:
-        sys.exit(
-            f"No coverage data at:\n  {REPORT}\n\nRun: bazel coverage //... first."
-        )
+        sys.exit(f"No coverage data at:\n  {REPORT}\n\nRun: bazel coverage //... first.")
 
     stats: dict[str, tuple[int, int]] = {}
     for sf, line_hits in records.items():


### PR DESCRIPTION
## Summary

Adds Python format + lint via `aspect_rules_lint`'s ruff. The repo had two first-party Python files (`tools/show_coverage.py`, used by \`bazel run //tools:show_coverage\`, plus a forthcoming check) that went through unchecked — no formatter, no linter, no import sort.

Stacked on top of #273 (Cargo.toml drift fix). Second of three PRs; the third adds a guardrail that needs to pass python lint when introduced.

## Changes

- `pyproject.toml` (new) — ruff config: line-length 100, py312 target, `extend-select = ["I"]` so import sort runs alongside default E/F.
- `BUILD.bazel` — adds `python = "@aspect_rules_lint//format:ruff"` to `format_multirun`, plus `_all_python_format_srcs` aggregator and a `format_python_check` sh_test.
- `tools/lint/format_check.bzl` — new `ruff_check()` macro and `python_format_srcs` filegroup in `format_srcs()`.
- `tools/lint/run_ruff_check.sh` (new) — sh_test driver runs `ruff format --check` then `ruff check`.
- `tools/show_coverage.py` — auto-formatted (single-quote → double-quote string normalisation, one wrap).

## Test plan

- [x] `bazel run //:format` is a no-op on the formatted tree
- [x] `bazel test //:format_python_check` passes
- [x] Verified the check fails when an existing `.py` file has bad formatting
- [x] `tools/coverage.sh //...` passes