### PR TITLE
bazel: enable remote cache compression

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -10,6 +10,15 @@ build --experimental_proto_descriptor_sets_include_source_info
 # Local disk cache (shared across workspaces on the same machine)
 build --disk_cache=~/.cache/bazel-disk-cache
 
+# Compress remote-cache traffic with zstd.
+# Default-off in Bazel, but our CI runs are network-bound — a single `coverage`
+# invocation pulls hundreds of MB from the BB remote cache.
+# Compression typically halves on-the-wire bytes for Rust artifacts (rlibs +
+# debug info) at modest CPU cost, which we have spare on the GH runners and
+# locally.
+# BuildBuddy supports zstd on both ends.
+build --remote_cache_compression
+
 # Workspace status: populates COMMIT_SHA and REPO_URL for BuildBuddy flake detection.
 build --workspace_status_command="bash workspace_status.sh"
 

--- a/.bazelrc.user.template
+++ b/.bazelrc.user.template
@@ -5,3 +5,10 @@ build --remote_cache=grpcs://remote.buildbuddy.io
 build --remote_header=x-buildbuddy-api-key=YOUR_KEY_HERE
 build --bes_backend=grpcs://remote.buildbuddy.io
 build --bes_results_url=https://app.buildbuddy.io/invocation/
+
+# Optional: richer Chrome-trace profile in BuildBuddy's timing view.
+# Costs slightly larger BES uploads per invocation; useful when chasing a slow
+# target. Uncomment for the session, then re-comment to keep BES streams lean.
+# build --noslim_profile
+# build --experimental_profile_include_target_label
+# build --experimental_profile_include_primary_output


### PR DESCRIPTION
## Summary

Adds `build --remote_cache_compression` to `.bazelrc` (workspace-wide, dev + CI), and a commented-out hint in `.bazelrc.user.template` for the optional diagnostic profile flags.

## Why

BuildBuddy's UI flagged the build as cache-enabled but not opting into wire-level compression.
Our CI is network-bound, not CPU-bound: a single `coverage //...` invocation pulls hundreds of MB from the BB remote cache — the just-landed ci_health instrumentation captured 504 MB downloaded on a 148 s job, ~3.4 MB/s sustained, well below the runner's network ceiling.

zstd compression on Rust artifacts (rlibs, debug info, BES blobs) typically halves on-the-wire bytes at modest CPU cost.
GH runners have spare CPU; the trade is favourable.
BuildBuddy supports zstd on both ends.

The flag has been default-off in Bazel only because Google's internal builds tend to be CPU-bound, which isn't our profile.

## What changed

- `.bazelrc`: workspace-wide `build --remote_cache_compression` (with comment block explaining why).
- `.bazelrc.user.template`: optional Chrome-trace profile flags (`--noslim_profile`, `--experimental_profile_include_target_label`, `--experimental_profile_include_primary_output`) added as commented-out hints — useful for chasing a slow target locally, costly enough in BES upload size that they shouldn't be always-on.

## Validation

Once this lands, the ci_health baseline (PRs #312–#320, #327) will measure the actual reduction in `remote_bytes_downloaded` on subsequent runs.
Easy to roll back if CPU becomes the new bottleneck.

## Test plan

- [x] `tools/coverage.sh //...` green.
- [ ] After merge: confirm CI builds still pass.
- [ ] After merge + a few runs: compare ci_health-reported `remote_bytes_downloaded` against the pre-flag baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)