### PR TITLE
ci: regen lockfile on Cargo.lock changes too

### DIFF
--- a/.github/workflows/renovate-lockfile.yml
+++ b/.github/workflows/renovate-lockfile.yml
@@ -1,11 +1,20 @@
 name: renovate-lockfile
 # Renovate (hosted) cannot run Bazel, so MODULE.bazel.lock would be stale
-# after a bazel_dep update.  This workflow detects that case and pushes the
-# regenerated lockfile back to the Renovate branch before CI runs.
+# after any change that feeds a Bazel module extension.  This workflow
+# detects that case and pushes the regenerated lockfile back to the
+# Renovate branch before CI runs.
+#
+# The push uses AUTO_QUEUE_TOKEN (not the default GITHUB_TOKEN) because
+# pushes performed with GITHUB_TOKEN do not create new workflow runs,
+# which would leave the PR's `build` check stuck on the pre-fix commit.
 on:
   push:
     branches: ["renovate/**"]
-    paths: ["MODULE.bazel"]
+    paths:
+      - "MODULE.bazel"
+      - "Cargo.lock"
+      - "Cargo.toml"
+      - "**/Cargo.toml"
 permissions:
   contents: write
 jobs:
@@ -15,6 +24,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
         with:
           ref: ${{ github.ref_name }}
+          token: ${{ secrets.AUTO_QUEUE_TOKEN }}
       - name: Install Bazelisk
         uses: bazel-contrib/setup-bazel@c5acdfb288317d0b5c0bbd7a396a3dc868bb0f86  # 0.19.0
         with:


### PR DESCRIPTION
## Summary

- Expand `renovate-lockfile.yml` `paths` filter to fire on `Cargo.lock` / `Cargo.toml` (workspace + members), not just `MODULE.bazel`.
- Switch the checkout to `secrets.AUTO_QUEUE_TOKEN` so the follow-up `git push` retriggers `build.yml` on the PR.

## Why

After `--lockfile_mode=error` was enforced (#257), the `rules_rs` crate extension started failing the build whenever Renovate updates `Cargo.lock` without a matching `MODULE.bazel.lock` refresh. Renovate's Rust-crate PRs touch only `Cargo.lock`, so the lockfile workflow (path-restricted to `MODULE.bazel`) never fired. Result: every Rust Renovate PR ends up `BLOCKED` with a failed `build` check, and `platformAutomerge` correctly refuses to merge them.

Confirmed stuck PRs: #266 rustls, #278 reqwest, #281 rmcp, #284 tokio (all `Cargo.lock`-only, all failing on the "extension `@@rules_rs+//rs:extensions.bzl%crate` has changed its facts" error). Python (`requirements_lock.txt`) PRs continue to merge fine because the pip extension doesn't bind lockfile content as a fact.

## Token note

The token swap is mandatory, not cosmetic. GitHub's documented rule: a push performed using `GITHUB_TOKEN` does not create new workflow runs. Without a different token, the lockfile-fix commit would land on the PR branch but `build.yml` would not rerun, leaving the failed check stuck on the pre-fix commit and auto-merge blocked forever.

**Pre-flight check before relying on this:** confirm `AUTO_QUEUE_TOKEN` is scoped with `contents: write` on this repo. It currently only needs `pull_requests: write` for `gh pr merge --auto` in `auto-queue.yml`. If it doesn't have `contents: write`, the push step will fail and a fresh scoped token (or a widened `AUTO_QUEUE_TOKEN`) is needed.

## Test plan

- [ ] Verify `AUTO_QUEUE_TOKEN` has `contents: write` on `causes-tracker/causes-tracker`.
- [ ] After merge, rebase the four stuck Renovate PRs onto master and confirm each gets an auto-commit regenerating `MODULE.bazel.lock`, a green `build` rerun, and an auto-merge through the merge queue.
- [ ] Watch the next fresh Renovate Rust PR end-to-end: PR created → lockfile workflow fires → fix commit pushed → `build.yml` reruns → green → merge queue → merged, with no human touch.