### PR TITLE
renovate: group sqlx + sqlx-cli into one PR

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -24,6 +24,13 @@
         "/^opentelemetry/"
       ],
       "groupName": "opentelemetry-rust"
+    },
+    {
+      "matchManagers": ["cargo"],
+      "matchPackageNames": [
+        "/^sqlx($|-)/"
+      ],
+      "groupName": "sqlx"
     }
   ],
   "customManagers": [


### PR DESCRIPTION
Group `sqlx` and `sqlx-cli` into one Renovate PR so version bumps land together.