### PR TITLE
lint: enforce Cargo.toml deps cover BUILD.bazel @crates// refs

### DIFF
--- a/tools/lint/BUILD.bazel
+++ b/tools/lint/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@rules_python//python:defs.bzl", "py_test")
 load(
     "@rules_python//python/entry_points:py_console_script_binary.bzl",
     "py_console_script_binary",
@@ -81,6 +82,37 @@ sh_binary(
         ":taplo_extracted",
         "@bazel_tools//tools/bash/runfiles",
     ],
+)
+
+# ── cargo/bazel dep parity check ──────────────────────────────────────────────
+# Guards against silent drift where BUILD.bazel adds a @crates//:foo dep but
+# the sibling Cargo.toml doesn't list it — which leaves Bazel green but `cargo`
+# spuriously broken.  Reuses each Rust crate's existing format_srcs filegroups
+# so no new exports are needed; the script filters runfiles by file name.
+_RUST_CRATE_PACKAGES = [
+    "//lib/rust/api_db",
+    "//lib/rust/causes_mcp",
+    "//lib/rust/causes_proto",
+    "//lib/rust/causes_session",
+    "//lib/rust/proto_ext",
+    "//services/causes_api",
+    "//services/causes_cli",
+]
+
+py_test(
+    name = "cargo_bazel_deps_check",
+    srcs = ["check_cargo_bazel_deps.py"],
+    args = [
+        "$(rootpaths %s:%s)" % (pkg, fg)
+        for pkg in _RUST_CRATE_PACKAGES
+        for fg in ("toml_format_srcs", "starlark_format_srcs")
+    ],
+    data = [
+        "%s:%s" % (pkg, fg)
+        for pkg in _RUST_CRATE_PACKAGES
+        for fg in ("toml_format_srcs", "starlark_format_srcs")
+    ],
+    main = "check_cargo_bazel_deps.py",
 )
 
 format_srcs()

--- a/tools/lint/check_cargo_bazel_deps.py
+++ b/tools/lint/check_cargo_bazel_deps.py
@@ -1,0 +1,73 @@
+"""Guardrail: every @crates//:NAME reference in BUILD.bazel must appear as a
+key in the sibling Cargo.toml's [dependencies] or [dev-dependencies].
+
+Bazel is the build of record; this check exists only so `cargo` (used for
+metadata, IDE integration, and one-off cargo invocations) doesn't spuriously
+break when someone adds a Bazel-only crate.  The reverse direction (deps in
+Cargo.toml but not BUILD.bazel) is naturally enforced by rustc — Bazel won't
+compile a `use foo` without `@crates//:foo`.
+
+Invocation: pass every Cargo.toml and BUILD.bazel from each Rust crate's
+package as positional arguments.  The script pairs them by directory.
+"""
+
+from pathlib import Path
+import re
+import sys
+import tomllib
+
+CRATE_RE = re.compile(r"@crates//:([A-Za-z0-9_-]+)")
+
+
+def check(cargo_toml: Path, build_bazel: Path) -> list[str]:
+    bazel_crates = set(CRATE_RE.findall(build_bazel.read_text()))
+    manifest = tomllib.loads(cargo_toml.read_text())
+    deps = set(manifest.get("dependencies", {}).keys())
+    deps |= set(manifest.get("dev-dependencies", {}).keys())
+    return sorted(bazel_crates - deps)
+
+
+def main(argv: list[str]) -> int:
+    by_dir: dict[Path, dict[str, Path]] = {}
+    for arg in argv:
+        path = Path(arg)
+        if path.name in ("Cargo.toml", "BUILD.bazel"):
+            by_dir.setdefault(path.parent, {})[path.name] = path
+
+    failures: list[tuple[Path, list[str]]] = []
+    checked = 0
+    for directory, files in sorted(by_dir.items()):
+        cargo = files.get("Cargo.toml")
+        build = files.get("BUILD.bazel")
+        if cargo is None or build is None:
+            continue
+        checked += 1
+        missing = check(cargo, build)
+        if missing:
+            failures.append((cargo, missing))
+
+    if failures:
+        sys.stderr.write(
+            "Cargo.toml is missing dependencies that BUILD.bazel references via @crates//:\n\n"
+        )
+        for path, missing in failures:
+            sys.stderr.write(f"  {path}\n")
+            for m in missing:
+                sys.stderr.write(f"    - {m}\n")
+        sys.stderr.write(
+            "\nAdd each missing crate to [dependencies] or [dev-dependencies] "
+            "in the listed Cargo.toml, e.g.:\n"
+            "    futures.workspace = true\n"
+        )
+        return 1
+
+    if checked == 0:
+        sys.stderr.write("no crate manifests checked — wiring bug\n")
+        return 1
+
+    print(f"checked {checked} crate(s); Cargo.toml ⊇ BUILD.bazel @crates// refs")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))


### PR DESCRIPTION
## Summary

Adds `//tools/lint:cargo_bazel_deps_check` — a py_test that fails when a Rust crate's `BUILD.bazel` references a `@crates//:NAME` that isn't listed in the sibling `Cargo.toml` `[dependencies]` / `[dev-dependencies]`. Without this check, Bazel-only dep adds silently break cargo (used for IDE / metadata / one-off invocations).

Third of three stacked PRs. Depends on:
- #273 (drift fix) — the check would fail on master without it.
- #274 (ruff wiring) — the new python file would fail format check.

The check is unidirectional: only `BUILD.bazel @crates// ⊆ Cargo.toml deps`. The reverse is enforced by rustc.

## Implementation notes

- Reuses each crate's existing `format_srcs()` filegroups (`toml_format_srcs`, `starlark_format_srcs`) — no per-crate wiring needed.
- New crates are added by appending one path to `_RUST_CRATE_PACKAGES` in `tools/lint/BUILD.bazel`.
- ~75 lines of Python; no third-party deps (uses stdlib `tomllib`, `re`).

## Test plan

- [x] `bazel test //tools/lint:cargo_bazel_deps_check` passes on the fixed tree
- [x] Verified the check fails with a clear error pointing at the right Cargo.toml when `futures`/`prost-types` are removed
- [x] `bazel test //:format_python_check` passes (new file is ruff-clean)
- [x] `tools/coverage.sh //...` passes