### PR TITLE
ci: --test_output=errors so failing tests log inline

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -24,6 +24,10 @@ build:ci --bes_results_url=https://app.buildbuddy.io/invocation/
 # Renovate PRs; for human PRs that add deps, run
 # `bazel mod deps --lockfile_mode=update` locally and commit the result.
 build:ci --lockfile_mode=error
+# Surface failing tests' stderr/stdout inline in the workflow log so failures
+# can be diagnosed from `gh run view --log-failed` without needing to chase
+# bazel-testlogs/<target>/test.log on the runner or in BuildBuddy.
+test:ci --test_output=errors
 
 # Rust: use the experimental platform so the toolchain glibc constraint is satisfied.
 # Without this, rules_rs toolchains (which embed gnu.2.28) cannot match the default


### PR DESCRIPTION
## Summary

- `.bazelrc`: `test:ci --test_output=errors`.

## Why

The artifact upload from #299 ran on #252's latest failed build, but the upload step reported "No files were found with the provided path: test-logs/". The collect step suppressed stderr (`2>/dev/null`), so we can't tell whether `bazel info bazel-testlogs` returned an empty path, a path that didn't exist on the runner, or a path that pointed at an empty dir. Either way: #252's actual `sqlx_prepare_test` failure is still invisible from `gh`.

`--test_output=errors` is a much simpler route — bazel itself prints the failing test's stdout/stderr to the bazel runner's own output, which then appears verbatim in the GitHub Actions log. No artifact handling, no symlink chasing, no `cp -RL` heuristic.

Scoped to `--config=ci` so local interactive runs stay quiet.

`bazel coverage` inherits flags from `bazel test`, so `test:ci` correctly applies to the `bazel coverage` invocation inside `tools/coverage.sh`.

## Test plan

- [ ] After merge, #252's next build (rebased onto fresh master) will show the `sqlx_prepare_test` failure text inline in `gh run view --log-failed`. Use that to drive the next #252 fix.
- [ ] Future Bazel test failures in CI become diagnosable without BuildBuddy or artifact downloads.

## Note

This does not retire #299's artifact upload — the artifact still has value for tests that produce *passing* logs or for tests with very large output that's awkward to scroll through in the workflow log. The two mechanisms are complementary; this one's the fast path.