### PR TITLE
renovate: group tracing-opentelemetry with opentelemetry

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -15,6 +15,17 @@
   "vulnerabilityAlerts": {
     "minimumReleaseAge": "0 days"
   },
+  "packageRules": [
+    {
+      "description": "Group tracing-opentelemetry with opentelemetry-* into one PR. tracing-opentelemetry's trait bounds resolve against whichever opentelemetry version it was built with, so an opentelemetry major bump without a matching tracing-opentelemetry release leaves both versions in the dep graph and breaks compilation. Grouping forces Renovate to wait until compatible versions of both are available.",
+      "matchManagers": ["cargo"],
+      "matchPackageNames": [
+        "tracing-opentelemetry",
+        "/^opentelemetry/"
+      ],
+      "groupName": "opentelemetry-rust"
+    }
+  ],
   "customManagers": [
     {
       "customType": "regex",


### PR DESCRIPTION
## Summary

Add a Renovate `packageRule` that groups `tracing-opentelemetry` with the `opentelemetry-*` crates into one PR called `opentelemetry-rust`.

## Why — PR #297 root cause

PR #297 (opentelemetry-rust monorepo 0.31 → 0.32) failed to compile with:

```
error[E0277]: the trait bound `opentelemetry_sdk::trace::SdkTracer:
  opentelemetry::trace::tracer::Tracer` is not satisfied
note: there are multiple different versions of crate `opentelemetry`
      in the dependency graph
  → crates__opentelemetry-0.31.0/src/trace/tracer.rs:121 (expected)
  → crates__opentelemetry-0.32.0/src/trace/tracer.rs:121 (found)
```

`tracing-opentelemetry` pins its own `opentelemetry` dep at 0.31. Bumping our direct `opentelemetry` to 0.32 leaves both versions in the graph; the trait bound in `tracing_opentelemetry::layer().with_tracer(...)` resolves against 0.31's `Tracer`, but the `SdkTracer` we pass comes from 0.32. Compilation fails.

`tracing-opentelemetry` lives in a different repo from the opentelemetry-rust monorepo, so Renovate's built-in monorepo grouping doesn't include it. Adding it to a custom group forces Renovate to hold the opentelemetry-* bump until tracing-opentelemetry ships a release that pins the compatible major.

## Behaviour after merge

- PR #297 (and any future `opentelemetry-rust` monorepo PR) will be regenerated with both opentelemetry-* and tracing-opentelemetry in a single PR, and Renovate will only open it when compatible versions of both exist.
- The `opentelemetry-rust monorepo` preset (from `config:recommended`) still applies to the opentelemetry-* crates; this rule extends that group with `tracing-opentelemetry` rather than replacing it.

## Test plan

- [ ] After merge, the next dashboard refresh should move the existing opentelemetry-rust update into a `opentelemetry-rust` group entry that includes `tracing-opentelemetry`, and #297 should either rebase to include both or be replaced.