### PR TITLE
renovate: rebaseWhen conflicted, not on every master move

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -7,6 +7,7 @@
   "automerge": true,
   "platformAutomerge": true,
   "automergeStrategy": "merge",
+  "rebaseWhen": "conflicted",
   "gitIgnoredAuthors": [
     "41898282+github-actions[bot]@users.noreply.github.com"
   ],


### PR DESCRIPTION
## Summary

- `renovate.json`: `rebaseWhen: "conflicted"`.

## Why

Default `rebaseWhen: "auto"` rebases every Renovate PR with `automerge: true` the moment master moves. With this many open Renovate PRs and a busy master, every merge triggers a wave of rebases + full CI on every open PR — for no actual behaviour change.

The merge queue tests the merged result, so an out-of-date PR branch isn't a correctness problem. Restrict Renovate to rebasing only when a PR is actually conflicted; everything else rides through the queue on its existing commit.

## Test plan

- [ ] After merge, observe that merging an unrelated PR no longer triggers fresh `build` runs on open Renovate PRs unless their content actually conflicts with master.
- [ ] Confirm a *conflicting* Renovate PR still gets rebased on its next Renovate run.