### PR TITLE
check.sh: use jj globs instead of list+grep

### DIFF
--- a/tools/check.sh
+++ b/tools/check.sh
@@ -270,7 +270,7 @@ run_agent_scan() {
 	# new-language detector. Computed once per agent run; cheap (a single
 	# jj invocation listing tracked paths).
 	local master_exts
-	master_exts="$(jj file list -r master 2>/dev/null |
+	master_exts="$(jj file list --ignore-working-copy -r master 2>/dev/null |
 		awk -F/ '{print $NF}' |
 		awk -F. 'NF > 1 { print $NF }' |
 		sort -u | tr '\n' ',')"
@@ -282,7 +282,7 @@ run_agent_scan() {
 
 check_rules_rs_macros() {
 	local files
-	files="$(jj file list -r @ 2>/dev/null | grep '\(^\|/\)BUILD\.bazel$')"
+	files="$(jj file list --ignore-working-copy 'glob:**/BUILD.bazel' 2>/dev/null)"
 	if [[ -z "$files" ]]; then
 		return 0
 	fi

--- a/tools/require_bazel_quiet_test.sh
+++ b/tools/require_bazel_quiet_test.sh
@@ -19,8 +19,7 @@ while IFS= read -r file; do
 			print "    " $0
 		}
 	' "$file"
-done < <(jj file list -r @ 2>/dev/null |
-	grep -E '\.(sh|md)$' |
+done < <(jj file list --ignore-working-copy 'glob:**/*.sh' 'glob:**/*.md' 2>/dev/null |
 	sort) >"$violations_file"
 
 if [[ -s "$violations_file" ]]; then

--- a/tools/require_readme_test.sh
+++ b/tools/require_readme_test.sh
@@ -15,8 +15,7 @@ while IFS= read -r build_file; do
 	if [[ ! -f "$pkg_dir/README.md" ]]; then
 		missing+=("$pkg_dir")
 	fi
-done < <(jj file list -r @ 2>/dev/null |
-	grep -E '(^|/)(BUILD\.bazel|BUILD)$' |
+done < <(jj file list --ignore-working-copy 'glob:**/BUILD.bazel' 'glob:**/BUILD' 2>/dev/null |
 	sed 's|^|./|' |
 	sort)
 


### PR DESCRIPTION
jj file list 'glob:**/X' --ignore-working-copy is roughly twice as fast as
listing every tracked file then grepping, since the glob is pushed down
into the working-copy index walk and the --ignore-working-copy flag skips
the snapshot-and-stat pass over the working tree.

Apply to the three call sites whose previous form was 'jj file list | grep
basename-pattern':

- tools/check.sh check_rules_rs_macros: '**/BUILD.bazel'.
- tools/check.sh master_exts: keep the list-then-awk shape (we want every
  extension), but add --ignore-working-copy.
- tools/require_readme_test.sh: '**/BUILD.bazel' + '**/BUILD'.
- tools/require_bazel_quiet_test.sh: '**/*.sh' + '**/*.md'.
