### PR TITLE
ci_health: proper JSON, atomic output, truncate stale entries

### DIFF
--- a/tools/check.sh
+++ b/tools/check.sh
@@ -418,8 +418,12 @@ run_gate() {
 	elapsed=$(awk "BEGIN {printf \"%.3f\", $end - $start}")
 	TIMINGS+=("$name"$'\t'"$rc"$'\t'"$elapsed")
 	if [[ -n "${CHECK_TIMING_JSONL:-}" ]]; then
-		printf '{"gate":"%s","rc":%s,"seconds":%s}\n' \
-			"$name" "$rc" "$elapsed" >>"$CHECK_TIMING_JSONL"
+		jq -nc \
+			--arg gate "$name" \
+			--argjson rc "$rc" \
+			--argjson seconds "$elapsed" \
+			'{gate: $gate, rc: $rc, seconds: $seconds}' \
+			>>"$CHECK_TIMING_JSONL"
 	fi
 	return $rc
 }
@@ -438,6 +442,9 @@ emit_timing_summary() {
 trap emit_timing_summary EXIT
 
 run_all_gates() {
+	if [[ -n "${CHECK_TIMING_JSONL:-}" ]]; then
+		: >"$CHECK_TIMING_JSONL"
+	fi
 	run_gate rules_rs_macros check_rules_rs_macros
 	run_gate package_readmes check_package_readmes
 	run_gate bazel_quiet check_bazel_quiet

--- a/tools/ci_health/src/main.rs
+++ b/tools/ci_health/src/main.rs
@@ -762,7 +762,7 @@ async fn record(
         gate_timings,
     };
     let json = serde_json::to_string_pretty(&metrics).context("serialize metrics")?;
-    std::fs::write(out, json).with_context(|| format!("write {}", out.display()))?;
+    write_atomic(out, json.as_bytes()).with_context(|| format!("write {}", out.display()))?;
     Ok(())
 }
 
@@ -802,6 +802,27 @@ fn parse_gate_timings(path: &std::path::Path) -> Result<Vec<GateTiming>> {
     Ok(out)
 }
 
+/// Atomically write `bytes` to `out` via a sibling temp file + rename.
+fn write_atomic(out: &std::path::Path, bytes: &[u8]) -> std::io::Result<()> {
+    let parent = out.parent().ok_or_else(|| {
+        std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            format!("{} has no parent directory", out.display()),
+        )
+    })?;
+    let file_name = out
+        .file_name()
+        .ok_or_else(|| {
+            std::io::Error::new(
+                std::io::ErrorKind::InvalidInput,
+                format!("{} has no file name", out.display()),
+            )
+        })?
+        .to_string_lossy();
+    let tmp = parent.join(format!(".{file_name}.tmp.{}", std::process::id()));
+    std::fs::write(&tmp, bytes)?;
+    std::fs::rename(&tmp, out)
+}
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
## Summary

Three pre-existing issues surfaced in the #350 review (not introduced by #350; identified during it).

1. **JSON escaping.** `tools/check.sh` emitted JSON via `printf '{"gate":"%s",…}'`, which does no escaping. Switched to `jq -nc --arg/--argjson` so future gate names containing quotes, backslashes, or control chars produce valid JSON instead of corruption.

2. **Truncate before first gate.** `run_all_gates` now truncates `$CHECK_TIMING_JSONL` before running the first gate. Previously the file was opened with `>>` and never cleared, so re-running locally (or in any environment that reuses the path) accumulated stale entries.

3. **Temp file + rename for ci-metrics.json.** `record`'s output is now written via a sibling temp `.<name>.tmp.<pid>` and `rename`'d onto the destination. Atomic against concurrent readers: a killed writer leaves either the previous or new contents, never a truncated mix, so `upload-artifact` can't ship a partial `ci-metrics.json` on job cancellation. No fsync — a runner crash before writeback could still lose contents on some filesystems, but that's not worth the cost for an ephemeral CI artifact.

## Test plan

- [ ] `bazel test //tools:check_scan_test` (covers the check.sh path)
- [ ] `bazel build //tools/ci_health` + manual run, verify ci-metrics.json content
- [ ] Inspect a CI run's uploaded artifact to confirm valid JSON