### PR TITLE
ci: diagnostic-friendly bazel test logs collector

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,16 +40,24 @@ jobs:
       - name: Collect Bazel test logs (on failure)
         if: failure()
         # Bazel writes per-test stdout/stderr to bazel-testlogs/<target>/test.log.
-        # The workflow log only surfaces the FAIL summary, so without this the
-        # only place to read the failure is the BuildBuddy UI. Copy the tree
-        # into a plain directory so the upload step doesn't have to chase the
-        # bazel-out symlink chain.
+        # `--test_output=errors` (in .bazelrc test:ci) inlines failures in the
+        # workflow log; this artifact captures the full tree for cases where
+        # the inlined output is truncated or where we want passing-test logs.
+        # No -e: keep every diagnostic line running even if a sibling errors,
+        # so a future regression here is debuggable from the run log.
         run: |
-          set -euo pipefail
-          bazel_testlogs="$(bazel info bazel-testlogs 2>/dev/null || true)"
-          if [[ -n "$bazel_testlogs" && -d "$bazel_testlogs" ]]; then
+          set -uo pipefail
+          echo "::group::bazel info + workspace state"
+          ls -la bazel-* 2>&1 || true
+          bazel info bazel-testlogs 2>&1 || true
+          echo "::endgroup::"
+          bazel_testlogs="$(bazel info bazel-testlogs 2>/dev/null)" || bazel_testlogs=""
+          if [[ -d "$bazel_testlogs" ]]; then
             mkdir -p test-logs
             cp -RL "$bazel_testlogs/." test-logs/
+            echo "Captured $(find test-logs -type f | wc -l) test log file(s)"
+          else
+            echo "bazel-testlogs not resolvable to a directory; skipping copy"
           fi
       - name: Upload Bazel test logs artifact (on failure)
         if: failure()


### PR DESCRIPTION
## Summary

Replace #299's silent collect step with a diagnostic-friendly version.

## What was wrong

#299's script:

```bash
set -euo pipefail
bazel_testlogs="$(bazel info bazel-testlogs 2>/dev/null || true)"
if [[ -n "$bazel_testlogs" && -d "$bazel_testlogs" ]]; then
  mkdir -p test-logs
  cp -RL "$bazel_testlogs/." test-logs/
fi
```

Two compounding bugs:

1. **Diagnostics suppressed.** `2>/dev/null` discards stderr from `bazel info`, and `|| true` masks its exit code. Any failure → `bazel_testlogs=""` with no trace of why.
2. **Empty case silent.** With an empty path, the guard fails false, `mkdir`/`cp` skip, and `actions/upload-artifact` with `if-no-files-found: ignore` reports "no files" without explaining. Two ✓ steps, zero artifact, zero signal.

This bit us on PR #252 — the collect step ran ✓ but produced nothing, and we had no way to know why.

## What this changes

```bash
set -uo pipefail   # NB: no -e; want every diagnostic line to run
echo "::group::bazel info + workspace state"
ls -la bazel-* 2>&1 || true
bazel info bazel-testlogs 2>&1 || true
echo "::endgroup::"
bazel_testlogs="$(bazel info bazel-testlogs 2>/dev/null)" || bazel_testlogs=""
if [[ -d "$bazel_testlogs" ]]; then
  mkdir -p test-logs
  cp -RL "$bazel_testlogs/." test-logs/
  echo "Captured $(find test-logs -type f | wc -l) test log file(s)"
else
  echo "bazel-testlogs not resolvable to a directory; skipping copy"
fi
```

- Drops `-e` so a `bazel info` failure doesn't kill subsequent diagnostics.
- `::group::`-wraps an explicit `bazel info` and `ls bazel-*` with stderr included.
- Echoes a captured-file count on the success path and an explicit "skipping" message on the empty path.

## Relationship to #301

Now that `test:ci --test_output=errors` inlines failing tests into the workflow log directly, the artifact's role narrows to:

- output too large/truncated for the workflow log
- passing-test logs (occasionally useful)
- multi-failure runs where the inlined output gets noisy

This keeps the artifact functional for those cases without leaving the silent-failure footgun in place.

## Test plan

- [ ] Next CI failure should produce the new diagnostic group and either a non-zero captured count or the explicit skip message.
- [ ] If the captured count is non-zero, the `bazel-test-logs` artifact appears on the run summary as expected.