### PR TITLE
docs: enable zensical --strict and fix existing warnings

### DIFF
--- a/designdocs/Design-Choices.md
+++ b/designdocs/Design-Choices.md
@@ -64,7 +64,7 @@ SSE does not appear anywhere else in the system.
 
 Webhooks are not part of the core model; they may be offered as an optional outbound integration for external tools that cannot speak gRPC.
 
-See [ADR-007](Decisions.md#adr-007-push-notifications--grpc-streaming).
+See [ADR-007](Decisions.md#adr-007-push-notifications-grpc-streaming).
 
 ## API specification
 
@@ -73,7 +73,7 @@ An OpenAPI spec is generated from the proto definitions and published for third-
 Proto service definitions are the contract at component boundaries, making the backend language an implementation detail per component.
 The choice of RPC framework (Connect, grpc-gateway, tonic, etc.) follows the language decision in ADR-008.
 Real-time browser updates use Server-Sent Events (SSE), which is browser-native and requires no client library.
-See [ADR-009](Decisions.md#adr-009-api-specification-format--protobuf).
+See [ADR-009](Decisions.md#adr-009-api-specification-format-protobuf).
 
 ## Security
 

--- a/designdocs/Manifesto.md
+++ b/designdocs/Manifesto.md
@@ -78,14 +78,14 @@ Users are interested in:
 
 Tracking symptoms and signs separately from proposed changes provides dedicated interfaces that meet users' needs, developers' needs, and the needs of folk that do planning.
 The interfaces should be fluid, not rigidly partitioned — people wear multiple hats, especially on small projects.
-[not validated — experience with Bazaar, Ubuntu etc was a strong indicator]
+\[not validated — experience with Bazaar, Ubuntu etc was a strong indicator\]
 
 ### Sensible assumptions
 
 In the absence of explicit decisions, Causes makes sensible assumptions — and updates those as the facts change.
 For instance, a symptom many users are experiencing is assumed to be more important to the project than one that only a single user has reported.
 If a developer overrides that, the override sticks until removed.
-[Importance: not validated]
+\[Importance: not validated\]
 
 ### Does one thing well
 
@@ -130,14 +130,14 @@ The same core logic that drives offline access and behind-the-firewall replicati
 While Causes is not a Kanban system, it does know about work in progress: plans that have been made but not actioned, plans that are pending review, symptoms where reproduction discussion has stalled, and so on.
 Causes shows you a clear list of things you have started but not finished, including things where other people are waiting on you, or you are waiting on other people.
 Similarly it can show a project-wide view of in-progress work.
-[unvalidated, but a direct application of the automate-tedious-stuff principle]
+\[unvalidated, but a direct application of the automate-tedious-stuff principle\]
 
 ### Clearly shows what you and your collaborators have done
 
 The flip side of knowing what you are doing is knowing what you have done.
 Causes can summarise this for you, making it easy to talk about what you have done for a project.
 Similarly, see what has happened in the whole project recently, over the last month or year.
-[not validated; keep-aware-of-things is fairly obvious; the advertise-myself aspect less so]
+\[not validated; keep-aware-of-things is fairly obvious; the advertise-myself aspect less so\]
 
 ---
 
@@ -385,8 +385,8 @@ Operations:
 The following were not addressed in the original 2013 design and need decisions before implementation:
 
 - **Language and stack** — see [ADR-008](Decisions.md#adr-008-language-stack-open)
-- **Security model** (authentication, authorisation, private disclosure workflow) — see [ADR-010](Decisions.md#adr-010-security-model-open)
-- **API specification format** (recommend OpenAPI 3.x) — see [ADR-009](Decisions.md#adr-009-api-specification-format-open)
+- **Security model** (authentication, authorisation, private disclosure workflow) — see [ADR-010](Decisions.md#adr-010-security-model)
+- **API specification format** (recommend OpenAPI 3.x) — see [ADR-009](Decisions.md#adr-009-api-specification-format-protobuf)
 - **Deployment** (Docker Compose for local dev; OCI containers for production) — see [Design-Choices.md](Design-Choices.md#deployment)
 - **CI/CD pipeline** (GitHub Actions: lint, test, build, publish container image)
 - **Data schema** — the four entity types are described in prose; a concrete schema definition is needed

--- a/designdocs/Raw-Discussion.md
+++ b/designdocs/Raw-Discussion.md
@@ -146,9 +146,9 @@ Interesting actors in a bug report
 
 Consider a project member. The project likely has some a priori agenda (whether commercial like LP itself, or opinionated, like testtools)  A project member may well want to track both personal interests and project interests. (NB: I'm not strictly talking priorities here.)
 
-Consider a user.  They probably don't want to track anything, but they want to know if *anyone* has decided they will do this thing so they want [queue depth in days for this bug to be what someone is hacking on].
+Consider a user.  They probably don't want to track anything, but they want to know if *anyone* has decided they will do this thing so they want \[queue depth in days for this bug to be what someone is hacking on\].
 
-Consider the project again.  Beyond or complementary to its a priori agenda, it may well want to know what things are most frustrating to its user base.  Which is where tracking incident rates [for crashes] and reporting rates [for frequently requested dups], and 'me wants it too' etc data.
+Consider the project again.  Beyond or complementary to its a priori agenda, it may well want to know what things are most frustrating to its user base.  Which is where tracking incident rates \[for crashes\] and reporting rates \[for frequently requested dups\], and 'me wants it too' etc data.
 
 Do I want to track every users priority on every bug in every project? Probably.
 Do I want to show it as that? Hell no.
@@ -441,7 +441,7 @@ A user says 'this is fix released' but you treat that as input to 'what users th
 Some of the Launchpad bug tracker and the Ubuntu crash tracker help of this, but I would like to see much more done in open source bug trackers towards this:
 
 * default towards doing nothing.
-* don't encourage developers to triage everything[b]
+* don't encourage developers to triage everything\[b\]
 * bugs should decay from view
 * still make it possible to dig out old bugs
 * good automatic dupe-finding, including retrospectively or interactively hunting for dupes
@@ -500,8 +500,8 @@ I think that's useful, but would like to avoid the complication of having to sup
 
 Martin Pool adds, "from andyfitz's talk, a hierarchy of needs for design: function> reliability > usability > pleasure"
 
-[b]robertc:
-I think triage as Launchpad does it now is useful, not as Ubuntu does it. [which is to say, encourage devs to look briefly at all reports to identify zomg things].
+\[b\]robertc:
+I think triage as Launchpad does it now is useful, not as Ubuntu does it. \[which is to say, encourage devs to look briefly at all reports to identify zomg things\].
 
 ---
 

--- a/designdocs/Replication.md
+++ b/designdocs/Replication.md
@@ -4,7 +4,7 @@ This document specifies the Causes replication protocol.
 It is the specification for implementors building a Causes-compatible instance or alternative storage backend.
 
 For the design rationale behind these decisions, see [ADR-013](Decisions.md#adr-013-replication-protocol) in Decisions.md.
-For the broader federation strategy, see [ADR-006](Decisions.md#adr-006-federation-strategy--distribute-dont-federate-by-default).
+For the broader federation strategy, see [ADR-006](Decisions.md#adr-006-federation-strategy-distribute-dont-federate-by-default).
 For a machine-checked TLA+ model of the protocol's safety properties, see [../tla/Replication.tla](../tla/Replication.tla).
 
 ## Overview

--- a/docs/BUILD.bazel
+++ b/docs/BUILD.bazel
@@ -46,7 +46,7 @@ genrule(
         sed -e '/^docs_dir:/d' -e '/^site_dir:/d' docs/mkdocs.yml > $$OUTDIR/mkdocs.yml
         echo "docs_dir: designdocs" >> $$OUTDIR/mkdocs.yml
         cd $$OUTDIR
-        $$EXECROOT/$(location :zensical) build --clean
+        $$EXECROOT/$(location :zensical) build --clean --strict
         # Zensical locates its theme assets via __file__ at runtime, but the Bazel
         # runfiles layout differs from a regular pip install, so it silently skips
         # the copy. Copy them manually from the tool's runfiles.

--- a/docs/site_builder.bash
+++ b/docs/site_builder.bash
@@ -33,7 +33,7 @@ build_docs_site() {
 	echo "docs_dir: designdocs" >>"$build_root/mkdocs.yml"
 
 	# Build in a subshell to avoid changing the caller's working directory.
-	(cd "$build_root" && "$ZENSICAL" build)
+	(cd "$build_root" && "$ZENSICAL" build --strict)
 
 	# Zensical locates its theme assets via __file__ at runtime, but the Bazel
 	# runfiles layout differs from a regular pip install, so it silently skips

--- a/lib/rust/causes_proto/src/generated/causes.v1.rs
+++ b/lib/rust/causes_proto/src/generated/causes.v1.rs
@@ -102,7 +102,7 @@ pub struct ReplicationPath {
     /// path lists instance_ids in delivery order.  The first element is the
     /// writing instance; the last element is the local instance that stored
     /// this entry.  Locally-authored entries have a single-element path of
-    /// \[self\].  The receiver appends its own instance_id on ingest.
+    /// `\[self\]`.  The receiver appends its own instance_id on ingest.
     #[prost(message, repeated, tag = "1")]
     pub path: ::prost::alloc::vec::Vec<InstanceId>,
 }

--- a/proto/BUILD.bazel
+++ b/proto/BUILD.bazel
@@ -64,6 +64,13 @@ genrule(
             --proto_path=$$EXECROOT/proto \
             --proto_path=$$EXECROOT/$$WKT_ROOT \
             $$PROTO_FILES
+        # protoc-gen-doc emits links to well-known type anchors that do not
+        # exist in our output (Timestamp et al). Rewrite them to point at the
+        # upstream Protobuf reference instead, so the docs build can run
+        # under zensical's --strict mode.
+        sed -i \
+            -e 's|\\[google\\.protobuf\\.Timestamp\\](#google-protobuf-Timestamp)|[google.protobuf.Timestamp](https://protobuf.dev/reference/protobuf/google.protobuf/#timestamp)|g' \
+            $$EXECROOT/$(@D)/proto_docs.md
     """,
     tools = [
         "@protobuf//:protoc",

--- a/proto/causes/v1/common.proto
+++ b/proto/causes/v1/common.proto
@@ -118,7 +118,7 @@ message ReplicationPath {
   // path lists instance_ids in delivery order.  The first element is the
   // writing instance; the last element is the local instance that stored
   // this entry.  Locally-authored entries have a single-element path of
-  // [self].  The receiver appends its own instance_id on ingest.
+  // `[self]`.  The receiver appends its own instance_id on ingest.
   repeated InstanceId path = 1;
 }
 


### PR DESCRIPTION
## Summary

The docs site build was silently logging 30 broken-link / missing-anchor warnings per build because `zensical build` exits 0 even when it logs them. Pass `--strict` so they fail the build instead, and fix the pre-existing warnings.

- `docs/BUILD.bazel`, `docs/site_builder.bash`: add `--strict` to `zensical build` (covers genrule, `docs_test`, `serve_docs`, `deploy_docs`).
- `proto/BUILD.bazel`: post-process the generated `proto_docs.md` to rewrite the dangling `google.protobuf.Timestamp` anchor (~14 sites) to the upstream Protobuf reference URL.
- `designdocs/Manifesto.md`: refresh stale ADR-009/ADR-010 anchor slugs (titles dropped "OPEN" since the cross-links were written).
- `designdocs/Design-Choices.md`, `designdocs/Replication.md`: collapse double-hyphen em-dash slugs to the single-hyphen form zensical emits.
- `designdocs/Raw-Discussion.md`, `designdocs/Manifesto.md`: backslash-escape bracketed prose asides being parsed as reference-style link references.
- `proto/causes/v1/common.proto`: backtick the `[self]` example so the generated docs don't trip the same parser.

## Test plan

- [x] `bazel build //docs:docs_site` — clean ("No issues found")
- [x] `bazel test //docs:docs_test` — passes