### PR TITLE
check.sh: detect new langs, bazelrc -A, BUILD tags

### DIFF
--- a/tools/check.sh
+++ b/tools/check.sh
@@ -51,10 +51,14 @@ SKIP_FILES=(
 
 # Patterns the agent scanner flags when added on a `+` line.
 # Each is a POSIX ERE matched by awk against the line body (minus the +).
+# Backslashes are doubled: `awk -v var=value` strips one level of escapes
+# before the value becomes a regex, and stricter awks (CI's mawk emits
+# `escape sequence '\[' treated as plain '['`) otherwise leave a bare `[`
+# in the pattern and fail to compile it.
 SUPPRESSION_LINE_PATTERNS=(
 	'# *shellcheck +disable'        # bash
-	'#!?\[allow\('                  # rust attribute (item or crate)
-	'#\[ignore(\]|\()'              # rust #[ignore] or #[ignore("...")]
+	'#!?\\[allow\\('                # rust attribute (item or crate)
+	'#\\[ignore(\\]|\\()'           # rust #[ignore] or #[ignore("...")]
 	'// *eslint-disable'            # js/ts
 	'// *@ts-(ignore|expect-error)' # ts
 	'(^|[ \t])# *noqa([: ]|$)'      # python
@@ -71,6 +75,21 @@ SUPPRESSION_GATE_FILES=(
 	".shellcheckrc"
 	".yamlfmt"
 	"tools/check.sh"
+)
+
+# Patterns matched on `+` lines whose file is `.bazelrc` or `.bazelrc.user`.
+# Targeted at lint-allow flags (rustc/clippy `-A`); we do NOT flag the file
+# itself, since legitimate cache/network/toolchain config lives here too.
+SUPPRESSION_BAZELRC_PATTERNS=(
+	'(^|[ \t=,])-A(warnings|clippy|[ \t=,])' # rustc/clippy lint-allow
+)
+
+# Patterns matched on `+` lines whose basename is `BUILD.bazel`.
+# These are the test-evasion attributes a human reviewer would want to see
+# flagged at the door, since they detach a target from the default build.
+SUPPRESSION_BUILDBAZEL_PATTERNS=(
+	'tags *= *\\[[^]]*"(manual|no-ci|flaky)"' # opt-out tags on tests
+	'target_compatible_with *= *'             # platform-incompatible carve-out
 )
 
 # Argument parsing is deferred until after the function definitions so that
@@ -154,13 +173,28 @@ compute_cache_key() {
 scan_diff_for_suppressions() {
 	awk \
 		-v line_patterns="$(printf '%s\n' "${SUPPRESSION_LINE_PATTERNS[@]}")" \
-		-v gate_files="$(printf '%s\n' "${SUPPRESSION_GATE_FILES[@]}")" '
+		-v gate_files="$(printf '%s\n' "${SUPPRESSION_GATE_FILES[@]}")" \
+		-v bazelrc_patterns="$(printf '%s\n' "${SUPPRESSION_BAZELRC_PATTERNS[@]}")" \
+		-v buildbazel_patterns="$(printf '%s\n' "${SUPPRESSION_BUILDBAZEL_PATTERNS[@]}")" \
+		-v master_exts="${MASTER_FILE_EXTENSIONS:-}" '
 BEGIN {
 	n_line = split(line_patterns, line_pat, "\n")
 	n_gate = split(gate_files, gate_arr, "\n")
 	for (i = 1; i <= n_gate; i++) gate_set[gate_arr[i]] = 1
+	n_bazelrc = split(bazelrc_patterns, bazelrc_pat, "\n")
+	n_buildbazel = split(buildbazel_patterns, buildbazel_pat, "\n")
+	n_master_ext = split(master_exts, ext_arr, ",")
+	have_master_exts = 0
+	for (i = 1; i <= n_master_ext; i++) {
+		if (ext_arr[i] != "") {
+			master_ext_set[ext_arr[i]] = 1
+			have_master_exts = 1
+		}
+	}
 	n_violations = 0
 	file = ""
+	is_bazelrc = 0
+	is_buildbazel = 0
 }
 /^diff --git a\// {
 	file = $0
@@ -168,6 +202,21 @@ BEGIN {
 	sub(/ b\/.*$/, "", file)
 	if (file in gate_set) {
 		violations[n_violations++] = file ": edits to a quality-gate config file"
+	}
+	base = file
+	sub(/.*\//, "", base)
+	is_bazelrc = (file == ".bazelrc" || file == ".bazelrc.user")
+	is_buildbazel = (base == "BUILD.bazel")
+	# New-language detection: extension not seen in master is a likely
+	# bypass via the simple "switch language to dodge the existing gates"
+	# route. Only runs when the harness supplied master_exts (i.e. agent
+	# mode against a real jj tree, not synthetic test diffs).
+	if (have_master_exts && index(base, ".") > 0) {
+		ext = base
+		sub(/^.*\./, "", ext)
+		if (!(ext in master_ext_set)) {
+			violations[n_violations++] = file ": introduces file extension '." ext "' not present in master (new language?)"
+		}
 	}
 	next
 }
@@ -177,6 +226,20 @@ BEGIN {
 	for (i = 1; i <= n_line; i++) {
 		if (line_pat[i] != "" && body ~ line_pat[i]) {
 			violations[n_violations++] = file ": + matches /" line_pat[i] "/"
+		}
+	}
+	if (is_bazelrc) {
+		for (i = 1; i <= n_bazelrc; i++) {
+			if (bazelrc_pat[i] != "" && body ~ bazelrc_pat[i]) {
+				violations[n_violations++] = file ": + matches /" bazelrc_pat[i] "/ (lint-allow flag in bazelrc)"
+			}
+		}
+	}
+	if (is_buildbazel) {
+		for (i = 1; i <= n_buildbazel; i++) {
+			if (buildbazel_pat[i] != "" && body ~ buildbazel_pat[i]) {
+				violations[n_violations++] = file ": + matches /" buildbazel_pat[i] "/ (suspect BUILD attribute)"
+			}
 		}
 	}
 }
@@ -198,7 +261,16 @@ run_agent_scan() {
 		exit 1
 	fi
 	[[ -z "$diff" ]] && return 0
-	printf '%s\n' "$diff" | scan_diff_for_suppressions
+	# Comma-separated set of extensions present in master, used by the
+	# new-language detector. Computed once per agent run; cheap (a single
+	# jj invocation listing tracked paths).
+	local master_exts
+	master_exts="$(jj file list -r master 2>/dev/null |
+		awk -F/ '{print $NF}' |
+		awk -F. 'NF > 1 { print $NF }' |
+		sort -u | tr '\n' ',')"
+	MASTER_FILE_EXTENSIONS="$master_exts" \
+		scan_diff_for_suppressions <<<"$diff"
 }
 
 # ── individual gates ──────────────────────────────────────────────────────

--- a/tools/test_check_scan.sh
+++ b/tools/test_check_scan.sh
@@ -251,6 +251,117 @@ case_fail "two suppressions on two added lines" 'diff --git a/x.rs b/x.rs
 +#[ignore]
 '
 
+# ── .bazelrc content (file edits OK, lint-allow flags NOT) ────────────────
+
+case_fail ".bazelrc adds -A warnings" 'diff --git a/.bazelrc b/.bazelrc
+--- a/.bazelrc
++++ b/.bazelrc
+@@ -1 +1,2 @@
+ build --remote_cache=https://example
++build --@rules_rust//:extra_rustc_flags=-A,warnings
+'
+
+case_fail ".bazelrc.user adds -A clippy::all" 'diff --git a/.bazelrc.user b/.bazelrc.user
+--- a/.bazelrc.user
++++ b/.bazelrc.user
+@@ -1 +1,2 @@
+ build --jobs=8
++build --rustc-flag=-Aclippy::all
+'
+
+case_pass ".bazelrc benign cache config" 'diff --git a/.bazelrc b/.bazelrc
+--- a/.bazelrc
++++ b/.bazelrc
+@@ -1 +1,2 @@
+ build --remote_cache=https://example
++build --remote_upload_local_results=true
+'
+
+# ── BUILD.bazel suspect attributes ────────────────────────────────────────
+
+case_fail "BUILD.bazel adds tags = [\"manual\"]" 'diff --git a/lib/x/BUILD.bazel b/lib/x/BUILD.bazel
+--- a/lib/x/BUILD.bazel
++++ b/lib/x/BUILD.bazel
+@@ -1,3 +1,4 @@
+ rust_test(
+     name = "foo",
++    tags = ["manual"],
+ )
+'
+
+case_fail "BUILD.bazel adds target_compatible_with" 'diff --git a/lib/x/BUILD.bazel b/lib/x/BUILD.bazel
+--- a/lib/x/BUILD.bazel
++++ b/lib/x/BUILD.bazel
+@@ -1,3 +1,4 @@
+ rust_test(
+     name = "foo",
++    target_compatible_with = ["@platforms//os:macos"],
+ )
+'
+
+case_pass "BUILD.bazel adds a normal dep" 'diff --git a/lib/x/BUILD.bazel b/lib/x/BUILD.bazel
+--- a/lib/x/BUILD.bazel
++++ b/lib/x/BUILD.bazel
+@@ -1,3 +1,4 @@
+ rust_test(
+     name = "foo",
++    deps = ["//lib/bar"],
+ )
+'
+
+# ── new-language detection (driven by MASTER_FILE_EXTENSIONS) ─────────────
+
+run_with_master_exts() {
+	local name="$1" expected="$2" diff="$3"
+	local out rc=0
+	out="$(printf '%s' "$diff" |
+		MASTER_FILE_EXTENSIONS="rs,sh,py,toml,md,bzl" scan_diff_for_suppressions 2>&1)" || rc=$?
+	if [[ "$rc" == "$expected" ]]; then
+		echo "PASS: $name"
+		((PASS++)) || true
+	else
+		echo "FAIL: $name — expected rc=$expected, got $rc"
+		printf '%s\n' "$out"
+		((FAIL++)) || true
+	fi
+}
+case_fail_with_master_exts() { run_with_master_exts "$1" 1 "$2"; }
+case_pass_with_master_exts() { run_with_master_exts "$1" 0 "$2"; }
+
+case_fail_with_master_exts "new .go file flagged when master lacks .go" 'diff --git a/lib/x/main.go b/lib/x/main.go
+new file mode 100644
+--- /dev/null
++++ b/lib/x/main.go
+@@ -0,0 +1,1 @@
++package main
+'
+
+case_pass_with_master_exts "new .rs file fine (extension exists in master)" 'diff --git a/lib/x/y.rs b/lib/x/y.rs
+new file mode 100644
+--- /dev/null
++++ b/lib/x/y.rs
+@@ -0,0 +1,1 @@
++fn foo() {}
+'
+
+case_pass_with_master_exts "modify .rs file (existing extension)" 'diff --git a/lib/x/y.rs b/lib/x/y.rs
+--- a/lib/x/y.rs
++++ b/lib/x/y.rs
+@@ -1 +1 @@
+-fn foo() {}
++fn bar() {}
+'
+
+# Without master_exts set, language detector is a no-op (default fall-back
+# for synthetic-diff tests that don't care about the language gate).
+case_pass "new .go file passes when master_exts unset" 'diff --git a/lib/x/main.go b/lib/x/main.go
+new file mode 100644
+--- /dev/null
++++ b/lib/x/main.go
+@@ -0,0 +1,1 @@
++package main
+'
+
 # ── summary ───────────────────────────────────────────────────────────────
 
 echo ""


### PR DESCRIPTION
## Summary

Three bypass categories weren't caught by the existing lexical suppression-marker scanner:

- **New language.** A `+` file whose extension is absent from master — the textbook "switch to Go to dodge the Rust gates" route. The language detector compares the diff's file extensions against master's tracked-file extension set, computed once per agent run via `jj file list -r master`.
- **rustc/clippy `-A` flag in `.bazelrc{,.user}`.** A single `-A warnings` or `-Aclippy::all` line silently undoes the project-wide `-Dwarnings` policy without editing any listed gate-config file. The new pattern fires only when the file is `.bazelrc` or `.bazelrc.user`, leaving legitimate cache/network/toolchain config alone.
- **Test-evasion attributes on `BUILD.bazel`.** `tags = ["manual"|"no-ci"|"flaky"]` or `target_compatible_with = …` on a test target detaches it from the default `//...` build. Patterns fire only in `BUILD.bazel` files.

When the harness doesn't supply a master-extension set (synthetic-diff unit tests), the language detector is a no-op, so the existing fixture suite is unaffected.

Ten new cases in `test_check_scan.sh` cover positive and negative paths for each gate; full suite is 34/34 green.

## What's deliberately out of scope

- Other-language suppression markers (`//nolint`, `@SuppressWarnings`, etc.) — covered transitively by the new-language gate, which flags introducing the language itself.
- `.github/workflows/**.yml` — PRs must pass locally first, which already exercises the relevant checks.
- `.claude/rules/**` and `CLAUDE.md` — Claude is allowed to self-modify; the auto-classifier handles this layer.

## Test plan

- [x] `bazel test //tools:check_scan_test` — 34/34 pass (10 new).
- [x] `tools/check.sh agent` correctly flags this PR's own edit to `tools/check.sh` (gate-file guard unchanged).
- [ ] On merge, future PRs introducing a `.go` / `.kt` / etc. trip the new-language gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)