### PR TITLE
ci: remove bazel test-logs artifact upload

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,28 +37,6 @@ jobs:
         run: bazel run $BB_FLAGS //:format.check
       - name: Test, build docs, and check coverage
         run: tools/coverage.sh $BB_FLAGS //...
-      - name: Collect Bazel test logs (on failure)
-        if: failure()
-        # Bazel writes per-test stdout/stderr to bazel-testlogs/<target>/test.log.
-        # The workflow log only surfaces the FAIL summary, so without this the
-        # only place to read the failure is the BuildBuddy UI. Copy the tree
-        # into a plain directory so the upload step doesn't have to chase the
-        # bazel-out symlink chain.
-        run: |
-          set -euo pipefail
-          bazel_testlogs="$(bazel info bazel-testlogs 2>/dev/null || true)"
-          if [[ -n "$bazel_testlogs" && -d "$bazel_testlogs" ]]; then
-            mkdir -p test-logs
-            cp -RL "$bazel_testlogs/." test-logs/
-          fi
-      - name: Upload Bazel test logs artifact (on failure)
-        if: failure()
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
-        with:
-          name: bazel-test-logs
-          path: test-logs/
-          if-no-files-found: ignore
-          retention-days: 14
   deploy:
     runs-on: ubuntu-latest
     needs: build


### PR DESCRIPTION
## Summary

Delete the Bazel test-logs collect + upload pair from `build.yml` and the `actions/upload-artifact` reference. Closes #302 (which was trying to fix the collector, before we realised the collector itself isn't needed).

## Why

- #299 added the artifact so we could read failing tests' output from `gh` without a BuildBuddy account.
- #301 added `test:ci --test_output=errors`, which inlines every failing test's stdout/stderr into the workflow log itself — readable via `gh run view --log-failed`.

That leaves the artifact path doing no work the workflow log doesn't already do:

- GHA's per-step log cap (~4MB) is well beyond what any test here emits.
- No use case for passing-test logs.
- The `cp`/symlink dance from #299 has already proved fragile (silent skip when `bazel info` errored, which is exactly what bit us on PR #252).

#301 stays — that's the single mechanism we actually rely on.

## Test plan

- [ ] After merge, the next failing CI run inlines the test's output via `--test_output=errors` and shows no `Collect Bazel test logs` / `Upload Bazel test logs artifact` step.
- [ ] No artifact attached to failing runs (verified in the run summary UI).