### PR TITLE
ci: lockfile workflow fires on .bazelversion / MODULE.bazel.lock

### DIFF
--- a/.github/workflows/renovate-lockfile.yml
+++ b/.github/workflows/renovate-lockfile.yml
@@ -11,7 +11,9 @@ on:
   push:
     branches: ["renovate/**"]
     paths:
+      - ".bazelversion"
       - "MODULE.bazel"
+      - "MODULE.bazel.lock"
       - "Cargo.lock"
       - "Cargo.toml"
       - "**/Cargo.toml"


### PR DESCRIPTION
## Summary

Add `.bazelversion` and `MODULE.bazel.lock` to `renovate-lockfile.yml`'s `on.push.paths`.

## Why — PR #252 post-rebase failure

#252 (`bazel 9.0.2 → 9.1.0`) is now rebased onto master with all our previous fixes, but its `build` still fails — this time with:

```
ERROR: Error computing the main repository mapping: Missing checksum
for registry file https://bcr.bazel.build/modules/rules_java/9.1.0/MODULE.bazel
not permitted with --lockfile_mode=error.
Please run `bazel mod deps --lockfile_mode=update` to update your lockfile.
```

Bazel 9.1.0 pulls in transitive registry entries (e.g. `rules_java 9.1.0`) that aren't present in `MODULE.bazel.lock`. Renovate's update only patches the version string in `.bazelversion`; the regenerated lockfile from Renovate's internal lockfile-fetch is sometimes incomplete for new transitive deps under a new Bazel version.

The renovate-lockfile workflow exists for exactly this — re-run `bazel mod tidy` + `bazel mod deps --lockfile_mode=update` against the rebased branch and commit the refreshed lockfile. But its `paths` filter omits `.bazelversion`, so a pure version bump doesn't trigger it. Adding `.bazelversion` (and the lockfile itself, as a belt-and-braces safety net) closes the gap.

After this lands and Renovate next rebases #252 onto fresh master, the workflow fires, regenerates the lockfile, and #252 should go green.

## Test plan

- [ ] After merge, tick the rebase checkbox for #252 on dashboard issue #7. Renovate rebases; the workflow fires on the new push (because `.bazelversion` is in the diff); a `chore: update generated lockfiles` commit lands; build re-runs green; auto-merge takes it through the queue.
- [ ] Future Bazel version bumps land cleanly with no manual intervention.