### PR TITLE
ci: exercise buck2 in a bazel-free job

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -54,6 +54,20 @@ jobs:
           path: check-timings.jsonl
           retention-days: 90
           if-no-files-found: warn
+  # Runs on a checkout where Bazel never runs: buck2's file watcher follows the
+  # bazel-* convenience symlinks into the output tree and hangs, so buck2 builds
+  # cannot share a checkout with Bazel.
+  buck2:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
+      - name: Install buckle
+        run: sudo bash tools/buckle/install.sh /usr/local/bin
+      - name: Build buck2 targets
+        run: buck2 build //...
+      - name: Shut down buck2 daemon
+        if: always()
+        run: buck2 kill || true
   # Metrics collection runs as a separate job depending on `build` so
   # that the job's step logs are finalized by the time `record` reads
   # them. Inside the build job, the GH logs endpoint 404s on the

--- a/infra/github/rulesets.tf
+++ b/infra/github/rulesets.tf
@@ -29,6 +29,10 @@ resource "github_repository_ruleset" "master" {
       required_check {
         context = "build"
       }
+
+      required_check {
+        context = "buck2"
+      }
     }
 
     merge_queue {

--- a/tools/buckle/install.sh
+++ b/tools/buckle/install.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+# Install the buckle launcher as `buck2` into $1 (default /usr/local/bin).
+set -euo pipefail
+
+BINDIR="${1:-/usr/local/bin}"
+BUCKLE_VERSION=1.1.0
+BUCKLE_SHA256=dad88b264b1139ff12c30b81c5a71b9ddee54b4148e0f45a2708f7d809bd151d
+
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+
+curl -fsSL \
+	"https://github.com/benbrittain/buckle/releases/download/v${BUCKLE_VERSION}/buckle-x86_64-unknown-linux-gnu.tar.xz" \
+	-o "$tmp/buckle.tar.xz"
+echo "${BUCKLE_SHA256}  $tmp/buckle.tar.xz" | sha256sum -c -
+tar xf "$tmp/buckle.tar.xz" -C "$tmp"
+install -m 0755 "$tmp/buckle-x86_64-unknown-linux-gnu/buckle" "$BINDIR/buckle"
+ln -sf buckle "$BINDIR/buck2"


### PR DESCRIPTION
Adds a CI job that builds the buck2 targets (//...) and makes it a required check on the master ruleset, so a red buck2 //... blocks the merge like the Bazel build. Anything we commit to buck2 has to build, enforced from the first commit.

The job runs on a fresh checkout and never invokes Bazel, so the bazel-* convenience symlinks — which buck2's file watcher follows into the output tree and hangs on — never exist. That is why it is a separate job rather than a step in the existing build job.

- buckle is installed via tools/buckle/install.sh. The devcontainer Dockerfile keeps its own inline copy with the same pins; this mirrors how bazelisk is already installed two ways (Dockerfile curl vs the setup-bazel action), with the build-tool version single-sourced in .buckversion / .bazelversion.
- infra/github/rulesets.tf adds buck2 to required_status_checks. Do not apply the tofu until the buck2 check is green on master, or it would block every merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
