### PR TITLE
ci: upload bazel test logs on build failure

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,6 +37,28 @@ jobs:
         run: bazel run $BB_FLAGS //:format.check
       - name: Test, build docs, and check coverage
         run: tools/coverage.sh $BB_FLAGS //...
+      - name: Collect Bazel test logs (on failure)
+        if: failure()
+        # Bazel writes per-test stdout/stderr to bazel-testlogs/<target>/test.log.
+        # The workflow log only surfaces the FAIL summary, so without this the
+        # only place to read the failure is the BuildBuddy UI. Copy the tree
+        # into a plain directory so the upload step doesn't have to chase the
+        # bazel-out symlink chain.
+        run: |
+          set -euo pipefail
+          bazel_testlogs="$(bazel info bazel-testlogs 2>/dev/null || true)"
+          if [[ -n "$bazel_testlogs" && -d "$bazel_testlogs" ]]; then
+            mkdir -p test-logs
+            cp -RL "$bazel_testlogs/." test-logs/
+          fi
+      - name: Upload Bazel test logs artifact (on failure)
+        if: failure()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
+        with:
+          name: bazel-test-logs
+          path: test-logs/
+          if-no-files-found: ignore
+          retention-days: 14
   deploy:
     runs-on: ubuntu-latest
     needs: build


### PR DESCRIPTION
## Summary

Add a failure-only step to `build.yml` that copies `bazel-testlogs/` into `test-logs/` and uploads it as a `bazel-test-logs` artifact (retention: 14 days).

## Why

When a Bazel test fails in CI, the workflow log only shows the `FAIL: //...` summary line; the actual stdout/stderr (stack traces, sqlx error messages, postgres startup output, etc.) lives in `bazel-out/.../testlogs/<target>/test.log` inside the runner and gets discarded at job teardown.

Today the only path to read it is the BuildBuddy invocation URL, which requires an account. That's the gap that left PR #252's `sqlx_prepare_test` failure (Bazel 9.0.2 → 9.1.0) unanalysable from `gh` alone — the test passes on the devcontainer with the same `.bazelversion` but fails on `ubuntu-latest` runners, and we have nothing to diff against.

With this in place, the next failed build will produce a downloadable artifact:

```sh
gh run download <run-id> --repo causes-tracker/causes-tracker --name bazel-test-logs
```

…and we can read the offending test.log directly.

## Notes

- `cp -RL` dereferences the `bazel-out/` symlink chain so `actions/upload-artifact` doesn't have to chase it. Pinned to `actions/upload-artifact@v4.6.2` (SHA `ea165f8d65b6e75b540449e92b4886f43607fa02`).
- `if: failure()` so successful builds don't pay the cost.
- `if-no-files-found: ignore` so an early-stage failure (before any test runs) doesn't itself fail the artifact step.
- Only added to the `build` job, not `deploy`.

## Test plan

- [ ] After merge, the next *successful* build shows no artifact step running (skipped due to `if: failure()`).
- [ ] Trigger a failure (or wait for the next one — e.g. re-run #252) and verify a `bazel-test-logs` artifact appears in the run summary, downloadable via `gh run download`.
- [ ] Download #252's artifact and read the actual `sqlx_prepare_test` failure to drive the next fix.