### PR TITLE
ci_health: capture record's own duration in metrics

### DIFF
--- a/tools/ci_health/src/main.rs
+++ b/tools/ci_health/src/main.rs
@@ -71,6 +71,7 @@ async fn record(
     pr: Option<u64>,
     out: &std::path::Path,
 ) -> Result<()> {
+    let started = std::time::Instant::now();
     let meta = gh.run_metadata(run_id).await?;
     let timings = gh.step_timings(run_id, job).await?;
     let invocation_ids = gh.bazel_invocation_ids(run_id, job).await?;
@@ -87,6 +88,7 @@ async fn record(
         timings,
         bazel: buildbuddy::aggregate(&stats),
         bb_invocation_ids: invocation_ids,
+        metrics_collection_seconds: started.elapsed().as_secs_f64(),
     };
     let json = serde_json::to_string_pretty(&metrics).context("serialize metrics")?;
     std::fs::write(out, json).with_context(|| format!("write {}", out.display()))?;
@@ -191,6 +193,9 @@ mod tests {
         assert_eq!(parsed.bazel.remote_cache_hits, 60);
         assert_eq!(parsed.bazel.cache_misses, 10);
         assert_eq!(parsed.bb_invocation_ids.len(), 1);
+        // Self-timer was started and stopped; with mock latency it's tiny
+        // but strictly positive.
+        assert!(parsed.metrics_collection_seconds > 0.0);
     }
 
     fn run_body(run_id: u64) -> serde_json::Value {

--- a/tools/ci_health/src/metrics.rs
+++ b/tools/ci_health/src/metrics.rs
@@ -43,6 +43,10 @@ pub struct RunMetrics {
     pub timings: StepTimings,
     pub bazel: BazelStats,
     pub bb_invocation_ids: Vec<InvocationId>,
+    /// Wall-clock seconds spent inside the `record` invocation itself: GH API calls (run metadata, jobs list, step timings, job log) plus BB GetInvocation round-trips plus JSON serialization.
+    /// This is the overhead the metrics-gathering step adds to a CI run.
+    /// The GH Actions step timing for the record step will be this plus runner/process startup, so the two numbers are complementary, not redundant.
+    pub metrics_collection_seconds: f64,
 }
 
 #[cfg(test)]
@@ -74,6 +78,7 @@ mod tests {
                 critical_path_seconds: 90.0,
             },
             bb_invocation_ids: vec![InvocationId("uuid-1".into())],
+            metrics_collection_seconds: 2.75,
         };
         let s = serde_json::to_string(&m).unwrap();
         let back: RunMetrics = serde_json::from_str(&s).unwrap();


### PR DESCRIPTION
## Summary

Adds `metrics_collection_seconds` to `RunMetrics`, populated by an `Instant::now()` taken at the top of `record()` and read just before serialization.

## Why

The current design captures the workflow's step timings (GH-recorded) and per-invocation bazel stats (BB-recorded), but is silent about how long `ci_health record` itself takes to do all that.
On the analyzed run, that's ~4s of GH + BB round-trips (`run_metadata`, `step_timings`, `bazel_invocation_ids`, then one `GetInvocation` per BB invocation).

It can't measure itself the easy way — by reading its own GH step timing — because the step doesn't complete until after `record` exits.
The instant-stopwatch is the only way to land the number in the same JSON the step writes.

This complements `job_wall_seconds`: the GH step timing for the record step will be roughly `metrics_collection_seconds` + runner/process startup, so both numbers are informative, not redundant.

## What changed

- New field `RunMetrics::metrics_collection_seconds: f64`.
- `record()` captures `Instant::now()` first thing and writes `started.elapsed().as_secs_f64()` into the struct.
- Test fixture in `metrics.rs::round_trips_through_json` adds the field.
- Integration test in `main.rs::record_writes_metrics_with_bazel_stats` asserts the field is `> 0.0` after a mock run.

## Validation

Real BB + GH end-to-end on run 25999435380 (the BB-wire PR's own CI run):

```
actions=3746 remote_hits=2729 BB_invocations=2 self_timer=4.12s
```

## Test plan

- [x] `tools/coverage.sh //...` green per commit.
- [x] Real `bazel run //tools/ci_health -- record --run-id 25999435380` against live BB + GH.

🤖 Generated with [Claude Code](https://claude.com/claude-code)