### PR TITLE
tools: coverage cache skips empty @, walks single-parent ancestor

### DIFF
--- a/tools/coverage.sh
+++ b/tools/coverage.sh
@@ -19,16 +19,33 @@ MIN_PCT=25
 # unchanged, so the cache says green while CI would fail. The test suite /
 # CI is authoritative; this cache is a local turn-end optimization only.
 #
+# Empty @: every empty working copy hashes to the same key regardless of
+# parent, so caching against an empty diff would alias unrelated states.
+# Handling: walk up single-parent ancestors until a non-empty change is
+# found, and key on that. If we hit a merge (multiple parents) or run out
+# of ancestors with the diff still empty, error — there is no unambiguous
+# patch to verify.
+#
 # Cache lives in .coverage-green/ (gitignored), one file per key. A
 # conflicted working copy is never cached.
 GREEN_CACHE_DIR=".coverage-green"
 CACHE_KEY=""
 if jj_conflicts="$(jj log -r '@ & conflicts()' --no-graph -T commit_id 2>/dev/null)" &&
-	[[ -z "$jj_conflicts" ]] &&
-	diff_hash="$(jj diff --git -r @ 2>/dev/null |
+	[[ -z "$jj_conflicts" ]]; then
+	target="@"
+	while [[ -z "$(jj diff -r "$target" --summary 2>/dev/null)" ]]; do
+		parent_ids="$(jj log -r "$target-" --no-graph -T 'commit_id ++ "\n"' 2>/dev/null)"
+		parent_count=$(printf '%s' "$parent_ids" | grep -c . || true)
+		if [[ "$parent_count" -ne 1 ]]; then
+			echo "error: $target has empty diff and $parent_count parent(s); cannot determine what to verify" >&2
+			exit 1
+		fi
+		target="${target}-"
+	done
+	diff_hash="$(jj diff --git -r "$target" 2>/dev/null |
 		sed -E -e '/^index [0-9a-f]+\.\.[0-9a-f]+/d' \
 			-e 's/^@@ -[0-9,]+ \+[0-9,]+ @@/@@/' |
-		sha256sum | awk '{print $1}')"; then
+		sha256sum | awk '{print $1}')"
 	CACHE_KEY="$(printf '%s\t%s' "$diff_hash" "$*" | sha256sum | awk '{print $1}')"
 fi
 if [[ -n "$CACHE_KEY" && -f "$GREEN_CACHE_DIR/$CACHE_KEY" ]]; then


### PR DESCRIPTION
## Summary

The patch-diff cache in `tools/coverage.sh` keys on the (filtered) `jj diff` of `@`. An empty `@` always hashes to sha256 of the empty string, so every empty working copy collides on the same cache key regardless of its parent — a prior green entry from an unrelated state would mask a real regression.

Walk up single-parent ancestors until a non-empty change is reached and key on that, treating an empty `@` as if we were editing its parent. If the walk hits a merge (multiple parents) or runs out of ancestors with the diff still empty, error out — there is no unambiguous patch to verify.

## Behavior matrix

- `@` has changes → key on `@` (unchanged behavior).
- `@` empty, `@-` non-empty → key on `@-` (no longer collides).
- `@` empty on a merge → error, `@ has empty diff and 2 parent(s)`.
- `@` empty, `@-` also empty, single-parent chain → walk up until non-empty.

## Test plan

- [x] `tools/coverage.sh //...` passes on this change (40 Rust files ≥ 25%, 67 tests pass).
- [x] Walk logic verified manually against three scenarios (single change, empty-on-single-parent, empty-on-merge).
- [ ] CI green.