### PR TITLE
ci: tag bazel invocations with GitHub metadata

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,8 +7,21 @@ on:
 permissions:
   contents: write
 env:
-  BB_FLAGS: >-
-    --config=ci --remote_header=x-buildbuddy-api-key=${{ secrets.BUILDBUDDY_ORG_API_KEY }}
+  # BB_FLAGS travels with every CI bazel invocation. The --build_metadata
+  # tags make BuildBuddy invocations searchable by GitHub run/PR/branch so
+  # tooling can correlate BB stats back to a specific CI run without
+  # having to capture per-invocation UUIDs. The literal-block scalar (|)
+  # keeps each flag on its own line for readability and yamllint compliance;
+  # shell word-splitting on $BB_FLAGS treats newlines as separators.
+  BB_FLAGS: |
+    --config=ci
+    --remote_header=x-buildbuddy-api-key=${{ secrets.BUILDBUDDY_ORG_API_KEY }}
+    --build_metadata=GITHUB_RUN_ID=${{ github.run_id }}
+    --build_metadata=GITHUB_RUN_ATTEMPT=${{ github.run_attempt }}
+    --build_metadata=GITHUB_EVENT_NAME=${{ github.event_name }}
+    --build_metadata=GITHUB_PR_NUMBER=${{ github.event.pull_request.number }}
+    --build_metadata=GITHUB_BRANCH=${{ github.ref_name }}
+    --build_metadata=GITHUB_JOB=${{ github.job }}
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
Adds `--build_metadata=GITHUB_RUN_ID/PR/BRANCH/...` to the existing `BB_FLAGS` env var so every CI bazel invocation streams GitHub run context to BuildBuddy. Enables BB invocations to be joined back to a specific GH run — the foundation the rest of this stack builds on.

## Test plan
- [ ] CI passes (workflow YAML change only)
- [ ] After merge: a BuildBuddy invocation from a CI run shows `GITHUB_RUN_ID=...` etc. in its metadata pane

## Stack
1. **this PR** — tag invocations
2. ci_health: scaffold crate skeleton
3. ci_health: metrics + GitHub Actions client
3b. ci_health: BuildBuddy client + record wiring
4. ci: record CI metrics + upload artifact
5. ci_health: compare subcommand
6. ci_health: pr-comment + auto-fetch baseline
7. ci_health: query subcommand for dev use
8. ci_health: trend subcommand
9. ci: scheduled ci-health-trend workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)