### PR TITLE
build: version-agnostic load for @devcontainers/cli

### DIFF
--- a/.devcontainer/BUILD.bazel
+++ b/.devcontainer/BUILD.bazel
@@ -1,5 +1,5 @@
 load("@npm//:defs.bzl", "npm_link_all_packages")
-load("@npm__at_devcontainers_cli__0.84.1//:package_json.bzl", devcontainers_cli_bin = "bin")
+load("@npm//.devcontainer:@devcontainers/cli/package_json.bzl", devcontainers_cli_bin = "bin")
 load("@rules_shell//shell:sh_test.bzl", "sh_test")
 load("//tools/lint:format_check.bzl", "format_srcs")
 

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -230,8 +230,4 @@ npm.npm_translate_lock(
     ],
     pnpm_lock = "//.devcontainer:pnpm-lock.yaml",
 )
-use_repo(
-    npm,
-    "npm",
-    "npm__at_devcontainers_cli__0.84.1",
-)
+use_repo(npm, "npm")


### PR DESCRIPTION
## Summary

Two-file refactor that decouples the @devcontainers/cli binary load from the resolved pnpm version:

- `.devcontainer/BUILD.bazel`: load `bin` from `@npm//.devcontainer:@devcontainers/cli/package_json.bzl` instead of `@npm__at_devcontainers_cli__0.84.1//:package_json.bzl`.
- `MODULE.bazel`: drop the now-unused `"npm__at_devcontainers_cli__0.84.1"` entry from the npm `use_repo`.

## Why

PR #138 (`@devcontainers/cli` 0.84.1 → 0.86.1) was failing because the version is baked into two strings Renovate doesn't touch:

1. `MODULE.bazel:236` — `use_repo(npm, "npm", "npm__at_devcontainers_cli__0.84.1")`
2. `.devcontainer/BUILD.bazel:2` — `load("@npm__at_devcontainers_cli__0.84.1//:package_json.bzl", …)`

`bazel mod tidy` does not rewrite these — `bazel help mod` documents that tidy only handles "supported module extensions", and aspect_rules_js's npm extension has not opted into tidy's API. We confirmed locally: `bazel mod tidy` exits 0 and produces zero diff against PR #138's tree.

aspect_rules_js generates a *version-agnostic* shim at `@npm//<workspace-path>:<package>/package_json.bzl` that re-exports `bin` from whichever per-version repo the extension currently produces. Switching to that shim moves the version dependency entirely inside the extension's generated output, where it auto-updates with the lockfile.

After this lands, an `@devcontainers/cli` bump will only touch `package.json` + `pnpm-lock.yaml` (Renovate) and `MODULE.bazel.lock` (renovate-lockfile workflow). No more `MODULE.bazel` / `BUILD.bazel` patching.

## Verification

- `bazel build //.devcontainer:devcontainer_cli` — succeeds.
- `bazel test //.devcontainer:build_test` — passes.
- `bazel mod tidy` — no further changes.
- `tools/coverage.sh //...` — green.

## Test plan

- [ ] After merge, Renovate's next rebase of #138 onto master should produce an `@devcontainers/cli` bump that builds without any MODULE.bazel or BUILD.bazel patch.