### PR TITLE
claude: record buck2 cache + jj workspace lessons

### DIFF
--- a/.claude/rules/project/project_buck2_re_client_facts.md
+++ b/.claude/rules/project/project_buck2_re_client_facts.md
@@ -5,6 +5,7 @@
 Working BuildBuddy config (verified 2026-07-14):
 scheme-less addresses (`remote.buildbuddy.io` — `grpcs://`/`https://` are rejected), `[buck2] digest_algorithms = SHA256`, API key via `.buckconfig.local` `http_headers = x-buildbuddy-api-key:…` (gitignored, like `.bazelrc.user`), and a custom exec platform with `remote_cache_enabled = True` (the bundled `prelude//platforms:default` has no cache).
 
-Cache uploads from locally-executed actions did not happen with executor `allow_cache_uploads = True` alone; action-level `allow_cache_upload` policy was still unsolved as of 2026-07-14, so no cache hit has been demonstrated.
+Uploads from locally-executed actions require per-action `allow_cache_upload = True` ANDed with the executor's `allow_cache_uploads`; the OSS prelude hard-codes uploads off for `genrule` and never sets the flag on `http_archive`'s unpack action, so cache-participating targets use the custom rules in `tools/defs.bzl` (`cached_check`, `cached_http_archive`).
+The round-trip (upload, then 100% hits after `buck2 clean` + `buck2 kill`) is asserted on every CI run (#392, verified 2026-07-15).
 
 tonic#2185 (GOAWAY mishandling behind BuildBuddy's L7 proxy) never reproduced here and is untested under sustained load; a GOAWAY-shielding hyper/hyper-util reverse proxy is shelved on branch `buck2-re-proxy-shelf` (no PR) — revive only if load testing shows GOAWAY failures.

--- a/.claude/rules/project/project_jj_workspace_snapshots.md
+++ b/.claude/rules/project/project_jj_workspace_snapshots.md
@@ -1,0 +1,8 @@
+# jj snapshots are per-workspace
+
+`jj` snapshots working-copy edits only in the workspace it is invoked from.
+Disk edits in a secondary workspace (e.g. `~/causes-buck2`) stay invisible to jj commands run in the main workspace: a cross-workspace `jj squash --from <ws>@` moves the stale recorded content (possibly empty), and `jj workspace update-stale` resets the secondary working copy, destroying the unsnapshotted edits.
+
+**Why:** fixes edited on disk in the buck2 workspace were squashed as empty from the main workspace; the unfixed commit reached CI, and the disk edits were then wiped by `update-stale` (PR #392, 2026-07-15).
+
+**How to apply:** after editing files in a secondary workspace, run any snapshotting command (`jj st`) inside that workspace before referencing its `<ws>@` commit from anywhere else.

--- a/platforms/defs.bzl
+++ b/platforms/defs.bzl
@@ -3,6 +3,11 @@
 # gitignored .buckconfig.local — see .buckconfig.local.template), so a
 # checkout without credentials builds purely locally with the same platform
 # and the whole graph keeps a single configuration in both modes.
+#
+# Invariant: everything in `//...` is a cacheable pure function of its
+# declared inputs, so caching is platform-wide with no per-target opt-out.
+# A target that cannot satisfy this must be redesigned or become a `run`
+# target.
 _REMOTE_CACHE = read_root_config("buck2_re_client", "engine_address") != None
 
 def _impl(ctx: AnalysisContext) -> list[Provider]:


### PR DESCRIPTION
Design decision documented where it binds: the platform invariant (everything in `//...` is a cacheable pure function of declared inputs, no per-target cache opt-outs) goes in `platforms/defs.bzl`.
Memories: the jj per-workspace snapshot gotcha (the #392 CI failure), and RE client facts refreshed — per-action `allow_cache_upload` solved uploads; the round-trip is now asserted in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)