### PR TITLE
tools: invalidate coverage cache on lockfile changes

### DIFF
--- a/tools/coverage.sh
+++ b/tools/coverage.sh
@@ -46,7 +46,15 @@ if jj_conflicts="$(jj log -r '@ & conflicts()' --no-graph -T commit_id 2>/dev/nu
 		sed -E -e '/^index [0-9a-f]+\.\.[0-9a-f]+/d' \
 			-e 's/^@@ -[0-9,]+ \+[0-9,]+ @@/@@/' |
 		sha256sum | awk '{print $1}')"
-	CACHE_KEY="$(printf '%s\t%s' "$diff_hash" "$*" | sha256sum | awk '{print $1}')"
+	# Lockfile state is folded into the key so that a stack rewrite that
+	# leaves a commit's patch unchanged but shifts the lockfile content (e.g.
+	# bumping a workspace dep in an ancestor) invalidates the cached green
+	# verdict — without this, the cache would falsely claim green on the new
+	# state because the patch hash is identical to before the rewrite.
+	lockfile_hash="$(sha256sum MODULE.bazel.lock Cargo.lock requirements_lock.txt 2>/dev/null |
+		sha256sum | awk '{print $1}')"
+	CACHE_KEY="$(printf '%s\t%s\t%s' "$diff_hash" "$lockfile_hash" "$*" |
+		sha256sum | awk '{print $1}')"
 fi
 if [[ -n "$CACHE_KEY" && -f "$GREEN_CACHE_DIR/$CACHE_KEY" ]]; then
 	echo "coverage ok: unchanged since last green (key ${CACHE_KEY:0:12})"


### PR DESCRIPTION
## Summary

Fold `MODULE.bazel.lock`, `Cargo.lock`, and `requirements_lock.txt` content into the `tools/coverage.sh` green-cache key so a lockfile change in an ancestor automatically invalidates the cache.

## Why

The cache keys on patch-diff hash, which captures changes inside the current commit's patch but not changes to the lockfile content *as committed at that commit*.
After a stack rewrite that touches a lockfile in an ancestor — for example, regenerating `MODULE.bazel.lock` in commit 1 of an 8-commit stack — every descendant's patch hash is unchanged, so the cache reports green from the pre-rewrite verification.
The actual build state at that commit is different, and CI sees that.

This hit the ci-health stack today: a lockfile fix in commit 1 cascaded through the stack, every commit's patch-diff hash matched its pre-rewrite green-cache entry, so `tools/coverage.sh //...` short-circuited on stale evidence at every commit.
CI failed on PR #322 with `extension '@@rules_rs+//rs:extensions.bzl%crate' has changed its facts: …`.

## What changed

`tools/coverage.sh` now folds `sha256(MODULE.bazel.lock + Cargo.lock + requirements_lock.txt)` into the cache key alongside the patch hash and the bazel arg list.
Any committed-content change to any of those lockfiles produces a different key, so the next coverage run re-evaluates instead of short-circuiting.

## Test plan

- [x] `rm -rf .coverage-green && tools/coverage.sh //...` — full run, writes a green entry.
- [x] `tools/coverage.sh //...` — short-circuits on the second run.
- [x] Probe verifies: touching each of the three lockfiles produces a different key; restoring the file recovers the original key.

🤖 Generated with [Claude Code](https://claude.com/claude-code)