### PR TITLE
ci: pass absolute --out path to ci_health record

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -71,6 +71,10 @@ jobs:
           bazelisk-cache: true
           disk-cache: ${{ github.workflow }}-ci-metrics
           repository-cache: true
+      # `--out` must be absolute: `bazel run` invokes the binary with cwd
+      # inside the runfiles tree, not GITHUB_WORKSPACE, so a relative path
+      # lands in `~/.cache/bazel/.../ci_health.runfiles/_main/` where
+      # upload-artifact can't see it.
       - name: Record CI metrics
         continue-on-error: true
         env:
@@ -80,7 +84,7 @@ jobs:
           bazel run $BB_FLAGS //tools/ci_health -- record \
             --run-id ${{ github.run_id }} \
             --job build \
-            --out ci-metrics.json \
+            --out "${{ github.workspace }}/ci-metrics.json" \
             ${{ github.event.pull_request.number && format('--pr {0}', github.event.pull_request.number) || '' }}
       - name: Upload CI metrics artifact
         continue-on-error: true


### PR DESCRIPTION
## Summary

#338 fixed the 404-on-job-logs bug, but the ci-metrics job still uploaded no artifact:

```
No files were found with the provided path: ci-metrics.json. No artifacts will be uploaded.
```

`bazel run` invokes the target binary with cwd inside the runfiles tree, not `GITHUB_WORKSPACE`. So a relative `--out ci-metrics.json` lands in `~/.cache/bazel/.../ci_health.runfiles/_main/ci-metrics.json` — invisible to upload-artifact. Verified locally too: relative path always writes inside the bazel cache.

Pass an absolute `${{ github.workspace }}/ci-metrics.json` so record and upload agree on a real path.

## Test plan
- [ ] CI green on this PR
- [ ] PR's own `ci-metrics` job uploads a `ci-metrics-<run-id>` artifact (visible in run summary)
- [ ] After merge: `bazel run //tools/ci_health -- query --branch master --last 3` returns real data