### PR TITLE
hooks: block forbidden agent actions

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -2,6 +2,16 @@
   "hooks": {
     "PreToolUse": [
       {
+        "matcher": "Bash|Write|Edit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 tools/agent_action_guard.py",
+            "timeout": 10
+          }
+        ]
+      },
+      {
         "matcher": "Bash",
         "hooks": [
           {

--- a/tools/BUILD.bazel
+++ b/tools/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@rules_python//python:defs.bzl", "py_binary")
+load("@rules_python//python:defs.bzl", "py_binary", "py_library", "py_test")
 load("@rules_shell//shell:sh_binary.bzl", "sh_binary")
 load("@rules_shell//shell:sh_test.bzl", "sh_test")
 load("//build:rust.bzl", "rust_binary")
@@ -146,6 +146,33 @@ sh_test(
         "check.sh",
         "@bazel_tools//tools/bash/runfiles",
     ],
+)
+
+# PreToolUse action guard, wired into .claude/settings.json.  Denies forbidden
+# agent actions at the moment of action: native tooling instead of the Bazel
+# wrappers, lockfile destruction, and mod.rs creation.  Decision logic lives in
+# decide() so it is unit-testable without spawning a subprocess.
+py_library(
+    name = "agent_action_guard",
+    srcs = ["agent_action_guard.py"],
+    imports = ["."],
+)
+
+py_test(
+    name = "agent_action_guard_test",
+    size = "small",
+    srcs = ["agent_action_guard_test.py"],
+    data = [
+        "cargo.sh",
+        "proto_gen_impl.sh",
+        "rustc.sh",
+        "rustfmt.sh",
+        "sqlx.sh",
+        "sqlx_prepare_impl.sh",
+        "toolchain_versions_test.sh",
+    ],
+    main = "agent_action_guard_test.py",
+    deps = [":agent_action_guard"],
 )
 
 format_srcs()

--- a/tools/agent_action_guard.py
+++ b/tools/agent_action_guard.py
@@ -1,0 +1,664 @@
+#!/usr/bin/env python3
+"""PreToolUse guardrail: deny actions this repo forbids, at the moment of action.
+
+Wired into `.claude/settings.json` as a PreToolUse hook over Bash/Write/Edit.
+Reads the hook payload as JSON on stdin; on a denied action it prints the
+PreToolUse deny envelope and exits 0, otherwise it stays silent (allow).
+
+What it denies:
+
+- native build/infra/lint tooling (the `NATIVE_TOOLS` set: rust, db, infra,
+  proto, go, js, formatters, linters) instead of the hermetic Bazel wrappers;
+- destroying a lockfile (rm/truncate of MODULE.bazel.lock, Cargo.lock,
+  requirements_lock.txt);
+- creating a `mod.rs` instead of the `<dir>.rs` module layout.
+
+Bash is scanned *recursively* so indirection can't launder a forbidden call:
+the checks apply to the leading word of each `;`/`&&`/`||`/`|`/`&` segment and
+also through `sh -c`/`bash -c` strings, `xargs`/`find -exec`/`env`/`sudo`/
+`timeout`/... wrappers, and the post-`--` / `--run_under` arguments of `bazel`.
+Inline or stdin Python (`python -c`, `python -`, a bare REPL) is denied
+outright: arbitrary inline code can shell out and can't be verified.
+
+Written shell scripts (a Write/Edit of a `.sh` file or a shell shebang) are
+scanned the same way for native tooling and lockfile destruction, so a script
+that invokes native tooling by bare name is caught. A Bazel-hosted script that
+locates its tool via runfiles (`tool="$(rlocation …/cargo)"; exec "$tool"`)
+passes, because the tool name is never in command position — only an `rlocation`
+path argument. (The inline-Python deny is interactive-only: a heredoc
+`python3 - <<EOF` in a reviewed build script is a normal idiom, not a bypass.)
+
+Fails closed: a hook payload that can't be parsed as JSON, or an interactive
+command with a segment that can't be tokenized, is denied. Valid payloads and
+commands always parse, so this never fires in normal operation. When scanning
+written content, a segment that defeats the tokenizer is skipped instead, so a
+complex but legitimate script is not blocked by a weak parser.
+
+
+"""
+
+import json
+import re
+import shlex
+import sys
+
+# Native binaries that have a hermetic equivalent in this repo's Bazel
+# definitions and so must go through it instead.  Maps the binary name to the
+# wrapper to suggest in the denial reason.  Covers every toolchain/tool the repo
+# provides hermetically (rust, db, infra, proto, go, js, formatters, linters) —
+# not just the most common reaches.
+NATIVE_TOOLS = {
+    # Rust toolchain (@rust_host_tools).
+    "cargo": "bazel run //tools:cargo -- … (or `bazel build` for compilation)",
+    "rustc": "bazel run //tools:rustc -- …",
+    "rustfmt": "bazel run //:format (or //tools:rustfmt)",
+    # Database.
+    "psql": "bazel run //infra/postgres:psql -- …",
+    "sqlx": "bazel run //tools:sqlx -- …",
+    # Infrastructure.
+    "tofu": "bazel run //infra:tofu -- …",
+    "terraform": "bazel run //infra:tofu -- … (the repo uses OpenTofu)",
+    "aws": "bazel run //infra:aws -- …",
+    # Proto.
+    "protoc": "bazel run //tools:proto_gen (codegen via rules_proto)",
+    "buf": "bazel test //... (buf runs as the proto lint aspect)",
+    # Go (rules_go + gazelle).
+    "go": "bazel build (Go runs under rules_go; no native go on PATH)",
+    "gazelle": "bazel run //:gazelle",
+    # JavaScript (aspect_rules_js).
+    "node": "bazel build (JS runs under aspect_rules_js)",
+    "npm": "edit .devcontainer/pnpm-lock.yaml; JS deps run under aspect_rules_js",
+    "npx": "bazel build (JS tooling runs under aspect_rules_js)",
+    "pnpm": "edit .devcontainer/pnpm-lock.yaml; deps run under aspect_rules_js",
+    # Formatters (the //:format multirun).
+    "taplo": "bazel run //:format",
+    "shfmt": "bazel run //:format",
+    "yamlfmt": "bazel run //:format",
+    "ruff": "bazel run //:format",
+    "buildifier": "bazel run //:format",
+    # Linters (run as aspects / test targets).
+    "yamllint": "bazel test //... (yamllint runs as a lint aspect)",
+    "shellcheck": "bazel test //... (shellcheck runs as a lint aspect)",
+    "pymarkdown": "bazel test //... (markdown lint runs via a test target)",
+    # Java / TLA+ (hermetic Temurin JRE).
+    "java": "TLC/TLA+ tooling runs on the hermetic JRE (see //infra/tla)",
+    # Coverage tooling (@llvm).
+    "llvm-cov": "coverage runs via `bazel coverage` / tools/coverage.sh (llvm-cov is @llvm)",
+    "llvm-profdata": "coverage runs via `bazel coverage` / tools/coverage.sh (llvm-profdata is @llvm)",
+    # Python deps (rules_python).
+    "pip": "add deps to requirements.in and run `bazel run //:requirements.update`",
+    "pip3": "add deps to requirements.in and run `bazel run //:requirements.update`",
+}
+
+# PostgreSQL binaries from the hermetic tarball (infra/postgres).  Only psql has
+# a run wrapper; the rest have none, so they are not permitted — a missing
+# wrapper means the tool is off-limits, not exempt.
+_PG_NOT_PERMITTED = (
+    "//infra/postgres:psql for SQL — the other PostgreSQL binaries have no run "
+    "wrapper and are not permitted"
+)
+NATIVE_TOOLS.update(
+    dict.fromkeys(
+        (
+            "clusterdb",
+            "createdb",
+            "createuser",
+            "dropdb",
+            "dropuser",
+            "ecpg",
+            "initdb",
+            "oid2name",
+            "pg_amcheck",
+            "pg_archivecleanup",
+            "pg_basebackup",
+            "pgbench",
+            "pg_checksums",
+            "pg_combinebackup",
+            "pg_config",
+            "pg_controldata",
+            "pg_createsubscriber",
+            "pg_ctl",
+            "pg_dump",
+            "pg_dumpall",
+            "pg_isready",
+            "pg_receivewal",
+            "pg_recvlogical",
+            "pg_resetwal",
+            "pg_restore",
+            "pg_rewind",
+            "pg_test_fsync",
+            "pg_test_timing",
+            "pg_upgrade",
+            "pg_verifybackup",
+            "pg_waldump",
+            "pg_walsummary",
+            "postgres",
+            "reindexdb",
+            "vacuumdb",
+            "vacuumlo",
+        ),
+        _PG_NOT_PERMITTED,
+    )
+)
+
+# protoc-gen-doc: a protoc plugin (docs), no standalone wrapper — not permitted.
+NATIVE_TOOLS["protoc-gen-doc"] = (
+    "the //docs target — protoc-gen-doc is a plugin, not permitted as a standalone CLI"
+)
+
+# Lockfiles whose destruction is forbidden — regenerate them in place.
+LOCKFILES = {
+    "MODULE.bazel.lock": "bazel mod deps --lockfile_mode=update",
+    "Cargo.lock": "bazel run //tools:cargo -- generate-lockfile",
+    "requirements_lock.txt": "the requirements lockfile workflow",
+}
+
+# Shells whose `-c <string>` argument is itself a command to recurse into.
+_SHELLS = {"sh", "bash", "dash", "zsh", "ksh", "ash", "mksh"}
+
+# Verbs that destroy a file's contents.
+_DESTRUCTIVE_VERBS = {"rm", "unlink", "shred", "truncate"}
+
+# Commands that run a trailing (post-option) argument as a subcommand.
+_COMMAND_WRAPPERS = {
+    "env",
+    "sudo",
+    "doas",
+    "nohup",
+    "setsid",
+    "nice",
+    "ionice",
+    "stdbuf",
+    "time",
+    "command",
+    "exec",
+    "builtin",
+    "xargs",
+    "timeout",
+    "watch",
+}
+
+# python / python3 / python3.12 / python2 — matched on the basename.
+_PYTHON_RE = re.compile(r"^python[0-9.]*$")
+
+# A single `>` (truncate), not `>>` (append), pointing at a lockfile.
+_TRUNCATE_REDIRECT = re.compile(
+    r"(?<!>)>(?!>)\s*['\"]?(" + "|".join(re.escape(n) for n in LOCKFILES) + r")\b"
+)
+
+_MAX_DEPTH = 6
+
+_PYTHON_REASON = (
+    "Refusing inline/stdin Python (`-c`, `-`, or a bare REPL): it can shell out to "
+    "native tooling and can't be verified. Put the logic in a script file run "
+    "through the hermetic toolchain, or use the appropriate `bazel run` target."
+)
+
+_TOO_DEEP_REASON = "Refusing: command nests subcommands too deeply to verify; denying."
+
+_MOD_RS_REASON = (
+    "Refusing to create a `mod.rs`. This project uses the `<dir>.rs` module layout: "
+    "put the module in a sibling file (e.g. `foo.rs` with `foo/` for its submodules), "
+    "never `foo/mod.rs`."
+)
+
+# Written files scanned as shell: by extension, or by a shell shebang.
+_SHELL_EXTS = (".sh", ".bash", ".ksh", ".zsh", ".dash")
+
+# Shell keywords that introduce a command (skipped to reach the real command).
+_SHELL_KEYWORDS = {"if", "then", "elif", "else", "while", "until", "do", "!"}
+
+
+def _basename(token):
+    return token.rsplit("/", 1)[-1]
+
+
+def _is_assignment(token):
+    return re.match(r"^\w+=", token) is not None
+
+
+def _native_reason(base):
+    return (
+        f"Refusing native `{base}`. This repo is Bazel-only and native toolchains "
+        f"are not on PATH (results would be non-hermetic). Use: {NATIVE_TOOLS[base]}"
+    )
+
+
+def _lockfile_reason(name, deleting):
+    verb = "delete" if deleting else "truncate"
+    return (
+        f"Refusing to {verb} {name}. Regenerate it in place with {LOCKFILES[name]}; "
+        f"destroying it drops extension facts CI computes but this container cannot, "
+        f"so CI then rejects the lockfile."
+    )
+
+
+def _consume_inside_quote(command, i, quote):
+    """Inside an open quote: advance past one literal char, escape, or the closing quote."""
+    c = command[i]
+    if c == "\\" and quote == '"' and i + 1 < len(command):
+        return 2, quote
+    if c == quote:
+        return 1, None
+    return 1, quote
+
+
+def _consume_unquoted_special(command, i):
+    """Outside quotes: if `i` opens an escape or quote, advance past it; else None."""
+    c = command[i]
+    n = len(command)
+    if c == "\\" and i + 1 < n:
+        return 2, None
+    if c in ("'", '"'):
+        return 1, c
+    return None
+
+
+def _consume_quote_or_escape(command, i, quote):
+    """Advance past a quoted or escaped run at `i`; None if `i` is an ordinary char.
+
+    Shared by `_split_segments` and `_strip_comments` so the quote state machine
+    isn't duplicated.
+    """
+    if quote:
+        return _consume_inside_quote(command, i, quote)
+    return _consume_unquoted_special(command, i)
+
+
+def _split_segments(command):
+    """Split a command on shell operators (; && || | & newline) outside quotes."""
+    segments = []
+    current = []
+    quote = None
+    i = 0
+    n = len(command)
+    while i < n:
+        consumed = _consume_quote_or_escape(command, i, quote)
+        if consumed is not None:
+            length, quote = consumed
+            current.append(command[i : i + length])
+            i += length
+            continue
+        if command[i : i + 2] in ("&&", "||"):
+            segments.append("".join(current))
+            current = []
+            i += 2
+            continue
+        c = command[i]
+        if c in (";", "|", "&", "\n"):
+            segments.append("".join(current))
+            current = []
+            i += 1
+            continue
+        current.append(c)
+        i += 1
+    segments.append("".join(current))
+    return segments
+
+
+def _shell_c_arg(rest):
+    """Return the argument to a shell `-c` (including clusters like `-lc`), or None."""
+    for k, t in enumerate(rest):
+        if t == "--":
+            return None
+        if t.startswith("-") and not t.startswith("--") and "c" in t:
+            return rest[k + 1] if k + 1 < len(rest) else None
+    return None
+
+
+def _python_reason(rest):
+    """Deny inline (`-c`), stdin (`-`), or bare Python; allow a script or `-m`."""
+    skip_value = False
+    for t in rest:
+        if skip_value:
+            return None  # the `-m module` or first positional — a real program
+        if t in ("-c", "-"):
+            return _PYTHON_REASON
+        if t == "-m":
+            skip_value = True
+            continue
+        if t.startswith("-"):
+            continue
+        return None  # a script file
+    return _PYTHON_REASON  # nothing to run but stdin → a REPL
+
+
+def _resolve_wrapped(wrapper, rest):
+    """The subcommand a wrapper runs: skip its options (+ a duration for timeout)."""
+    i = 0
+    while i < len(rest) and (_is_assignment(rest[i]) or rest[i].startswith("-")):
+        i += 1
+    if wrapper == "timeout" and i < len(rest):
+        i += 1  # the DURATION positional
+    return rest[i:]
+
+
+def _consume_exec_args(tokens):
+    """Tokens of an -exec command body, up to its terminating ; or +."""
+    out = []
+    for x in tokens:
+        if x in (";", "\\;", "+"):
+            break
+        if x == "{}":
+            continue
+        out.append(x)
+    return out
+
+
+def _find_exec_tokens(rest):
+    """The command run by `find ... -exec/-execdir CMD … ;/+`, or None."""
+    for k, t in enumerate(rest):
+        if t in ("-exec", "-execdir"):
+            return _consume_exec_args(rest[k + 1 :])
+    return None
+
+
+def _bazel_indirections(rest):
+    """Token-lists that bazel will hand to a shell: post-`--` args and `--run_under`."""
+    out = []
+    for k, t in enumerate(rest):
+        if t == "--":
+            after = rest[k + 1 :]
+            # Recurse only when bazel hands its args to a shell, e.g.
+            # `bazel run //x -- bash -c 'cargo'`.  Otherwise post-`--` tokens are
+            # arguments to the run target, not a command — e.g.
+            # `bazel run //infra:tofu -- infra/terraform output` passes the
+            # config dir to tofu; `infra/terraform`'s basename is not a tool.
+            if after and _basename(after[0]) in _SHELLS:
+                out.append(after)
+            break
+        if t.startswith("--run_under="):
+            out.append(shlex.split(t.split("=", 1)[1], posix=True))
+        elif t == "--run_under" and k + 1 < len(rest):
+            out.append(shlex.split(rest[k + 1], posix=True))
+    return out
+
+
+def _strip_token_prefix(tokens):
+    """Drop leading `VAR=value` assignments and shell keywords (`if`, `then`, …)."""
+    i = 0
+    while i < len(tokens) and (_is_assignment(tokens[i]) or tokens[i] in _SHELL_KEYWORDS):
+        i += 1
+    return tokens[i:]
+
+
+def _check_lockfile_args(rest):
+    for arg in rest:
+        if _basename(arg) in LOCKFILES:
+            return _lockfile_reason(_basename(arg), deleting=True)
+    return None
+
+
+def _check_shell(rest, depth, interactive):
+    inner = _shell_c_arg(rest)
+    return _check_command(inner, depth + 1, interactive) if inner is not None else None
+
+
+def _check_find(rest, depth, interactive):
+    exec_tokens = _find_exec_tokens(rest)
+    return _check_tokens(exec_tokens, depth + 1, interactive) if exec_tokens else None
+
+
+def _check_bazel(rest, depth, interactive):
+    for sub in _bazel_indirections(rest):
+        reason = _check_tokens(sub, depth + 1, interactive) if sub else None
+        if reason:
+            return reason
+    return None
+
+
+def _check_wrapper(base, rest, depth, interactive):
+    wrapped = _resolve_wrapped(base, rest)
+    return _check_tokens(wrapped, depth + 1, interactive) if wrapped else None
+
+
+def _dispatch_base(base, rest, depth, interactive):
+    """Per-basename handler dispatch, or None when nothing further applies."""
+    if base in _DESTRUCTIVE_VERBS:
+        return _check_lockfile_args(rest)
+    if base in _SHELLS:
+        return _check_shell(rest, depth, interactive)
+    if base == "find":
+        return _check_find(rest, depth, interactive)
+    if base == "bazel":
+        return _check_bazel(rest, depth, interactive)
+    if base in _COMMAND_WRAPPERS:
+        return _check_wrapper(base, rest, depth, interactive)
+    return None
+
+
+def _check_tokens(tokens, depth, interactive):
+    """Check one already-tokenized command (the command word + its args).
+
+    `interactive` is true for the interactive command surface and false when
+    scanning written script content. It governs two leniencies for content: an
+    ad-hoc `python -c` is denied only when interactive (a heredoc in a reviewed
+    build script is fine), and a segment that defeats the tokenizer fails closed
+    only when interactive (content skips it, to not block a complex script).
+    """
+    if depth > _MAX_DEPTH:
+        return _TOO_DEEP_REASON
+    head = _strip_token_prefix(tokens)
+    if not head:
+        return None
+    word = head[0]
+    base = _basename(word)
+    rest = head[1:]
+
+    # A command word containing `$` is dynamically resolved — a variable or a
+    # `$(rlocation …)` runfiles path — i.e. the hermetic-wrapper pattern, not a
+    # bare native invocation. psql.sh runs `exec "$(rlocation …)/bin/psql"`,
+    # whose basename is `psql`; the `$` is what marks it hermetic.
+    if "$" not in word and base in NATIVE_TOOLS:
+        return _native_reason(base)
+
+    if interactive and _PYTHON_RE.match(base):
+        return _python_reason(rest)
+
+    return _dispatch_base(base, rest, depth, interactive)
+
+
+def _skip_to_eol(command, i):
+    n = len(command)
+    while i < n and command[i] != "\n":
+        i += 1
+    return i
+
+
+def _strip_comments(command):
+    """Remove unquoted shell comments (`#` to end of line), quote-aware.
+
+    A comment can't invoke anything, and markdown-style backticks inside comments
+    (`# uses `cargo metadata``) would otherwise look like backtick substitutions.
+    """
+    out = []
+    quote = None
+    prev = "\n"
+    i = 0
+    n = len(command)
+    while i < n:
+        consumed = _consume_quote_or_escape(command, i, quote)
+        if consumed is not None:
+            length, quote = consumed
+            chunk = command[i : i + length]
+            out.append(chunk)
+            prev = chunk[-1]
+            i += length
+            continue
+        c = command[i]
+        if c == "#" and prev in " \t\n;|&(":
+            i = _skip_to_eol(command, i)
+            continue
+        out.append(c)
+        prev = c
+        i += 1
+    return "".join(out)
+
+
+def _find_paren_close(command, start):
+    """End-of-`$(...)` index (exclusive) starting just after `$(`, or None if unbalanced."""
+    depth = 1
+    j = start
+    n = len(command)
+    while j < n and depth > 0:
+        c = command[j]
+        if c == "(":
+            depth += 1
+        elif c == ")":
+            depth -= 1
+        j += 1
+    return j if depth == 0 else None
+
+
+def _consume_dollar_paren(command, i):
+    """If `i` opens `$(...)`, return `(end_index, inner_text)`; else None."""
+    n = len(command)
+    if i + 1 >= n or command[i + 1] != "(":
+        return None
+    end = _find_paren_close(command, i + 2)
+    if end is None:
+        return None
+    return end, command[i + 2 : end - 1]
+
+
+def _consume_backtick(command, i):
+    """If `i` opens `` `...` ``, return `(end_index, inner_text)`; else None."""
+    j = command.find("`", i + 1)
+    if j == -1:
+        return None
+    return j + 1, command[i + 1 : j]
+
+
+def _command_substitutions(command):
+    """Inner text of every $(...) and `...` substitution, for recursion."""
+    subs = []
+    i = 0
+    n = len(command)
+    while i < n:
+        c = command[i]
+        consumed = None
+        if c == "$":
+            consumed = _consume_dollar_paren(command, i)
+        elif c == "`":
+            consumed = _consume_backtick(command, i)
+        if consumed is not None:
+            end, inner = consumed
+            subs.append(inner)
+            i = end
+            continue
+        i += 1
+    return subs
+
+
+def _tokenize_segment(segment, interactive):
+    """Tokenize a segment; on tokenizer failure raise (interactive) or return None (content)."""
+    try:
+        return shlex.split(segment, posix=True)
+    except ValueError:
+        if interactive:
+            raise  # an interactive command we can't tokenize → fail closed
+        return None  # written content: skip a gnarly segment, don't block legit scripts
+
+
+def _check_substitutions(command, depth, interactive):
+    for inner in _command_substitutions(command):
+        reason = _check_command(inner, depth + 1, interactive)
+        if reason:
+            return reason
+    return None
+
+
+def _check_segments(command, depth, interactive):
+    for segment in _split_segments(command):
+        if not segment.strip():
+            continue
+        tokens = _tokenize_segment(segment, interactive)
+        if not tokens:
+            continue
+        reason = _check_tokens(tokens, depth, interactive)
+        if reason:
+            return reason
+    return None
+
+
+def _check_command(command, depth, interactive=True):
+    """Check a whole command string: redirects, $() bodies, then each segment."""
+    if depth > _MAX_DEPTH:
+        return _TOO_DEEP_REASON
+    command = _strip_comments(command)
+    match = _TRUNCATE_REDIRECT.search(command)
+    if match:
+        return _lockfile_reason(match.group(1), deleting=False)
+    return _check_substitutions(command, depth, interactive) or _check_segments(
+        command, depth, interactive
+    )
+
+
+def _looks_like_shell(file_path, content):
+    """Whether written content should be scanned as a shell script."""
+    if _basename(file_path).endswith(_SHELL_EXTS):
+        return True
+    head = content.lstrip()[:200].split("\n", 1)[0]
+    return head.startswith("#!") and re.search(r"\b(sh|bash|dash|ksh|zsh)\b", head) is not None
+
+
+def _check_write(file_path, content):
+    if _basename(file_path) == "mod.rs":
+        return _MOD_RS_REASON
+    if content and _looks_like_shell(file_path, content):
+        reason = _check_command(content, 0, interactive=False)
+        if reason:
+            return (
+                f"In the shell script being written ({file_path}): {reason} "
+                f"Bazel-hosted scripts locate tools via runfiles (e.g. "
+                f"`rlocation rust_host_tools/bin/cargo`) and run the resolved path, "
+                f"like tools/cargo.sh — not a bare invocation."
+            )
+    return None
+
+
+def decide(payload):
+    """Return a denial reason for a forbidden action, or None to allow."""
+    tool = payload.get("tool_name", "")
+    tool_input = payload.get("tool_input") or {}
+    if tool == "Bash":
+        return _check_command(tool_input.get("command") or "", 0)
+    if tool in ("Write", "Edit"):
+        content = tool_input.get("content") or tool_input.get("new_string") or ""
+        return _check_write(tool_input.get("file_path") or "", content)
+    return None
+
+
+def evaluate(raw_stdin):
+    """Return a denial reason for the payload, or None to allow.
+
+    Fails closed at the payload boundary: if the JSON payload can't be parsed
+    (or decide() raises), deny. A guard that can't read the action at all must
+    not permit it. Valid hook payloads always parse, so this never fires in
+    normal operation.
+    """
+    try:
+        return decide(json.loads(raw_stdin))
+    except Exception:
+        return "agent_action_guard could not parse the action; denying"
+
+
+def main():
+    reason = evaluate(sys.stdin.read())
+    if reason is None:
+        return
+    print(
+        json.dumps(
+            {
+                "hookSpecificOutput": {
+                    "hookEventName": "PreToolUse",
+                    "permissionDecision": "deny",
+                    "permissionDecisionReason": reason,
+                }
+            }
+        )
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/agent_action_guard_test.py
+++ b/tools/agent_action_guard_test.py
@@ -1,0 +1,325 @@
+"""Tests for the PreToolUse action guard (tools/agent_action_guard.py)."""
+
+import os
+import shlex
+import unittest
+
+from agent_action_guard import decide, evaluate
+
+
+def bash(command):
+    return {"tool_name": "Bash", "tool_input": {"command": command}}
+
+
+def write(path, content=""):
+    return {"tool_name": "Write", "tool_input": {"file_path": path, "content": content}}
+
+
+def edit(path, content=""):
+    return {"tool_name": "Edit", "tool_input": {"file_path": path, "new_string": content}}
+
+
+class NativeDirectTest(unittest.TestCase):
+    def test_bare_native_tools_are_denied(self):
+        for cmd in (
+            "cargo build",
+            "cargo",
+            "rustc --version",
+            "psql -c 'select 1'",
+            "tofu apply",
+            "terraform plan",
+            "yamllint .",
+            "/usr/bin/cargo build",
+            "FOO=1 cargo test",
+            "ls && cargo build",
+        ):
+            self.assertIsNotNone(decide(bash(cmd)), f"should deny: {cmd}")
+
+    def test_all_repo_hermetic_tools_are_denied(self):
+        # Every tool the repo provides hermetically, invoked natively.
+        for cmd in (
+            "sqlx migrate run",
+            "aws s3 ls",
+            "protoc --version",
+            "buf lint",
+            "go build ./...",
+            "gazelle",
+            "node x.js",
+            "npm install",
+            "npx tsc",
+            "pnpm install",
+            "taplo fmt",
+            "shfmt -w x.sh",
+            "yamlfmt .",
+            "ruff format x.py",
+            "buildifier BUILD.bazel",
+            "shellcheck x.sh",
+            "pymarkdown scan x.md",
+            "java -jar x.jar",
+            "llvm-cov report",
+            "llvm-profdata merge",
+            "pip install x",
+            "pip3 install y",
+            # PostgreSQL binaries with no wrapper — not permitted.
+            "pg_dump db",
+            "pg_isready",
+            "initdb -D x",
+            "pg_ctl start",
+            "postgres -D x",
+            "createdb foo",
+            "protoc-gen-doc",
+        ):
+            self.assertIsNotNone(decide(bash(cmd)), f"should deny: {cmd}")
+
+    def test_bazel_wrappers_are_allowed(self):
+        for cmd in (
+            "bazel run //tools:cargo -- generate-lockfile",
+            "bazel build //...",
+            "bazel run //infra:tofu -- plan",
+            "bazel run //infra/postgres:psql -- -c 'select 1'",
+            "bazel test //...",
+        ):
+            self.assertIsNone(decide(bash(cmd)), f"should allow: {cmd}")
+
+    def test_mentions_not_invocations_are_allowed(self):
+        for cmd in (
+            "echo cargo build",
+            "grep cargo tools/check.sh",
+            "git commit -m 'use cargo not native'",
+            "cat Cargo.toml",
+            "./tools/cargo.sh metadata",
+            'echo "a && cargo b"',
+        ):
+            self.assertIsNone(decide(bash(cmd)), f"should allow: {cmd}")
+
+
+class ShellDashCTest(unittest.TestCase):
+    def test_shell_c_native_is_denied(self):
+        for cmd in (
+            "sh -c 'cargo build'",
+            'bash -c "cargo build"',
+            'bash -c "echo hi && cargo build"',
+            "bash -lc 'cargo build'",
+            "sh -c \"bash -c 'cargo'\"",
+            "bash --norc -c 'rustc x.rs'",
+        ):
+            self.assertIsNotNone(decide(bash(cmd)), f"should deny: {cmd}")
+
+    def test_shell_c_mention_is_allowed(self):
+        for cmd in (
+            "bash -c 'echo cargo'",
+            "bash -c 'grep cargo file'",
+            "bash deploy.sh",
+        ):
+            self.assertIsNone(decide(bash(cmd)), f"should allow: {cmd}")
+
+    def test_lockfile_destruction_via_shell_c_is_denied(self):
+        self.assertIsNotNone(decide(bash("bash -c 'rm Cargo.lock'")))
+        self.assertIsNotNone(decide(bash('sh -c "echo x > MODULE.bazel.lock"')))
+
+
+class WrapperTest(unittest.TestCase):
+    def test_wrapped_native_is_denied(self):
+        for cmd in (
+            "xargs cargo",
+            "xargs -n1 cargo build",
+            "echo x | xargs cargo build",
+            "env cargo test",
+            "nohup cargo build",
+            "sudo cargo",
+            "timeout 30 cargo build",
+            "time cargo build",
+            "find . -name '*.rs' -exec cargo fmt {} +",
+        ):
+            self.assertIsNotNone(decide(bash(cmd)), f"should deny: {cmd}")
+
+    def test_wrapped_non_native_is_allowed(self):
+        for cmd in (
+            "xargs grep cargo",
+            "timeout 30 grep cargo",
+            "find . -exec grep cargo {} ;",
+        ):
+            self.assertIsNone(decide(bash(cmd)), f"should allow: {cmd}")
+
+
+class PythonInlineTest(unittest.TestCase):
+    def test_inline_and_stdin_python_denied(self):
+        for cmd in (
+            "python3 -c 'import os'",
+            "python -c 'x'",
+            "python3 -",
+            "python3",
+            "python3 -B -c 'y'",
+        ):
+            self.assertIsNotNone(decide(bash(cmd)), f"should deny: {cmd}")
+
+    def test_python_script_or_module_allowed(self):
+        for cmd in (
+            "python3 tools/agent_action_guard.py",
+            "python3 script.py",
+            "python3 -B tools/x.py",
+            "python3 -m json.tool",
+        ):
+            self.assertIsNone(decide(bash(cmd)), f"should allow: {cmd}")
+
+
+class BazelIndirectionTest(unittest.TestCase):
+    def test_bazel_indirect_to_native_is_denied(self):
+        for cmd in (
+            "bazel run //x -- bash -c 'cargo build'",
+            "bazel run --run_under='bash -c cargo' //x",
+            "bazel run //x -- sh -c 'rm Cargo.lock'",
+        ):
+            self.assertIsNotNone(decide(bash(cmd)), f"should deny: {cmd}")
+
+    def test_legitimate_bazel_is_allowed(self):
+        for cmd in (
+            "bazel run //tools:cargo -- generate-lockfile",
+            "bazel run //tools:cargo -- build",
+            "bazel build //...",
+            "bazel run //infra/postgres:psql -- -c 'select 1'",
+            # tofu takes the config dir as a post-`--` arg; basename is "terraform".
+            "bazel run //infra:tofu -- infra/terraform apply",
+            "bazel --quiet run //infra:tofu -- infra/terraform output -raw x",
+        ):
+            self.assertIsNone(decide(bash(cmd)), f"should allow: {cmd}")
+
+
+class LockfileTest(unittest.TestCase):
+    def test_direct_lockfile_destruction_denied(self):
+        for cmd in (
+            "rm MODULE.bazel.lock",
+            "rm -f Cargo.lock",
+            "truncate -s0 MODULE.bazel.lock",
+            "echo x > Cargo.lock",
+        ):
+            self.assertIsNotNone(decide(bash(cmd)), f"should deny: {cmd}")
+
+    def test_non_lockfile_rm_allowed(self):
+        self.assertIsNone(decide(bash("rm -rf .coverage-green")))
+        self.assertIsNone(decide(bash("echo x >> notes.txt")))
+
+
+class DepthTest(unittest.TestCase):
+    def test_deeply_nested_indirection_is_denied(self):
+        nested = "cargo build"
+        for _ in range(8):
+            nested = "sh -c " + shlex.quote(nested)
+        self.assertIsNotNone(decide(bash(nested)))
+
+
+class ModRsTest(unittest.TestCase):
+    def test_writing_mod_rs_is_denied(self):
+        self.assertIsNotNone(decide(write("services/causes_api/src/foo/mod.rs")))
+        self.assertIsNotNone(decide(edit("lib/rust/api_db/src/store/mod.rs")))
+
+    def test_other_writes_allowed(self):
+        self.assertIsNone(decide(write("services/causes_api/src/foo.rs")))
+        self.assertIsNone(decide(write(".claude/settings.json")))
+        self.assertIsNone(decide(write("README.md")))
+
+
+class EvaluateFailsClosedTest(unittest.TestCase):
+    def test_unparseable_payload_is_denied(self):
+        self.assertIsNotNone(evaluate("this is not json"))
+        self.assertIsNotNone(evaluate(""))
+
+    def test_unparseable_command_is_denied(self):
+        # Unbalanced quote → shlex raises → fail closed.
+        self.assertIsNotNone(
+            evaluate('{"tool_name": "Bash", "tool_input": {"command": "bash -c \\"oops"}}')
+        )
+
+    def test_parseable_allowed_action_is_silent(self):
+        self.assertIsNone(
+            evaluate('{"tool_name": "Bash", "tool_input": {"command": "bazel build //..."}}')
+        )
+
+    def test_unguarded_tool_is_allowed(self):
+        self.assertIsNone(decide({"tool_name": "Read", "tool_input": {"file_path": "x"}}))
+        self.assertIsNone(decide({}))
+
+
+_RUNFILES_WRAPPER = (
+    "#!/usr/bin/env bash\n"
+    'tool="$(rlocation rust_host_tools/bin/cargo)"\n'
+    'cd "${BUILD_WORKSPACE_DIRECTORY}"\n'
+    'exec "$tool" "$@"\n'
+)
+
+
+class ContentScanTest(unittest.TestCase):
+    def test_written_shell_with_bare_native_is_denied(self):
+        for body in (
+            "cargo build --release",
+            "if true; then cargo test; fi",
+            "V=$(cargo --version)",
+            "X=`rustc --version`",
+            "/usr/bin/cargo build",
+            "rm Cargo.lock",
+            'psql -c "select 1"',
+            "bash -c 'cargo build'",
+        ):
+            script = "#!/bin/bash\n" + body + "\n"
+            self.assertIsNotNone(decide(write("tools/new.sh", script)), f"deny: {body}")
+
+    def test_runfiles_located_tool_is_allowed(self):
+        self.assertIsNone(decide(write("tools/new.sh", _RUNFILES_WRAPPER)))
+
+    def test_runfiles_path_ending_in_tool_name_is_allowed(self):
+        # psql.sh runs `exec "$(rlocation …)/bin/psql"`: the command word's
+        # basename is `psql`, but the `$` marks it as a runfiles path.
+        script = (
+            "#!/bin/bash\n"
+            'exec "$(rlocation _main/infra/postgres/postgres_extracted)/bin/psql" "$@"\n'
+        )
+        self.assertIsNone(decide(write("infra/postgres/psql.sh", script)))
+
+    def test_env_var_bin_path_is_allowed(self):
+        # testfixture.sh runs `"$PGBIN/initdb"`; the `$` marks the path hermetic.
+        script = (
+            '#!/bin/bash\nPGBIN="$(rlocation x)/bin"\n"$PGBIN/initdb" -D d\n"$PGBIN/pg_ctl" start\n'
+        )
+        self.assertIsNone(decide(write("infra/postgres/testfixture.sh", script)))
+
+    def test_inline_python_heredoc_in_script_is_allowed(self):
+        # Reviewed build-script Python is fine; only the interactive surface denies it.
+        script = "#!/bin/bash\npython3 - foo bar <<'PYEOF'\nprint(1)\nPYEOF\n"
+        self.assertIsNone(decide(write("tools/new.sh", script)))
+
+    def test_backticks_in_comment_are_not_invocations(self):
+        script = "#!/bin/bash\n# invoke for `cargo metadata` and `cargo check`\ntrue\n"
+        self.assertIsNone(decide(write("tools/new.sh", script)))
+
+    def test_non_shell_files_are_not_scanned(self):
+        self.assertIsNone(decide(write("README.md", "Run `cargo build` — forbidden.\n")))
+        self.assertIsNone(decide(write("x.py", "cargo = 5\nsubprocess.run(['cargo'])\n")))
+
+    def test_edit_hunk_adding_bare_cargo_is_denied(self):
+        self.assertIsNotNone(decide(edit("tools/x.sh", "    cargo build\n")))
+
+
+class HelperScriptsTest(unittest.TestCase):
+    """Every current tools/*.sh wrapper must pass (they locate tools via runfiles)."""
+
+    HELPERS = (
+        "cargo.sh",
+        "rustc.sh",
+        "rustfmt.sh",
+        "sqlx.sh",
+        "proto_gen_impl.sh",
+        "sqlx_prepare_impl.sh",
+        "toolchain_versions_test.sh",
+    )
+
+    def test_helpers_are_not_blocked(self):
+        here = os.path.dirname(os.path.abspath(__file__))
+        for name in self.HELPERS:
+            path = os.path.join(here, name)
+            with open(path, encoding="utf-8") as handle:
+                content = handle.read()
+            self.assertIsNone(decide(write(path, content)), f"helper should pass: {name}")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

A `PreToolUse` hook (`Bash`/`Write`/`Edit`) that denies actions this repo forbids and points the caller at the supported alternative.

## Blocked, with the reason returned to the caller

- **Native tooling the repo provides hermetically** — not on `PATH` in this Bazel-only repo, so it runs non-hermetically. The set is derived from the repo's Bazel toolchain definitions, each routed to its wrapper:
  - Rust: `cargo`, `rustc`, `rustfmt` → `//tools:*`
  - DB: `psql` → `//infra/postgres:psql`, `sqlx` → `//tools:sqlx`; the rest of the hermetic PostgreSQL suite (`pg_dump`, `pg_isready`, `initdb`, `pg_ctl`, … — 36 binaries) has no wrapper → **not permitted**
  - Infra: `tofu`/`terraform` → `//infra:tofu`, `aws` → `//infra:aws`
  - Proto: `protoc` → `//tools:proto_gen`, `buf` → lint aspect, `protoc-gen-doc` → not permitted (a plugin)
  - Go: `go`, `gazelle` → rules_go / `//:gazelle`
  - JS: `node`, `npm`, `npx`, `pnpm` → aspect_rules_js
  - Formatters: `taplo`, `shfmt`, `yamlfmt`, `ruff`, `buildifier` → `//:format`
  - Linters: `yamllint`, `shellcheck`, `pymarkdown` → `bazel test //...`
  - Other: `java` (TLA+ JRE) → `//infra/tla`; `llvm-cov`/`llvm-profdata` → `bazel coverage`; `pip`/`pip3` → `requirements.in` + `//:requirements.update`

  A hermetic tool with **no run wrapper** (the wrapper-less PostgreSQL binaries, `protoc-gen-doc`) is refused as *not permitted* — a missing wrapper makes the tool off-limits, not exempt.
- **`rm`/`truncate` of `MODULE.bazel.lock`, `Cargo.lock`, `requirements_lock.txt`** — regenerating a lockfile from scratch drops extension facts CI computes but the dev container does not, after which CI rejects the lockfile.
- **Creating a `mod.rs`** — the project uses the `<dir>.rs` module layout.

## Indirection (Bash commands)

Scanned recursively so a forbidden call can't be laundered through a wrapper. Applies to the leading word of each `;`/`&&`/`||`/`|`/`&` segment and through:

- `sh -c` / `bash -c` strings (incl. `-lc` clusters);
- `xargs`, `find -exec`/`-execdir`, and `env`/`sudo`/`nohup`/`timeout`/… wrappers;
- `bazel`'s `--run_under`, and post-`--` args **only when handed to a shell** (`bazel run //x -- bash -c …`) — so `bazel run //infra:tofu -- infra/terraform …` (a config-dir arg) isn't mistaken for `terraform`;
- `$(…)` and backtick substitutions.

Inline/stdin Python (`python -c`, `python -`) is denied on the interactive surface. Only command-position tokens are checked, so mentions (`grep cargo`, `echo cargo`) pass.

## Written shell scripts (Write/Edit content)

A `.sh` file or shell shebang is scanned for native tooling and lockfile destruction. The discriminator is the **command word**:

- **blocked** — a bare `cargo build`, `if …; then cargo test`, `V=$(cargo --version)`, `` X=`rustc …` ``, `/usr/bin/cargo`, `rm Cargo.lock`;
- **passes** — a command word containing `$` (a variable or a `$(rlocation …)` runfiles path) is the hermetic-wrapper pattern, so both `exec "$tool"` and `exec "$(rlocation …)/bin/psql"` (basename `psql`) are allowed.

Comments are stripped first (markdown backticks in a comment aren't read as substitutions); inline Python in a reviewed script (a `python3 - <<EOF` heredoc) is allowed — that deny is interactive-only. **Validated against all 37 `.sh` files in the repo (0 false positives)**; the `tools/*.sh` wrappers are also a committed test corpus (`HelperScriptsTest`).

## Scope / limits

Non-shell written content isn't scanned (native tooling embedded in Python, a YAML CI step, or a Dockerfile). Execution that never passes through a hook (CI, already-committed files) is gate territory. This raises the floor against *reaching* for native tooling; it is not a wall against deliberate evasion.

## Design

- Matching logic is in `decide(payload) -> reason | None`, unit-tested (30 cases) including the helper corpus.
- Fails closed: an unparseable JSON payload or interactive command is denied; a segment of written content that defeats the tokenizer is skipped (not denied), so a complex but legitimate script isn't blocked.
- Wired in `.claude/settings.json` as a `Bash|Write|Edit` matcher.

## Test plan

- `bazel test //tools:agent_action_guard_test` — 30 cases.
- `tools/check.sh agent //...` — green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
