### PR TITLE
ci: record CI metrics + upload artifact

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,6 +50,31 @@ jobs:
         run: bazel run $BB_FLAGS //:format.check
       - name: Test, build docs, and check coverage
         run: tools/coverage.sh $BB_FLAGS //...
+      # The metrics step is best-effort: a failure here must not turn a
+      # green build red. It also runs on failed builds so we keep
+      # visibility into "the build failed because cache restore took 5
+      # minutes" kinds of regressions.
+      - name: Record CI metrics
+        if: always()
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BUILDBUDDY_API_KEY: ${{ secrets.BUILDBUDDY_ORG_API_KEY }}
+        run: |
+          bazel run $BB_FLAGS //tools/ci_health -- record \
+            --run-id ${{ github.run_id }} \
+            --job build \
+            --out ci-metrics.json \
+            ${{ github.event.pull_request.number && format('--pr {0}', github.event.pull_request.number) || '' }}
+      - name: Upload CI metrics artifact
+        if: always()
+        continue-on-error: true
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
+        with:
+          name: ci-metrics-${{ github.run_id }}
+          path: ci-metrics.json
+          retention-days: 90
+          if-no-files-found: ignore
   deploy:
     runs-on: ubuntu-latest
     needs: build


### PR DESCRIPTION
## Summary
Two new best-effort steps in `build.yml`: run `//tools/ci_health -- record` after the bazel work, and upload `ci-metrics-<run_id>` as a 90-day workflow artifact. Both gated `if: always()` + `continue-on-error: true` so a failure here never breaks a build.

## Test plan
- [ ] After merge: the next master build produces a `ci-metrics-<run_id>` artifact visible under the run's Artifacts tab
- [ ] The artifact contains a valid `ci-metrics.json`
- [ ] Workflow runs without failure

Stacked on #314.

🤖 Generated with [Claude Code](https://claude.com/claude-code)