### PR TITLE
check.sh: lint captured bazel runs for --quiet

### DIFF
--- a/tools/check.sh
+++ b/tools/check.sh
@@ -18,9 +18,10 @@
 # The gates, in order:
 #   1. No BUILD.bazel file may load @rules_rs directly — use //build:rust.bzl.
 #   2. Every Bazel package must have a README.md.
-#   3. //:format.check (every formatter the project configures).
-#   4. bazel coverage --lockfile_mode=error (runs every test).
-#   5. Per-file Rust coverage threshold (MIN_PCT).
+#   3. Output-captured `bazel run|build` invocations use `--quiet`.
+#   4. //:format.check (every formatter the project configures).
+#   5. bazel coverage --lockfile_mode=error (runs every test).
+#   6. Per-file Rust coverage threshold (MIN_PCT).
 #
 # Usage:
 #   tools/check.sh ci    [bazel-flags...] [target...]
@@ -287,6 +288,10 @@ check_package_readmes() {
 	bash tools/require_readme_test.sh
 }
 
+check_bazel_quiet() {
+	bash tools/require_bazel_quiet_test.sh
+}
+
 run_format_check() {
 	bazel run "${BAZEL_FLAGS[@]}" //:format.check
 }
@@ -381,6 +386,7 @@ enforce_per_file_coverage() {
 run_all_gates() {
 	check_rules_rs_macros
 	check_package_readmes
+	check_bazel_quiet
 	run_format_check
 	run_bazel_coverage
 	enforce_per_file_coverage

--- a/tools/require_bazel_quiet_test.sh
+++ b/tools/require_bazel_quiet_test.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# Flags `bazel run|build` whose stdout is captured by $(...) without
+# `--quiet` between `bazel` and the subcommand.
+#
+# Usage: tools/require_bazel_quiet_test.sh
+#   Run from the workspace root (same as check.sh).
+set -uo pipefail
+
+violations_file="$(mktemp)"
+trap 'rm -f "$violations_file"' EXIT
+
+while IFS= read -r file; do
+	awk -v file="$file" '
+		file ~ /\.sh$/ && /^[[:space:]]*#/ { next }
+		/\$\([^)]*bazel/ {
+			if ($0 !~ /bazel[[:space:]]+(--[^[:space:]]+[[:space:]]+)*(run|build)[[:space:]]/) next
+			if ($0 ~ /bazel[[:space:]]+(--[^[:space:]]+[[:space:]]+)*--quiet/) next
+			print file ":" NR ": output-captured bazel run/build missing --quiet"
+			print "    " $0
+		}
+	' "$file"
+done < <(find . -type f \( -name '*.sh' -o -name '*.md' \) \
+	-not -path './bazel-*' \
+	-not -path './.git/*' \
+	-not -path './node_modules/*' |
+	sort) >"$violations_file"
+
+if [[ -s "$violations_file" ]]; then
+	echo "FAIL: bazel run/build commands missing --quiet:" >&2
+	cat "$violations_file" >&2
+	echo "" >&2
+	echo "Fix: add --quiet between 'bazel' and the subcommand" >&2
+	echo "(e.g. \`bazel --quiet run //infra:tofu -- output -raw foo\`)." >&2
+	exit 1
+fi
+
+echo "bazel-quiet ok: all output-captured bazel run/build commands use --quiet"


### PR DESCRIPTION
## Summary

Adds gate `check_bazel_quiet` to `tools/check.sh`, wired in `run_all_gates` between `check_package_readmes` and `run_format_check`.

New script `tools/require_bazel_quiet_test.sh` walks tracked `.sh` and `.md` files, skips shell comment lines, and flags any line where `bazel run|build` output is captured by `$(...)` without `--quiet` between `bazel` and the subcommand. Exits non-zero with `file:line: offending line` listing on violation.

Zero violations on master at time of writing.

## Test plan

- [x] `bash tools/require_bazel_quiet_test.sh` returns 0 on master.
- [ ] `FOO=$(bazel run //tools:cargo -- --version)` injected anywhere trips the lint.
- [ ] Adding `--quiet` (`FOO=$(bazel --quiet run //tools:cargo -- --version)`) makes it pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)