### PR TITLE
renovate: bump minimumReleaseAge 3->5 days

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,7 +3,7 @@
   "extends": [
     "config:recommended"
   ],
-  "minimumReleaseAge": "3 days",
+  "minimumReleaseAge": "5 days",
   "automerge": true,
   "platformAutomerge": true,
   "automergeStrategy": "merge",


### PR DESCRIPTION
## Summary

- Raise `minimumReleaseAge` in `renovate.json` from `3 days` to `5 days`.

## Why

Widens the stability window: a release must now be at least 5 days old before Renovate opens a PR for it. The default `internalChecksFilter` is `strict`, so this acts as a creation filter — dependencies younger than 5 days simply don't show up as PRs, rather than appearing as pending.

The `vulnerabilityAlerts.minimumReleaseAge: "0 days"` override is preserved, so security advisories continue to flow without waiting.

## Test plan

- [ ] After merge, confirm a dependency on the Renovate dashboard whose newest release is between 3 and 5 days old stays as "Pending — Release Age" and no PR is opened until the 5-day mark.