### PR TITLE
ci: regen requirements_lock on Renovate Python deps

### DIFF
--- a/.github/workflows/renovate-lockfile.yml
+++ b/.github/workflows/renovate-lockfile.yml
@@ -18,6 +18,8 @@ on:
       - "infra/**/*.tf"
       - "infra/**/.terraform.lock.hcl"
       - "**/pnpm-lock.yaml"
+      - "requirements.in"
+      - "requirements_lock.txt"
 permissions:
   contents: write
 jobs:
@@ -49,6 +51,14 @@ jobs:
         # future Bazel version that changes mod tidy's lockfile behaviour
         # doesn't silently leave the lockfile stale.
         run: bazel mod deps --lockfile_mode=update
+      - name: Regenerate requirements_lock.txt
+        # Renovate's Python lockfile update only patches the bumped package's
+        # hashes; it does not re-run pip-compile, so a release that adds a
+        # transitive dependency (e.g. zensical 0.0.41 picking up jinja2) lands
+        # with an incomplete lockfile and the build fails with
+        # ModuleNotFoundError.  bazel run //:requirements.update resolves the
+        # full graph from requirements.in and writes the updated lockfile.
+        run: bazel run //:requirements.update
       - name: Regenerate infra/terraform/.terraform.lock.hcl
         run: bazel run //infra:tofu -- infra/terraform providers lock -platform=linux_amd64
       - name: Regenerate infra/github/.terraform.lock.hcl
@@ -58,6 +68,7 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git add MODULE.bazel MODULE.bazel.lock \
+            requirements_lock.txt \
             infra/terraform/.terraform.lock.hcl \
             infra/github/.terraform.lock.hcl
           git diff --cached --quiet && exit 0


### PR DESCRIPTION
## Summary

Extend `.github/workflows/renovate-lockfile.yml`:

- Trigger paths gain `requirements.in` and `requirements_lock.txt`.
- New step: `bazel run //:requirements.update` (resolves the full graph via rules_python's `compile_pip_requirements`).
- Commit step stages `requirements_lock.txt` alongside the other lockfiles.

## Why — PR #253 root cause

PR #253 (`zensical 0.0.33 → 0.0.41`) failed with `ModuleNotFoundError: No module named 'jinja2'`. The cause: zensical 0.0.41 added a runtime dependency on `jinja2` (and `markupsafe`), but Renovate's Python lockfile update only patches the bumped package's hash entries — it doesn't re-run `pip-compile`, so new transitive deps are silently absent.

Confirmed locally:
- `bazel build //docs:docs_site` on `renovate/zensical-0.x` → `ModuleNotFoundError`.
- `bazel run //:requirements.update` on that branch → adds `jinja2==3.1.6`, `markupsafe==3.0.3`, fixes the build.

This mirrors how the workflow already handles `MODULE.bazel.lock` (Cargo/npm changes), `.terraform.lock.hcl` (provider changes), and `MODULE.bazel` (use_repo declarations). Python is the last manager that wasn't covered.

## Test plan

- [ ] After merge, PR #253 (or its successor) rebases onto master, triggers a fresh `chore: update generated lockfiles` commit that adds `jinja2`/`markupsafe`, and `build` goes green.
- [ ] Future Python-dep bumps with new transitive deps land cleanly.