### PR TITLE
ci: bazel mod tidy + pnpm-lock trigger in lockfile workflow

### DIFF
--- a/.github/workflows/renovate-lockfile.yml
+++ b/.github/workflows/renovate-lockfile.yml
@@ -17,6 +17,7 @@ on:
       - "**/Cargo.toml"
       - "infra/**/*.tf"
       - "infra/**/.terraform.lock.hcl"
+      - "**/pnpm-lock.yaml"
 permissions:
   contents: write
 jobs:
@@ -33,7 +34,20 @@ jobs:
           bazelisk-cache: true
           disk-cache: ${{ github.workflow }}
           repository-cache: true
-      - name: Regenerate MODULE.bazel.lock
+      - name: Sync use_repo declarations + MODULE.bazel.lock
+        # rules_js and similar extensions encode version strings in their
+        # generated repo names (e.g. npm__at_devcontainers_cli__0.86.1).
+        # When Renovate bumps the underlying lockfile, the extension output
+        # changes name but MODULE.bazel's use_repo line still references the
+        # old name, which would break `bazel mod deps --lockfile_mode=update`
+        # before it ever reached the lockfile. `mod tidy` rewrites use_repo
+        # to match what the extensions actually produce and refreshes the
+        # lockfile in the same pass.
+        run: bazel mod tidy
+      - name: Refresh MODULE.bazel.lock (belt and braces)
+        # Redundant after `mod tidy` in the common case, but explicit so a
+        # future Bazel version that changes mod tidy's lockfile behaviour
+        # doesn't silently leave the lockfile stale.
         run: bazel mod deps --lockfile_mode=update
       - name: Regenerate infra/terraform/.terraform.lock.hcl
         run: bazel run //infra:tofu -- infra/terraform providers lock -platform=linux_amd64
@@ -43,7 +57,7 @@ jobs:
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add MODULE.bazel.lock \
+          git add MODULE.bazel MODULE.bazel.lock \
             infra/terraform/.terraform.lock.hcl \
             infra/github/.terraform.lock.hcl
           git diff --cached --quiet && exit 0


### PR DESCRIPTION
## Summary

- Run `bazel mod tidy` ahead of `bazel mod deps --lockfile_mode=update` in `renovate-lockfile.yml`.
- Stage `MODULE.bazel` (so `mod tidy`'s edits get committed) alongside the existing lockfile files.
- Add `**/pnpm-lock.yaml` to the trigger paths so the workflow fires on the first push of a Renovate npm bump, not only on later rebases.

## Why — PR #138 root cause

`@devcontainers/cli` 0.84.1 → 0.86.1 fails because `rules_js`'s npm extension encodes the version into the generated repo name (`npm__at_devcontainers_cli__0.84.1` → `…__0.86.1`). When the lockfile bumps, the extension renames the repo, but `MODULE.bazel:224`'s `use_repo` line still references the old name and Bazel refuses to evaluate the graph:

```
ERROR: module extension @@aspect_rules_js+//npm:extensions.bzl%npm
does not generate repository "npm__at_devcontainers_cli__0.84.1"
```

The Cargo path never hit this because `rules_rs`'s `use_repo` target is the hub name `"crates"`, not version-suffixed. Same for rules_python (`"pip"`).

`bazel mod tidy` is Bazel's command for exactly this — rewrites `use_repo` declarations to match what each extension actually produces. Order matters: `mod tidy` first, because `mod deps --lockfile_mode=update` would otherwise error on the use_repo mismatch before it could refresh the lockfile.

## Belt-and-braces

`mod tidy` already refreshes `MODULE.bazel.lock` as a side effect, but the explicit `mod deps --lockfile_mode=update` step is kept so a future Bazel version that decouples those behaviours doesn't silently leave the lockfile stale.

## Test plan

- [ ] After merge, PR #138 (or its successor, since `rebaseWhen` may have changed by then) gets a follow-up `chore: update generated lockfiles` commit on its branch with `MODULE.bazel` edited from `…__0.84.1` to `…__0.86.1`; `build.yml` reruns green; auto-merge takes the PR through the queue.
- [ ] No regression for Cargo/Terraform paths: the existing trigger files still produce the same single follow-up commit when relevant.