### PR TITLE
tools: coverage cache skips empty @ above a merge instead of erroring

### DIFF
--- a/tools/coverage.sh
+++ b/tools/coverage.sh
@@ -43,6 +43,23 @@ if jj_conflicts="$(jj log -r '@ & conflicts()' --no-graph -T commit_id 2>/dev/nu
 		parent_ids="$(jj log -r "$target-" --no-graph -T 'commit_id ++ "\n"' 2>/dev/null)"
 		parent_count=$(printf '%s' "$parent_ids" | grep -c . || true)
 		if [[ "$parent_count" -ne 1 ]]; then
+			# Walked up empty diffs and hit either a merge (2+ parents) or the
+			# root (0 parents). Two cases:
+			#
+			# - In immutable history (e.g. master itself, which is a chain of
+			#   GH-merged PR commits with multiple parents). Unfixable by the
+			#   user — master can't be rebased to stop being a merge. Treat as
+			#   no-op success so the Stop hook doesn't block on a transient
+			#   navigation state (common right after `jj rebase -r 'mutable()'
+			#   -d master` leaves `@` empty on top of a synthetic merge).
+			#
+			# - In mutable history (e.g. a user-constructed WIP merge-of-all-
+			#   work). The user can rebase or otherwise resolve this; surfacing
+			#   it as an error is the right signal.
+			if jj log -r "$target & immutable()" --no-graph -T commit_id 2>/dev/null | grep -q .; then
+				echo "coverage skipped${CHANGE_ID:+ ($CHANGE_ID)}: nothing to verify — $target is in immutable history with empty diff and $parent_count parent(s)"
+				exit 0
+			fi
 			echo "error: $target has empty diff and $parent_count parent(s); cannot determine what to verify" >&2
 			exit 1
 		fi


### PR DESCRIPTION
## Summary

When `tools/coverage.sh` walks up empty-diff ancestors and lands on a merge in **immutable** history (e.g. `master`, which is a chain of GH-merged PR commits), exit 0 with `coverage skipped …` instead of exit 1 with `error: …`.
A user-constructed WIP merge in mutable space still errors — that one is fixable.

## Why

Master is immutable and can't be rebased to stop being a merge.
After `jj rebase -r 'mutable()' -d master` the working copy often lands as an empty change directly above master.
The walk-up logic then hits master, sees 2+ parents and an empty diff, and previously exited 1.

The Stop hook runs this script after every assistant turn — exit 1 blocks the hook with a state the user can't act on.
Treating an immutable-history dead-end as no-op success matches the actual semantics: nothing changed, so nothing failed.

A WIP merge (e.g. the `merge-of-all-work` pattern in the jj skill) is different — the user constructed it deliberately and can rebase it.
That case keeps the existing error behaviour so the user gets a signal they need to act.

## Discriminator

`jj log -r "$target & immutable()"` — non-empty result means the target is in immutable history (≈ ancestors of `trunk()` / `master`), and the empty-diff dead-end is unfixable.
Empty result means the target is in mutable space, and the error stays.

## Before / after

Trigger: empty `@` whose parent is `master`, which is itself a merge commit from the GH merge queue.

Before:
```
$ tools/coverage.sh //...
error: @- has empty diff and 2 parent(s); cannot determine what to verify
$ echo $?
1
```

After:
```
$ tools/coverage.sh //...
coverage skipped (ab): nothing to verify — @- is in immutable history with empty diff and 2 parent(s)
$ echo $?
0
```

## Test plan

- [x] Manual: in `jj new master` state where master is a merge commit, walk-up hits master, immutability check matches, exit 0.
- [x] Confirmed `master & immutable()` returns master via `jj log` directly.
- [ ] Mutable WIP merge case: not directly exercised here, fix is by inspection — the existing `exit 1` branch is preserved when the immutability check fails.

🤖 Generated with [Claude Code](https://claude.com/claude-code)