### PR TITLE
infra: merge commit subject = PR title

### DIFF
--- a/infra/github/main.tf
+++ b/infra/github/main.tf
@@ -29,10 +29,12 @@ resource "github_repository" "causes" {
 
   delete_branch_on_merge = true
 
-  allow_merge_commit = true
-  allow_squash_merge = false
-  allow_rebase_merge = false
-  allow_auto_merge   = true
+  allow_merge_commit   = true
+  allow_squash_merge   = false
+  allow_rebase_merge   = false
+  allow_auto_merge     = true
+  merge_commit_title   = "PR_TITLE"
+  merge_commit_message = "BLANK"
 
   vulnerability_alerts = true
 


### PR DESCRIPTION
## Summary

- `merge_commit_title = "PR_TITLE"` (was `MERGE_MESSAGE`)
- `merge_commit_message = "BLANK"` (was `PR_TITLE`)

## Why

Today the merge queue produces commits like:

> Merge pull request #278 from causes-tracker/renovate/reqwest-0.x-lockfile
>
> chore(deps): update rust crate reqwest to v0.13.3

After this change:

> chore(deps): update rust crate reqwest to v0.13.3

The merge queue routes through `merge_method = "MERGE"` in the master ruleset, so it inherits these repo-level settings — no ruleset change needed.

## Apply

This PR only updates `main.tf`. To roll out the actual change, after merging:

```sh
export GITHUB_TOKEN="github_pat_..."   # fine-grained PAT, Administration:write
bazel run //infra:tofu -- infra/github plan
bazel run //infra:tofu -- infra/github apply
```

Expected plan diff: two attribute changes on `github_repository.causes` and nothing else. If anything else shows up, the live repo state has drifted from main.tf and should be reconciled before applying.

## Test plan

- [ ] `tofu plan` shows only the two intended attribute changes.
- [ ] `tofu apply` succeeds.
- [ ] `gh api repos/causes-tracker/causes-tracker -q '{merge_commit_title, merge_commit_message}'` returns `{"merge_commit_title":"PR_TITLE","merge_commit_message":"BLANK"}`.
- [ ] First merge after apply (Renovate or human PR) produces a one-line merge commit with the PR title as the subject and no body.