### PR TITLE
claude: update buck2 cache-upload memory

### DIFF
--- a/.claude/rules/project/project_buck2_re_client_facts.md
+++ b/.claude/rules/project/project_buck2_re_client_facts.md
@@ -5,6 +5,7 @@
 Working BuildBuddy config (verified 2026-07-14):
 scheme-less addresses (`remote.buildbuddy.io` — `grpcs://`/`https://` are rejected), `[buck2] digest_algorithms = SHA256`, API key via `.buckconfig.local` `http_headers = x-buildbuddy-api-key:…` (gitignored, like `.bazelrc.user`), and a custom exec platform with `remote_cache_enabled = True` (the bundled `prelude//platforms:default` has no cache).
 
-Cache uploads from locally-executed actions did not happen with executor `allow_cache_uploads = True` alone; action-level `allow_cache_upload` policy was still unsolved as of 2026-07-14, so no cache hit has been demonstrated.
+Cache uploads from locally-executed actions are gated per action, not just per executor: OSS-prelude genrules hard-code `allow_cache_uploads = False` (`prelude/genrule.bzl` cache mode) and never upload; rules exposing the `allow_cache_upload` attr (rust, cxx) upload when both the attr and the executor's `allow_cache_uploads = True` are set.
+The full round-trip (upload → `buck2 clean` → rebuild with 100% action-cache hits) is verified against BuildBuddy using the test-only `BUCK2_TEST_FORCE_CACHE_UPLOAD=true` env, which bypasses the per-action gate.
 
 tonic#2185 (GOAWAY mishandling behind BuildBuddy's L7 proxy) never reproduced here and is untested under sustained load; a GOAWAY-shielding hyper/hyper-util reverse proxy is shelved on branch `buck2-re-proxy-shelf` (no PR) — revive only if load testing shows GOAWAY failures.


### PR DESCRIPTION
The upload question is answered: OSS-prelude genrules never upload (hard-coded allow_cache_uploads = False); rules with the allow_cache_upload attr (rust, cxx) upload when the executor also allows it. Full round-trip verified against BuildBuddy (upload, clean, 100% action-cache hits) via the test-only BUCK2_TEST_FORCE_CACHE_UPLOAD env.

🤖 Generated with [Claude Code](https://claude.com/claude-code)