### PR TITLE
check.sh: structured per-gate timing summary

### DIFF
--- a/tools/check.sh
+++ b/tools/check.sh
@@ -31,6 +31,10 @@
 # Anything starting with `-` is treated as a bazel flag (forwarded to
 # format.check and coverage); the rest is treated as bazel targets
 # (forwarded only to coverage).  Default target is //....
+#
+# A per-gate timing summary is printed to stderr at exit.  Setting
+# CHECK_TIMING_JSONL=<path> additionally appends one JSON object per
+# gate (`{"gate":"…","rc":N,"seconds":N.NNN}`) to that path.
 
 set -euo pipefail
 
@@ -383,13 +387,48 @@ enforce_per_file_coverage() {
 	echo "check ok${CHANGE_ID:+ ($CHANGE_ID)}: ${#disk_files[@]} Rust source file(s) checked, all >= ${MIN_PCT}%"
 }
 
+# Per-gate wall-clock timings, populated by run_gate.
+# Emitted as a summary to stderr at exit (via the EXIT trap below) and,
+# when CHECK_TIMING_JSONL is set, appended as one JSON object per gate
+# to that path.
+TIMINGS=()
+
+run_gate() {
+	local name="$1"
+	shift
+	local start end elapsed rc=0
+	start="$EPOCHREALTIME"
+	"$@" || rc=$?
+	end="$EPOCHREALTIME"
+	elapsed=$(awk "BEGIN {printf \"%.3f\", $end - $start}")
+	TIMINGS+=("$name"$'\t'"$rc"$'\t'"$elapsed")
+	if [[ -n "${CHECK_TIMING_JSONL:-}" ]]; then
+		printf '{"gate":"%s","rc":%s,"seconds":%s}\n' \
+			"$name" "$rc" "$elapsed" >>"$CHECK_TIMING_JSONL"
+	fi
+	return $rc
+}
+
+emit_timing_summary() {
+	[[ ${#TIMINGS[@]} -eq 0 ]] && return 0
+	local total=0 t n r s
+	printf '\nGate timings:\n' >&2
+	for t in "${TIMINGS[@]}"; do
+		IFS=$'\t' read -r n r s <<<"$t"
+		printf '  %-24s rc=%s %8ss\n' "$n" "$r" "$s" >&2
+		total=$(awk "BEGIN {printf \"%.3f\", $total + $s}")
+	done
+	printf '  %-24s     %8ss\n' "TOTAL" "$total" >&2
+}
+trap emit_timing_summary EXIT
+
 run_all_gates() {
-	check_rules_rs_macros
-	check_package_readmes
-	check_bazel_quiet
-	run_format_check
-	run_bazel_coverage
-	enforce_per_file_coverage
+	run_gate rules_rs_macros check_rules_rs_macros
+	run_gate package_readmes check_package_readmes
+	run_gate bazel_quiet check_bazel_quiet
+	run_gate format_check run_format_check
+	run_gate bazel_coverage run_bazel_coverage
+	run_gate per_file_coverage enforce_per_file_coverage
 }
 
 # ── dispatch ──────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Adds a `run_gate <name> <fn>` wrapper to `tools/check.sh` that captures wall-clock time via `$EPOCHREALTIME` and records `<name, rc, seconds>` into a `TIMINGS` array. Each gate in `run_all_gates` is now invoked through `run_gate`, and an `EXIT` trap prints a per-gate summary table to stderr.

When `CHECK_TIMING_JSONL=<path>` is set, `run_gate` additionally appends one JSON object per gate to that path (`{"gate":"…","rc":N,"seconds":N.NNN}`) for downstream consumption by ci_health or similar tooling.

The wrapper re-raises the gate's exit code so `set -e` still aborts on the first failure; the trap fires regardless, so the summary shows partial timings on failure as well.

Sample output:
```
Gate timings:
  rules_rs_macros          rc=0   0.012s
  package_readmes          rc=0   0.031s
  bazel_quiet              rc=0   0.018s
  format_check             rc=0   4.221s
  bazel_coverage           rc=0  42.106s
  per_file_coverage        rc=0   0.187s
  TOTAL                          46.575s
```

## Test plan

- [x] Successful run: trap fires, summary correct, TOTAL = sum of gates.
- [x] Forced gate failure (`run_gate fail_demo false`): rc=1 captured, summary still prints via trap.
- [x] `CHECK_TIMING_JSONL=/tmp/t.jsonl` produces valid JSONL, one object per gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)