### PR TITLE
infra: track terraform lockfiles + auto-update on Renovate

### DIFF
--- a/.github/workflows/renovate-lockfile.yml
+++ b/.github/workflows/renovate-lockfile.yml
@@ -15,6 +15,8 @@ on:
       - "Cargo.lock"
       - "Cargo.toml"
       - "**/Cargo.toml"
+      - "infra/**/*.tf"
+      - "infra/**/.terraform.lock.hcl"
 permissions:
   contents: write
 jobs:
@@ -33,11 +35,17 @@ jobs:
           repository-cache: true
       - name: Regenerate MODULE.bazel.lock
         run: bazel mod deps --lockfile_mode=update
-      - name: Commit updated lockfile
+      - name: Regenerate infra/terraform/.terraform.lock.hcl
+        run: bazel run //infra:tofu -- infra/terraform providers lock -platform=linux_amd64
+      - name: Regenerate infra/github/.terraform.lock.hcl
+        run: bazel run //infra:tofu -- infra/github providers lock -platform=linux_amd64
+      - name: Commit updated lockfiles
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add MODULE.bazel.lock
+          git add MODULE.bazel.lock \
+            infra/terraform/.terraform.lock.hcl \
+            infra/github/.terraform.lock.hcl
           git diff --cached --quiet && exit 0
-          git commit -m "chore: update MODULE.bazel.lock"
+          git commit -m "chore: update generated lockfiles"
           git push

--- a/.gitignore
+++ b/.gitignore
@@ -1,19 +1,19 @@
 # OpenTofu / Terraform — AWS module
+# .terraform.lock.hcl IS tracked (supply-chain protection — pinned provider hashes).
 infra/terraform/.terraform/
 infra/terraform/*.tfstate
 infra/terraform/*.tfstate.backup
 infra/terraform/*.tfplan
 infra/terraform/*.lock.info
-infra/terraform/.terraform.lock.hcl
 infra/terraform/terraform.tfvars
 
 # OpenTofu / Terraform — GitHub module
+# .terraform.lock.hcl IS tracked (supply-chain protection — pinned provider hashes).
 infra/github/.terraform/
 infra/github/*.tfstate
 infra/github/*.tfstate.backup
 infra/github/*.tfplan
 infra/github/*.lock.info
-infra/github/.terraform.lock.hcl
 infra/github/terraform.tfvars
 
 # Local dev environment overrides (DATABASE_URL, etc.) — never commit

--- a/infra/github/.terraform.lock.hcl
+++ b/infra/github/.terraform.lock.hcl
@@ -1,0 +1,25 @@
+# This file is maintained automatically by "tofu init".
+# Manual edits may be lost in future updates.
+
+provider "registry.opentofu.org/integrations/github" {
+  version     = "6.11.1"
+  constraints = "~> 6.0"
+  hashes = [
+    "h1:Hqvebe3Zc19DxRCHHLIByBvxCm+WJqGyAyYCbJDuHGE=",
+    "zh:0a5262b033a30d8a77ebf844dc3afd7e726d5f53ac1c9d4072cf9157820d1f73",
+    "zh:437236181326f92d1a7c56985b2ac3223efd73f75c528323b90f4b7d1b781090",
+    "zh:49a12c14d1d3a143a124ba81f15fbf18714af90752c993698c76e84fa85da004",
+    "zh:61eaf17b559a26ca14deb597375a6678d054d739e8b81c586ef1d0391c307916",
+    "zh:7f3f1e2c36f4787ca9a5aeb5317b8c3f6cc652368d1f8f00fb80f404109d4db1",
+    "zh:85a232f2e96e5adafa2676f38a96b8cc074e96f715caf6ee1d169431174897d2",
+    "zh:979d005af2a9003d887413195948c899e9f5aba4a79cce1eed40f3ba50301af1",
+    "zh:b8c8cd3254504d2184d2b2233ad41b5fdfda91a36fc864926cbc5c7eee1bfea3",
+    "zh:d00959e62930fb75d2b97c1d66ab0143120541d5a1b3f26d3551f24cb0361f83",
+    "zh:d0b544eed171c7563387fe87f0af3d238bb3804798159b4d0453c97927237daf",
+    "zh:ecfa19b1219aa55b1ece98d8cff5b1494dc0387329c8ae0d8f762ec3871fb75d",
+    "zh:f2c99825f38c92ac599ad36b9d093ea0c0d790fd0c02e861789e14735a605f86",
+    "zh:f33b5abe14ad5fb9978da5dbd3bc6989f69766150d4b30ed283a2c281871eda3",
+    "zh:f6c2fe9dd958c554170dc0c35ca41b60fcc6253304cde0b9941c5c872b18ac54",
+    "zh:fbd1fee2c9df3aa19cf8851ce134dea6e45ea01cb85695c1726670c285797e25",
+  ]
+}

--- a/infra/terraform/.terraform.lock.hcl
+++ b/infra/terraform/.terraform.lock.hcl
@@ -1,0 +1,42 @@
+# This file is maintained automatically by "tofu init".
+# Manual edits may be lost in future updates.
+
+provider "registry.opentofu.org/hashicorp/aws" {
+  version     = "6.38.0"
+  constraints = "~> 6.0"
+  hashes = [
+    "h1:2Zib+i+MPTE053uE5CKZQ+j1ZJ24Om4FU1N7E9OvjYo=",
+    "zh:0444417955631da2250db30994a21810a5b3388a7c7e9f33243e8b4c4aad45de",
+    "zh:2db1e7f7530d583927668b33c26749f8c4e832963d18cead76de03b2e886517d",
+    "zh:306afc96243ccf07caa2a2a20863ed098d010b645c547f894ee45d729d6278b2",
+    "zh:36cbab61792be4b457ffbdee994b5bdaa81f356c1e5bca5c9591543e376e79b0",
+    "zh:44ec51c2bf9997a8847ef5a3eef1727a2ca73ec0673c21196e860a41ef0c1a06",
+    "zh:49ee8f6a637c2a684082e69d7f2e49ef2ddab63f178124a63f4e6069818f440a",
+    "zh:4a40b799a132c947f5cb32ed85fc516e5615ff649022fe056cdb70d0467a76fb",
+    "zh:4d82a141013391371ef2da8fecd52a95740d07978a1c0908f1964c1411ecc508",
+    "zh:7282205b4f152b08f944a86ae07f36a1b304153c7b923b5e84a7e7d1a75782a0",
+    "zh:78507af5ce09f68d4cb02faefb365dba08dc8cd2746c060d3467ba90c6857115",
+    "zh:8c15164448e87499e3b02b2b03e1e02811de1cc904c667aeb05aa0a0691320fd",
+    "zh:90e955c80ed582759e4fdc22ca4aefaee5175fd6bf8cf0d0e763d3f9fe38aa35",
+    "zh:9ddbc6be09d02ca1b882ba5244b024f76a8042e8bfd8ce3c81d0c25c7220d105",
+    "zh:9f8fc6f328db326bbf04365a1359b76fe1cf39cd890454053bb86db217b37f8f",
+    "zh:eef6dfef9feaac9e9a42af2b9767e23d86d3bae4947b604ba6821b9496d83ed9",
+  ]
+}
+
+provider "registry.opentofu.org/hashicorp/random" {
+  version     = "3.8.1"
+  constraints = "~> 3.0"
+  hashes = [
+    "h1:EHn3jsqOKhWjbg0X+psk0Ww96yz3N7ASqEKKuFvDFwo=",
+    "zh:25c458c7c676f15705e872202dad7dcd0982e4a48e7ea1800afa5fc64e77f4c8",
+    "zh:2edeaf6f1b20435b2f81855ad98a2e70956d473be9e52a5fdf57ccd0098ba476",
+    "zh:44becb9d5f75d55e36dfed0c5beabaf4c92e0a2bc61a3814d698271c646d48e7",
+    "zh:7699032612c3b16cc69928add8973de47b10ce81b1141f30644a0e8a895b5cd3",
+    "zh:86d07aa98d17703de9fbf402c89590dc1e01dbe5671dd6bc5e487eb8fe87eee0",
+    "zh:8c411c77b8390a49a8a1bc9f176529e6b32369dd33a723606c8533e5ca4d68c1",
+    "zh:a5ecc8255a612652a56b28149994985e2c4dc046e5d34d416d47fa7767f5c28f",
+    "zh:aea3fe1a5669b932eda9c5c72e5f327db8da707fe514aaca0d0ef60cb24892f9",
+    "zh:f56e26e6977f755d7ae56fa6320af96ecf4bb09580d47cb481efbf27f1c5afff",
+  ]
+}


### PR DESCRIPTION
## Summary

Two commits, intended to land together:

1. **`infra: track .terraform.lock.hcl in both root modules`** — un-ignore the two lockfiles and commit them. Generated with `bazel run //infra:tofu -- <module> providers lock -platform=linux_amd64`.
2. **`ci: regen terraform locks on provider updates`** — extend `.github/workflows/renovate-lockfile.yml` to also regenerate the Terraform lockfiles whenever a Renovate PR touches `infra/**/*.tf` or the lockfile itself.

## Why — supply chain

Tracked `.terraform.lock.hcl` files pin registry-signed `zh:` checksums per provider+platform. `tofu init` rejects any provider download whose hash doesn't match. Without this, a malicious upload that reuses or typosquats a provider source would silently flow through `init` on every workstation and CI run.

## Why — Renovate plumbing

The existing renovate-lockfile workflow already handles MODULE.bazel.lock the same way (path-trigger on the source files, regenerate the lockfile via Bazel, commit, push with `AUTO_QUEUE_TOKEN` so `build.yml` retriggers). Mirroring that for Terraform means provider bumps proposed by Renovate land with consistent lockfiles and proceed through auto-merge with no human touch — same as the Cargo path.

`gitIgnoredAuthors` in #287 already covers the `github-actions[bot]` commit this workflow produces, so terraform-update PRs will not get quarantined as "PR Edited" once #287 lands.

## Scope of lockfiles

linux_amd64 only — devcontainer and CI both run x86_64 Linux. If a non-Linux contributor ever runs tofu directly outside the devcontainer, `init` will fail loudly until additional `-platform=…` runs are added (deliberate trade-off, not a regression).

## Verification

Already done locally:

- `bazel run //infra:tofu -- infra/terraform providers lock -platform=linux_amd64` → `Success! OpenTofu has validated the lock file and found no need for changes.`
- `bazel run //infra:tofu -- infra/github   providers lock -platform=linux_amd64` → same.
- `tools/coverage.sh //...` green.
- Format check green.

Post-merge:

- [ ] On the next Renovate provider-bump PR (`hashicorp/aws`, `hashicorp/random`, or `integrations/github` minor/patch), confirm `renovate-lockfile.yml` runs, lands a `chore: update generated lockfiles` commit, `build` re-runs and is green, auto-merge merges through the queue.

## Out of scope

- CI-side lockfile-consistency check for *human*-edited `.tf` files. Today the regen workflow fires only on `renovate/**` branches; a human bumping a provider in a feature branch must regenerate the lockfile manually. A Bazel `tofu_lock_consistent` test target would close that gap but is a separate change.