### PR TITLE
fix(coverage): suppress profraw in sqlx_prepare_impl

### DIFF
--- a/tools/sqlx_prepare_impl.sh
+++ b/tools/sqlx_prepare_impl.sh
@@ -7,6 +7,14 @@
 # check  mode (bazel test): starts hermetic postgres, fails if .sqlx/ is stale
 set -euo pipefail
 
+# Suppress LLVM profraw output from instrumented binaries (rustc/cargo we
+# invoke for `cargo metadata` and the sqlx-cli check).  Under `bazel coverage`
+# these would land in COVERAGE_DIR; Bazel's collect_cc_coverage.sh then tries
+# to invoke LLVM_PROFDATA, which isn't set for sh_test targets and trips
+# Bazel 9.1.0's `set -u` ("LLVM_PROFDATA: unbound variable").  sqlx prepare
+# has no coverage to collect — it's a metadata-check workflow.
+export LLVM_PROFILE_FILE=/dev/null
+
 CHECK=false
 if [[ "${1:-}" == "--check" ]]; then
 	CHECK=true


### PR DESCRIPTION
## Summary

Add `export LLVM_PROFILE_FILE=/dev/null` near the top of `tools/sqlx_prepare_impl.sh`, mirroring the existing pattern in `tools/proto_gen_impl.sh`.

## Why — PR #252 root cause

Bazel 9.1.0's `collect_cc_coverage.sh` runs under `set -u`. Line 76 dereferences `${LLVM_PROFDATA}`, which isn't set for sh_test targets — so as soon as the wrapper sees any `.profraw` blob the test produced, it dies with `LLVM_PROFDATA: unbound variable` and Bazel reports `error: coverage collection script failed`. PR #252 (bazel 9.0.2 → 9.1.0) tripped this; Bazel 9.0.2's version of the same script tolerated the unset var.

`sqlx_prepare_impl.sh` internally runs `cargo metadata` and `sqlx prepare --check` against an isolated workspace. Under `bazel coverage`, those inherit the instrumented rustc and emit `.profraw` files into `COVERAGE_DIR`. The test has no coverage to collect — it's a stale-metadata check — so the right fix is to redirect `LLVM_PROFILE_FILE` to `/dev/null` and stop generating the `.profraw`s entirely.

The same trick already lives in `tools/proto_gen_impl.sh:37` for the same reason (also a sh_test that runs instrumented binaries with no useful coverage).

## Verification

- Reproduced locally on `renovate/bazel-9.x@origin`: `bazel coverage --config=ci //lib/rust/api_db:sqlx_prepare_test` → `LLVM_PROFDATA: unbound variable`.
- With this patch applied: same command → PASSED in 4.9s.
- `tools/coverage.sh //...` on this branch — green.

## After this lands

PR #252 (`bazel 9.1.0`) should auto-merge on its next push. Future Bazel upgrades that tighten `set -u` further on `collect_cc_coverage.sh` will not regress this target.