### PR TITLE
ci_health: extract gh_token helper

### DIFF
--- a/tools/ci_health/src/github.rs
+++ b/tools/ci_health/src/github.rs
@@ -8,6 +8,18 @@ use octocrab::Octocrab;
 pub const OWNER: &str = "causes-tracker";
 pub const REPO: &str = "causes-tracker";
 
+/// Read a GitHub PAT from `GH_TOKEN` (what `gh auth token` writes) or `GITHUB_TOKEN` (what GH Actions injects).
+/// `subcommand` is folded into the error message so the user sees which call needed the credential.
+pub fn token_from_env(subcommand: &str) -> Result<String> {
+    std::env::var("GH_TOKEN")
+        .or_else(|_| std::env::var("GITHUB_TOKEN"))
+        .with_context(|| {
+            format!(
+                "GH_TOKEN or GITHUB_TOKEN must be set for the {subcommand} subcommand (try `export GH_TOKEN=$(gh auth token)`)"
+            )
+        })
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct RunMetadata {
     pub head_sha: CommitSha,

--- a/tools/ci_health/src/main.rs
+++ b/tools/ci_health/src/main.rs
@@ -13,7 +13,7 @@ use crate::buildbuddy::BuildBuddyClient;
 use crate::comparison::{
     Baseline, COMMENT_MARKER, Verdict, classify, load_baseline_dir, render_pr_comment,
 };
-use crate::github::{GithubClient, OWNER, REPO};
+use crate::github::{GithubClient, OWNER, REPO, token_from_env};
 use crate::metrics::{RunId, RunMetrics};
 use octocrab::Octocrab;
 use octocrab::models::CommentId;
@@ -99,9 +99,7 @@ async fn main() -> Result<()> {
             job,
             pr,
         } => {
-            let token = std::env::var("GH_TOKEN")
-                .or_else(|_| std::env::var("GITHUB_TOKEN"))
-                .context("GH_TOKEN or GITHUB_TOKEN must be set for the record subcommand")?;
+            let token = token_from_env("record")?;
             let bb_key = safelog::Sensitive::new(
                 std::env::var("BUILDBUDDY_API_KEY")
                     .context("BUILDBUDDY_API_KEY must be set for the record subcommand")?,
@@ -173,9 +171,7 @@ fn compare(current: &std::path::Path, baseline_dir: &std::path::Path) -> Result<
 }
 
 async fn pr_comment(current: &std::path::Path, window: usize, pr: u64) -> Result<()> {
-    let token = std::env::var("GH_TOKEN")
-        .or_else(|_| std::env::var("GITHUB_TOKEN"))
-        .context("GH_TOKEN or GITHUB_TOKEN must be set for the pr-comment subcommand")?;
+    let token = token_from_env("pr-comment")?;
 
     let cur_text =
         std::fs::read_to_string(current).with_context(|| format!("read {}", current.display()))?;
@@ -256,9 +252,7 @@ struct QueryArgs {
 }
 
 async fn query(args: QueryArgs) -> Result<()> {
-    let token = std::env::var("GH_TOKEN")
-        .or_else(|_| std::env::var("GITHUB_TOKEN"))
-        .context("GH_TOKEN or GITHUB_TOKEN must be set (try `export GH_TOKEN=$(gh auth token)`)")?;
+    let token = token_from_env("query")?;
     let artifacts = ArtifactClient::new(token.clone(), OWNER.into(), REPO.into())?;
 
     if args.baseline {


### PR DESCRIPTION
## Summary

`pr_comment` and `query` have identical 4-line preambles to read the `GH_TOKEN` env var. PR #319's `trend_cmd` was about to add a third copy.

Factor into `github::token_from_env(subcommand)`. Unifies the error message and folds in the previously-query-only `try \`export GH_TOKEN=$(gh auth token)\`` hint for every site.

## Test plan
- [ ] `bazel test //tools/ci_health/...` green
- [ ] `bazel run //tools/ci_health -- query --baseline` works against live GitHub