### PR TITLE
claude: buck2 gotchas + plan-placement rule

### DIFF
--- a/.claude/rules/feedback/feedback_plans_are_ephemeral.md
+++ b/.claude/rules/feedback/feedback_plans_are_ephemeral.md
@@ -1,0 +1,10 @@
+# Plans are ephemeral; only facts go in the repo
+
+In-flight plans, status, and "next steps" do not belong in the source repo (including `.claude/rules/project/`): branches jump around, so an in-repo plan changes under you and is stale the moment work lands.
+
+**Why:** PR #390 (a buck2 status+plan doc under rules/project) was closed for this.
+
+**How to apply:** classify such content into exactly one of:
+(a) real documentation — follow project standards, shipped with the feature it documents;
+(b) durable non-obvious facts — a memory, committed under `.claude/rules/` and merged;
+(c) work-in-progress sequencing — the ephemeral session plan file, accepting it dies with the container.

--- a/.claude/rules/project/project_buck2_bazel_isolation.md
+++ b/.claude/rules/project/project_buck2_bazel_isolation.md
@@ -1,0 +1,6 @@
+# buck2 cannot share a checkout with Bazel
+
+buck2's file watcher follows the `bazel-*` convenience symlinks into the multi-GB output tree at daemon startup and hangs (>90s timeout); `project.ignore` does not prevent it (buck2#465, #474).
+
+**How to apply:** run buck2 from a bazel-free jj workspace (`jj workspace add --revision @ ~/causes-buck2`); author code and run quality gates in the main workspace.
+CI runs buck2 in a separate job on a fresh checkout that never invokes Bazel (the `buck2` job in `.github/workflows/build.yml`).

--- a/.claude/rules/project/project_buck2_daemon_stderr.md
+++ b/.claude/rules/project/project_buck2_daemon_stderr.md
@@ -1,0 +1,9 @@
+# buck2 client errors mask daemon deaths
+
+When the buck2 daemon dies (e.g. panics), the client reports only the event-bus collapse: "h2 protocol error: error reading a body from connection: broken pipe".
+That message describes the client↔daemon stream, not the real failure, and looks identical for any daemon death.
+The daemon's stderr (panic message and backtrace) is at `~/.buck/buckd/<repo-path>/<isolation-dir>/buckd.stderr` (default isolation dir `v2`; previous daemon under `prev/`).
+
+**Why:** chasing the client message as a network error cost two days against BuildBuddy; the real cause was a daemon panic visible only in daemon stderr.
+
+**How to apply:** on any buck2 "broken pipe"/event-bus error, read daemon stderr before theorizing.

--- a/.claude/rules/project/project_buck2_re_client_facts.md
+++ b/.claude/rules/project/project_buck2_re_client_facts.md
@@ -1,0 +1,10 @@
+# buck2 RE client / BuildBuddy facts
+
+`[buck2_re_client]` config is read only from `.buckconfig`/`.buckconfig.local`; `-c buck2_re_client.*` command-line overrides are silently ignored ("No engine address").
+
+Working BuildBuddy config (verified 2026-07-14):
+scheme-less addresses (`remote.buildbuddy.io` — `grpcs://`/`https://` are rejected), `[buck2] digest_algorithms = SHA256`, API key via `.buckconfig.local` `http_headers = x-buildbuddy-api-key:…` (gitignored, like `.bazelrc.user`), and a custom exec platform with `remote_cache_enabled = True` (the bundled `prelude//platforms:default` has no cache).
+
+Cache uploads from locally-executed actions did not happen with executor `allow_cache_uploads = True` alone; action-level `allow_cache_upload` policy was still unsolved as of 2026-07-14, so no cache hit has been demonstrated.
+
+tonic#2185 (GOAWAY mishandling behind BuildBuddy's L7 proxy) never reproduced here and is untested under sustained load; a GOAWAY-shielding hyper/hyper-util reverse proxy is shelved on branch `buck2-re-proxy-shelf` (no PR) — revive only if load testing shows GOAWAY failures.


### PR DESCRIPTION
Durable memories from the buck2 bring-up, under .claude/rules/ per convention:

- project: buck2 cannot share a checkout with Bazel (watcher follows bazel-* symlinks; workspace isolation workflow).
- project: buck2 client "broken pipe" masks daemon deaths; read ~/.buck/buckd/.../buckd.stderr first.
- project: RE client/BuildBuddy facts (file-only config, scheme-less addresses, upload policy unsolved, GOAWAY untested, proxy shelf branch).
- feedback: plans/status are ephemeral and never go in the repo; only documentation, memories, or the session plan file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)