### PR TITLE
tools: print cached green file path on coverage cache hit

### DIFF
--- a/tools/coverage.sh
+++ b/tools/coverage.sh
@@ -27,7 +27,9 @@ MIN_PCT=25
 # patch to verify.
 #
 # Cache lives in .coverage-green/ (gitignored), one file per key. A
-# conflicted working copy is never cached.
+# conflicted working copy is never cached. The cache-hit message prints
+# the full path of the green-marker file so `rm <printed-path>` is the
+# direct override knob when you want to force a real re-run.
 GREEN_CACHE_DIR=".coverage-green"
 CACHE_KEY=""
 # Shortest unambiguous jj change id of @, captured up front so the success
@@ -61,7 +63,7 @@ if jj_conflicts="$(jj log -r '@ & conflicts()' --no-graph -T commit_id 2>/dev/nu
 		sha256sum | awk '{print $1}')"
 fi
 if [[ -n "$CACHE_KEY" && -f "$GREEN_CACHE_DIR/$CACHE_KEY" ]]; then
-	echo "coverage ok${CHANGE_ID:+ ($CHANGE_ID)}: unchanged since last green (key ${CACHE_KEY:0:12})"
+	echo "coverage ok${CHANGE_ID:+ ($CHANGE_ID)}: unchanged since last green ($GREEN_CACHE_DIR/$CACHE_KEY)"
 	exit 0
 fi
 


### PR DESCRIPTION
## Summary

On a coverage-cache hit, `tools/coverage.sh` now prints the full path of the green-marker file instead of just a truncated hash prefix.
Removing that file becomes the direct override knob — no `COVERAGE_NO_CACHE=1` env var, no `rm -rf .coverage-green` shotgun.

## Before / after

Before:
```
coverage ok (lp): unchanged since last green (key 45db854ac477)
```

After:
```
coverage ok (lp): unchanged since last green (.coverage-green/45db854ac477a4471c3c4c68a7dd9f61e2e2559340dbd9687d8a3a07aff1f4be)
```

## Why

When you suspect the cache lying and want to force a real re-run, the cache-hit line should tell you *exactly* what to delete.
A truncated hash means "go look up which file matches this prefix, then `rm` it" — friction.
The full path means copy-paste and delete.

This also makes the override knob discoverable from the output itself, not a script-internal env var that no-one remembers.

## What changed

- The cache-hit `echo` now uses `$GREEN_CACHE_DIR/$CACHE_KEY` instead of `${CACHE_KEY:0:12}`.
- The header comment near the cache-hit logic documents the rm-printed-path convention.

## Test plan

- [x] `rm -rf .coverage-green && tools/coverage.sh //...` — full run, writes a green entry.
- [x] `tools/coverage.sh //...` — second run prints the cache-hit line with the full file path; verified the printed path exists on disk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)