### PR TITLE
renovate: ignore github-actions[bot] commits

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -7,6 +7,9 @@
   "automerge": true,
   "platformAutomerge": true,
   "automergeStrategy": "merge",
+  "gitIgnoredAuthors": [
+    "41898282+github-actions[bot]@users.noreply.github.com"
+  ],
   "osvVulnerabilityAlerts": true,
   "vulnerabilityAlerts": {
     "minimumReleaseAge": "0 days"


### PR DESCRIPTION
## Summary

- Add `gitIgnoredAuthors` to `renovate.json` listing the `41898282+github-actions[bot]@users.noreply.github.com` identity used by `renovate-lockfile.yml`.

## Why

The `renovate-lockfile` workflow commits regenerated `MODULE.bazel.lock` as `github-actions[bot]`. Without this option, Renovate treats those commits as an external edit and parks the PR in the dashboard's "PR Edited (Blocked)" section, refusing to rebase or update it again — which is how PR #80 (gazelle) and four sibling PRs (aspect_rules_js, aspect_rules_lint, llvm, rules_multirun) ended up abandoned with stale targets.

`gitIgnoredAuthors` tells Renovate to disregard commits from the listed emails when deciding whether a branch has been manually edited, which is exactly the desired behaviour for an automation-driven lockfile fix.

## Companion to #285

#285 expands the lockfile workflow to fire on `Cargo.lock` changes. Without this PR, that expanded workflow would now strand every Rust-crate Renovate PR the same way the existing five Bazel-dep PRs got stranded. They need to land together for the auto-merge story to actually work.

## Test plan

- [ ] After merge, tick the checkboxes for the five entries in dashboard issue #7 under "PR Edited (Blocked)" (gazelle/#80, aspect_rules_js, aspect_rules_lint, llvm, rules_multirun). Renovate should recreate each cleanly.
- [ ] On the next Renovate Rust PR, verify the lockfile workflow's follow-up commit does *not* land the PR in "PR Edited (Blocked)" — Renovate should leave auto-merge enabled and let the PR merge.