### PR TITLE
gitignore: ignore Python bytecode cache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,8 @@ cabal-dev
 
 # VS Code settings for the project — never commit; otherwise contributors cannot customise work.
 .vscode
+
+# Python bytecode cache — running a tools/*.py test directly (outside the Bazel
+# sandbox) writes these into the source tree.
+__pycache__/
+*.pyc


### PR DESCRIPTION
Running a `tools/*.py` test directly (outside the Bazel sandbox) writes `__pycache__/*.pyc` into the source tree, which then shows up as untracked files. Ignore them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)