### PR TITLE
ci_health: ingest buck2 job telemetry

### DIFF
--- a/tools/ci_health/src/artifacts.rs
+++ b/tools/ci_health/src/artifacts.rs
@@ -217,6 +217,7 @@ mod tests {
             bb_invocation_ids: vec![],
             metrics_collection_seconds: 0.0,
             gate_timings: vec![],
+            buck2: None,
         }
     }
 

--- a/tools/ci_health/src/buck2.rs
+++ b/tools/ci_health/src/buck2.rs
@@ -1,0 +1,269 @@
+//! Parses buck2's end-of-build summary lines out of a CI job log.
+//!
+//! Every buck2 invocation that runs actions prints, on stderr:
+//!
+//! ```text
+//! [2026-07-15T10:30:00.625+00:00] Build ID: ac446c1c-…
+//! [2026-07-15T10:30:04.155+00:00] Cache hits: 100%
+//! [2026-07-15T10:30:04.155+00:00] Commands: 2 (cached: 2, remote: 0, local: 0)
+//! [2026-07-15T10:30:04.155+00:00] Network: Up: 270KiB  Down: 90MiB  (GRPC-SESSION-ID)
+//! ```
+//!
+//! The `Network:` line is absent in local-only mode (no remote cache
+//! configured), and the `Cache hits:` percentage is redundant with the
+//! `Commands:` counts, so only `Build ID:`/`Commands:`/`Network:` are read.
+
+use crate::metrics::{Buck2BuildId, Buck2Invocation};
+use anyhow::{Context, Result, bail};
+
+/// Extract one `Buck2Invocation` per action-running buck2 invocation in `log`.
+/// A `Build ID:` with no following `Commands:` line (e.g. `buck2 clean`) is
+/// not an action-running invocation and is dropped.
+/// Malformed `Commands:`/`Network:` lines fail loudly.
+pub fn extract_invocations(log: &str) -> Result<Vec<Buck2Invocation>> {
+    let mut out = Vec::new();
+    let mut current: Option<Pending> = None;
+    for line in log.lines() {
+        if let Some(rest) = after(line, "] Build ID: ") {
+            if let Some(done) = current.take().and_then(Pending::finish) {
+                out.push(done);
+            }
+            current = Some(Pending::new(token(rest)));
+        } else if let Some(rest) = after(line, "] Commands: ") {
+            let cur = current
+                .as_mut()
+                .with_context(|| format!("Commands line before any Build ID: {line}"))?;
+            if cur.commands.is_some() {
+                bail!("second Commands line for build {}: {line}", cur.build_id.0);
+            }
+            cur.commands = Some(parse_commands(rest).with_context(|| format!("parse {line}"))?);
+        } else if let Some(rest) = after(line, "] Network: ") {
+            let cur = current
+                .as_mut()
+                .with_context(|| format!("Network line before any Build ID: {line}"))?;
+            cur.network = Some(parse_network(rest).with_context(|| format!("parse {line}"))?);
+        }
+    }
+    if let Some(done) = current.and_then(Pending::finish) {
+        out.push(done);
+    }
+    Ok(out)
+}
+
+struct Pending {
+    build_id: Buck2BuildId,
+    commands: Option<Commands>,
+    network: Option<Network>,
+}
+
+struct Commands {
+    total: u64,
+    cached: u64,
+    remote: u64,
+    local: u64,
+}
+
+struct Network {
+    up: u64,
+    down: u64,
+}
+
+impl Pending {
+    fn new(build_id: &str) -> Self {
+        Self {
+            build_id: Buck2BuildId(build_id.to_owned()),
+            commands: None,
+            network: None,
+        }
+    }
+
+    fn finish(self) -> Option<Buck2Invocation> {
+        let commands = self.commands?;
+        let network = self.network.unwrap_or(Network { up: 0, down: 0 });
+        Some(Buck2Invocation {
+            build_id: self.build_id,
+            commands_total: commands.total,
+            commands_cached: commands.cached,
+            commands_remote: commands.remote,
+            commands_local: commands.local,
+            bytes_uploaded: network.up,
+            bytes_downloaded: network.down,
+        })
+    }
+}
+
+/// The remainder of `line` after `needle`, when present.
+fn after<'a>(line: &'a str, needle: &str) -> Option<&'a str> {
+    line.find(needle).map(|i| &line[i + needle.len()..])
+}
+
+/// The leading whitespace-delimited token of `rest`.
+fn token(rest: &str) -> &str {
+    rest.split_whitespace().next().unwrap_or("")
+}
+
+/// Parse `2 (cached: 2, remote: 0, local: 0)`.
+fn parse_commands(rest: &str) -> Result<Commands> {
+    let total = token(rest).parse().context("total")?;
+    let field = |key: &str| -> Result<u64> {
+        let val = after(rest, key).with_context(|| format!("missing {key}"))?;
+        val.split(|c: char| !c.is_ascii_digit())
+            .next()
+            .unwrap_or("")
+            .parse()
+            .with_context(|| key.to_owned())
+    };
+    Ok(Commands {
+        total,
+        cached: field("cached: ")?,
+        remote: field("remote: ")?,
+        local: field("local: ")?,
+    })
+}
+
+/// Parse `Up: 270KiB  Down: 90MiB  (GRPC-SESSION-ID)`.
+fn parse_network(rest: &str) -> Result<Network> {
+    let side = |key: &str| -> Result<u64> {
+        let val = after(rest, key).with_context(|| format!("missing {key}"))?;
+        parse_size(token(val))
+    };
+    Ok(Network {
+        up: side("Up: ")?,
+        down: side("Down: ")?,
+    })
+}
+
+/// Parse buck2's humanized byte sizes: `0B`, `270KiB`, `95MiB`, `1.2GiB`.
+fn parse_size(s: &str) -> Result<u64> {
+    let split = s
+        .find(|c: char| !(c.is_ascii_digit() || c == '.'))
+        .with_context(|| format!("no unit suffix in size {s:?}"))?;
+    let (num, unit) = s.split_at(split);
+    let value: f64 = num.parse().with_context(|| format!("size {s:?}"))?;
+    let multiplier: f64 = match unit {
+        "B" => 1.0,
+        "KiB" => 1024.0,
+        "MiB" => 1024.0 * 1024.0,
+        "GiB" => 1024.0 * 1024.0 * 1024.0,
+        "TiB" => 1024.0 * 1024.0 * 1024.0 * 1024.0,
+        _ => bail!("unknown size unit {unit:?} in {s:?}"),
+    };
+    Ok((value * multiplier).round() as u64)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Verbatim shape of the CI `buck2` job log (run 29408325080): GH
+    /// timestamp prefix, buck2 timestamp bracket, two invocations
+    /// (populate build + round-trip rebuild), and noise lines that must
+    /// not match — including the workflow's echoed script, which contains
+    /// the text `Cache hits: 100%`.
+    const CI_LOG: &str = "\
+2026-07-15T10:29:58.7962448Z ##[group]Run buck2 build //...
+2026-07-15T10:30:00.6284552Z [2026-07-15T10:30:00.625+00:00] Build ID: ac446c1c-5913-44d6-bd0e-0c1a47d36f26
+2026-07-15T10:30:04.1555320Z [2026-07-15T10:30:04.155+00:00] Cache hits: 100%
+2026-07-15T10:30:04.1556498Z [2026-07-15T10:30:04.155+00:00] Commands: 2 (cached: 2, remote: 0, local: 0)
+2026-07-15T10:30:04.1557879Z [2026-07-15T10:30:04.155+00:00] Network: Up: 270KiB  Down: 90MiB  (GRPC-SESSION-ID)
+2026-07-15T10:30:04.1579315Z BUILD SUCCEEDED
+2026-07-15T10:30:04.1730050Z ##[group]Run buck2 clean
+2026-07-15T10:30:04.1732178Z \u{1b}[36;1mgrep -q 'Cache hits: 100%' rebuild.log\u{1b}[0m
+2026-07-15T10:30:04.7498178Z [2026-07-15T10:30:04.746+00:00] Build ID: 40e60d62-f0c7-4990-9649-9320026c1626
+2026-07-15T10:30:08.0737989Z [2026-07-15T10:30:08.073+00:00] Cache hits: 100%
+2026-07-15T10:30:08.0739025Z [2026-07-15T10:30:08.073+00:00] Commands: 2 (cached: 2, remote: 0, local: 0)
+2026-07-15T10:30:08.0740052Z [2026-07-15T10:30:08.073+00:00] Network: Up: 271KiB  Down: 95MiB  (GRPC-SESSION-ID)
+2026-07-15T10:30:08.0754127Z BUILD SUCCEEDED
+";
+
+    #[test]
+    fn extracts_both_invocations_from_ci_log() {
+        let got = extract_invocations(CI_LOG).unwrap();
+        assert_eq!(
+            got,
+            vec![
+                Buck2Invocation {
+                    build_id: Buck2BuildId("ac446c1c-5913-44d6-bd0e-0c1a47d36f26".into()),
+                    commands_total: 2,
+                    commands_cached: 2,
+                    commands_remote: 0,
+                    commands_local: 0,
+                    bytes_uploaded: 270 * 1024,
+                    bytes_downloaded: 90 * 1024 * 1024,
+                },
+                Buck2Invocation {
+                    build_id: Buck2BuildId("40e60d62-f0c7-4990-9649-9320026c1626".into()),
+                    commands_total: 2,
+                    commands_cached: 2,
+                    commands_remote: 0,
+                    commands_local: 0,
+                    bytes_uploaded: 271 * 1024,
+                    bytes_downloaded: 95 * 1024 * 1024,
+                },
+            ]
+        );
+    }
+
+    /// Local-only mode (no remote cache configured) prints no `Network:`
+    /// line; bytes default to zero.
+    /// Captured from a dev-workspace build on 2026-07-15.
+    #[test]
+    fn local_mode_has_no_network_line() {
+        let log = "\
+[2026-07-15T10:41:33.194+00:00] Build ID: c28c6d92-0198-4288-b836-b4e023a2fd9e
+[2026-07-15T10:41:36.545+00:00] Cache hits: 0%
+[2026-07-15T10:41:36.545+00:00] Commands: 2 (cached: 0, remote: 0, local: 2)
+BUILD SUCCEEDED
+";
+        let got = extract_invocations(log).unwrap();
+        assert_eq!(got.len(), 1);
+        assert_eq!(got[0].commands_local, 2);
+        assert_eq!(got[0].bytes_uploaded, 0);
+        assert_eq!(got[0].bytes_downloaded, 0);
+        assert_eq!(got[0].commands_cached, 0);
+    }
+
+    /// `buck2 clean` / `buck2 kill` print a `Build ID:` but run no
+    /// actions; they must not produce an invocation.
+    #[test]
+    fn build_id_without_commands_is_dropped() {
+        let log = "\
+[2026-07-15T10:30:04.5.000+00:00] Build ID: 11111111-2222-3333-4444-555555555555
+/home/runner/work/causes-tracker/causes-tracker/buck-out/v2/CACHEDIR.TAG
+[2026-07-15T10:30:04.746+00:00] Build ID: 40e60d62-f0c7-4990-9649-9320026c1626
+[2026-07-15T10:30:08.073+00:00] Commands: 3 (cached: 1, remote: 0, local: 2)
+";
+        let got = extract_invocations(log).unwrap();
+        assert_eq!(got.len(), 1);
+        assert_eq!(
+            got[0].build_id,
+            Buck2BuildId("40e60d62-f0c7-4990-9649-9320026c1626".into())
+        );
+        assert_eq!(got[0].commands_total, 3);
+    }
+
+    #[test]
+    fn malformed_commands_line_errors() {
+        let log = "\
+[2026-07-15T10:30:04.746+00:00] Build ID: 40e60d62-f0c7-4990-9649-9320026c1626
+[2026-07-15T10:30:08.073+00:00] Commands: 2 (cached: two, remote: 0, local: 0)
+";
+        assert!(extract_invocations(log).is_err());
+    }
+
+    #[test]
+    fn empty_log_yields_no_invocations() {
+        assert_eq!(extract_invocations("").unwrap(), vec![]);
+    }
+
+    #[test]
+    fn parses_humanized_sizes() {
+        assert_eq!(parse_size("0B").unwrap(), 0);
+        assert_eq!(parse_size("270KiB").unwrap(), 276480);
+        assert_eq!(parse_size("95MiB").unwrap(), 99614720);
+        assert_eq!(parse_size("1.2GiB").unwrap(), 1288490189);
+        assert_eq!(parse_size("3TiB").unwrap(), 3 * 1024u64.pow(4));
+        assert!(parse_size("95XB").is_err());
+        assert!(parse_size("").is_err());
+    }
+}

--- a/tools/ci_health/src/comparison.rs
+++ b/tools/ci_health/src/comparison.rs
@@ -300,6 +300,7 @@ mod tests {
             bb_invocation_ids: vec![],
             metrics_collection_seconds: 0.0,
             gate_timings: vec![],
+            buck2: None,
         }
     }
 

--- a/tools/ci_health/src/github.rs
+++ b/tools/ci_health/src/github.rs
@@ -144,6 +144,10 @@ impl GithubClient {
             .with_context(|| format!("job '{job_name}' not found in run {}", run_id.0))?;
         Ok(JobSteps {
             job_wall_seconds: duration(Some(job.started_at), job.completed_at),
+            succeeded: matches!(
+                job.conclusion,
+                Some(octocrab::models::workflows::Conclusion::Success)
+            ),
             steps: job
                 .steps
                 .into_iter()
@@ -179,6 +183,8 @@ impl GithubClient {
 /// Wall-clock duration of one job and its steps, by step name.
 pub struct JobSteps {
     pub job_wall_seconds: f64,
+    /// Whether the job's conclusion is `success`.
+    pub succeeded: bool,
     pub steps: Vec<(String, f64)>,
 }
 
@@ -393,6 +399,7 @@ mod tests {
         assert_eq!(t.other_seconds, 2.0);
         let js = client.job_steps(RunId(run_id), "build").await.unwrap();
         assert_eq!(js.job_wall_seconds, 180.0);
+        assert!(js.succeeded);
         assert_eq!(
             js.steps,
             vec![

--- a/tools/ci_health/src/main.rs
+++ b/tools/ci_health/src/main.rs
@@ -2,6 +2,7 @@ use anyhow::{Context, Result};
 use clap::{Parser, Subcommand};
 
 mod artifacts;
+mod buck2;
 mod buildbuddy;
 mod comparison;
 mod config;
@@ -15,7 +16,7 @@ use crate::comparison::{
     Baseline, COMMENT_MARKER, Verdict, classify, load_baseline_dir, render_pr_comment,
 };
 use crate::github::{GithubClient, OWNER, REPO, token_from_env};
-use crate::metrics::{GateTiming, RunId, RunMetrics};
+use crate::metrics::{Buck2Stats, GateTiming, RunId, RunMetrics};
 use crate::trend::{
     ISSUE_MARKER, ISSUE_TITLE, TrendVerdict, WindowStats, render_issue_body,
     render_recovery_comment,
@@ -57,6 +58,11 @@ enum Command {
         /// folded into the emitted `RunMetrics.gate_timings`.
         #[arg(long)]
         check_timings: Option<std::path::PathBuf>,
+        /// Name of the CI buck2 job to ingest telemetry from: its step
+        /// timings plus the invocation summaries buck2 printed into the
+        /// job log. Omitted → `RunMetrics.buck2` is null.
+        #[arg(long)]
+        buck2_job: Option<String>,
     },
     /// Classify a run's metrics against a baseline directory of recent
     /// successful master runs. Exit code reflects the verdict (0 = ok,
@@ -131,6 +137,7 @@ async fn main() -> Result<()> {
             job,
             pr,
             check_timings,
+            buck2_job,
         } => {
             let token = token_from_env("record")?;
             let bb_key = safelog::Sensitive::new(
@@ -146,6 +153,7 @@ async fn main() -> Result<()> {
                 &job,
                 pr,
                 check_timings.as_deref(),
+                buck2_job.as_deref(),
                 &out,
             )
             .await
@@ -735,6 +743,7 @@ async fn record(
     job: &str,
     pr: Option<u64>,
     check_timings_path: Option<&std::path::Path>,
+    buck2_job: Option<&str>,
     out: &std::path::Path,
 ) -> Result<()> {
     let started = std::time::Instant::now();
@@ -749,6 +758,10 @@ async fn record(
         Some(p) => parse_gate_timings(p)?,
         None => Vec::new(),
     };
+    let buck2 = match buck2_job {
+        Some(j) => Some(collect_buck2(gh, run_id, j).await?),
+        None => None,
+    };
     let metrics = RunMetrics {
         run_id,
         sha: meta.head_sha,
@@ -760,10 +773,58 @@ async fn record(
         bb_invocation_ids: invocation_ids,
         metrics_collection_seconds: started.elapsed().as_secs_f64(),
         gate_timings,
+        buck2,
     };
     let json = serde_json::to_string_pretty(&metrics).context("serialize metrics")?;
     write_atomic(out, json.as_bytes()).with_context(|| format!("write {}", out.display()))?;
     Ok(())
+}
+
+/// Step names in the CI buck2 job, mirroring `github::classify_step`'s
+/// coupling to the names in build.yml.
+const BUCK2_BUILD_STEP: &str = "Build buck2 targets";
+const BUCK2_ROUND_TRIP_STEP: &str = "Verify remote cache round-trip";
+
+/// Ingest the buck2 job's step timings and the invocation summaries buck2
+/// printed into its log.
+/// A failed job records whatever is present — zero step times, possibly
+/// no invocations — matching how bazel stats degrade on failed runs.
+/// A successful job always ran two builds, so missing summaries or a
+/// missing step name there means the parser or build.yml drifted and
+/// fails loudly.
+async fn collect_buck2(gh: &GithubClient, run_id: RunId, job: &str) -> Result<Buck2Stats> {
+    let log = gh.job_log(run_id, job).await?;
+    let invocations = buck2::extract_invocations(&log)?;
+    let steps = gh.job_steps(run_id, job).await?;
+    let step = |name: &str| -> f64 {
+        steps
+            .steps
+            .iter()
+            .filter(|(n, _)| n == name)
+            .map(|(_, d)| d)
+            .sum()
+    };
+    let build_seconds = step(BUCK2_BUILD_STEP);
+    let round_trip_seconds = step(BUCK2_ROUND_TRIP_STEP);
+    if steps.succeeded {
+        if invocations.is_empty() {
+            anyhow::bail!("no buck2 invocation summaries in job '{job}' log");
+        }
+        for (name, seconds) in [
+            (BUCK2_BUILD_STEP, build_seconds),
+            (BUCK2_ROUND_TRIP_STEP, round_trip_seconds),
+        ] {
+            if seconds == 0.0 {
+                anyhow::bail!("step '{name}' not found in job '{job}' (renamed in build.yml?)");
+            }
+        }
+    }
+    Ok(Buck2Stats {
+        job_wall_seconds: steps.job_wall_seconds,
+        build_seconds,
+        round_trip_seconds,
+        invocations,
+    })
 }
 
 /// Read the JSONL emitted by `tools/check.sh` with `CHECK_TIMING_JSONL=<path>`.
@@ -957,6 +1018,43 @@ mod tests {
         assert!(rows[2].ratio.is_none());
     }
 
+    /// Mount the `runs/{id}` and `runs/{id}/jobs` fixtures every `record`
+    /// test needs.
+    async fn mount_run_and_jobs(gh_mock: &wiremock::MockServer, run_id: u64) {
+        mount_run_with_jobs(gh_mock, run_id, jobs_body(run_id)).await;
+    }
+
+    async fn mount_run_with_jobs(
+        gh_mock: &wiremock::MockServer,
+        run_id: u64,
+        jobs: serde_json::Value,
+    ) {
+        wiremock::Mock::given(wiremock::matchers::method("GET"))
+            .and(wiremock::matchers::path(format!(
+                "/repos/causes-tracker/causes-tracker/actions/runs/{run_id}"
+            )))
+            .respond_with(wiremock::ResponseTemplate::new(200).set_body_json(run_body(run_id)))
+            .mount(gh_mock)
+            .await;
+        wiremock::Mock::given(wiremock::matchers::method("GET"))
+            .and(wiremock::matchers::path(format!(
+                "/repos/causes-tracker/causes-tracker/actions/runs/{run_id}/jobs"
+            )))
+            .respond_with(wiremock::ResponseTemplate::new(200).set_body_json(jobs))
+            .mount(gh_mock)
+            .await;
+    }
+
+    async fn mount_job_log(gh_mock: &wiremock::MockServer, job_id: u64, body: &str) {
+        wiremock::Mock::given(wiremock::matchers::method("GET"))
+            .and(wiremock::matchers::path(format!(
+                "/repos/causes-tracker/causes-tracker/actions/jobs/{job_id}/logs"
+            )))
+            .respond_with(wiremock::ResponseTemplate::new(200).set_body_string(body))
+            .mount(gh_mock)
+            .await;
+    }
+
     /// End-to-end test of the BB-extended `record`: both GH and BB clients pointed at wiremock servers produce a metrics JSON with populated bazel stats.
     #[tokio::test]
     async fn record_writes_metrics_with_bazel_stats() {
@@ -964,31 +1062,15 @@ mod tests {
         let gh_mock = wiremock::MockServer::start().await;
         let bb_mock = wiremock::MockServer::start().await;
         let run_id = 7777u64;
-        wiremock::Mock::given(wiremock::matchers::method("GET"))
-            .and(wiremock::matchers::path(format!(
-                "/repos/causes-tracker/causes-tracker/actions/runs/{run_id}"
-            )))
-            .respond_with(wiremock::ResponseTemplate::new(200).set_body_json(run_body(run_id)))
-            .mount(&gh_mock)
-            .await;
-        wiremock::Mock::given(wiremock::matchers::method("GET"))
-            .and(wiremock::matchers::path(format!(
-                "/repos/causes-tracker/causes-tracker/actions/runs/{run_id}/jobs"
-            )))
-            .respond_with(wiremock::ResponseTemplate::new(200).set_body_json(jobs_body(run_id)))
-            .mount(&gh_mock)
-            .await;
+        mount_run_and_jobs(&gh_mock, run_id).await;
         // GH job log: bazel prints one BB URL per `--bes_results_url`
         // invocation; `bazel_invocation_ids` regexes them out.
-        wiremock::Mock::given(wiremock::matchers::method("GET"))
-            .and(wiremock::matchers::path(
-                "/repos/causes-tracker/causes-tracker/actions/jobs/1/logs",
-            ))
-            .respond_with(wiremock::ResponseTemplate::new(200).set_body_string(
-                "INFO: Streaming build results to: https://app.buildbuddy.io/invocation/1234aaaa-bbbb-cccc-dddd-eeeeeeeeeeee\n",
-            ))
-            .mount(&gh_mock)
-            .await;
+        mount_job_log(
+            &gh_mock,
+            1,
+            "INFO: Streaming build results to: https://app.buildbuddy.io/invocation/1234aaaa-bbbb-cccc-dddd-eeeeeeeeeeee\n",
+        )
+        .await;
         wiremock::Mock::given(wiremock::matchers::method("POST"))
             .and(wiremock::matchers::path(
                 "/rpc/BuildBuddyService/GetInvocation",
@@ -1038,6 +1120,7 @@ mod tests {
             "build",
             Some(99),
             Some(timings.path()),
+            None,
             out.path(),
         )
         .await
@@ -1056,6 +1139,106 @@ mod tests {
         assert_eq!(parsed.gate_timings.len(), 2);
         assert_eq!(parsed.gate_timings[0].gate, "format_check");
         assert_eq!(parsed.gate_timings[1].seconds, 42.106);
+        assert!(parsed.buck2.is_none());
+    }
+
+    /// Summary lines as buck2 prints them into the CI job log, wrapped in
+    /// the GH timestamp prefix.
+    const BUCK2_JOB_LOG: &str = "\
+2026-07-15T10:30:00.6284552Z [2026-07-15T10:30:00.625+00:00] Build ID: ac446c1c-5913-44d6-bd0e-0c1a47d36f26
+2026-07-15T10:30:04.1556498Z [2026-07-15T10:30:04.155+00:00] Commands: 2 (cached: 0, remote: 0, local: 2)
+2026-07-15T10:30:04.1557879Z [2026-07-15T10:30:04.155+00:00] Network: Up: 270KiB  Down: 0B  (GRPC-SESSION-ID)
+2026-07-15T10:30:04.7498178Z [2026-07-15T10:30:04.746+00:00] Build ID: 40e60d62-f0c7-4990-9649-9320026c1626
+2026-07-15T10:30:08.0739025Z [2026-07-15T10:30:08.073+00:00] Commands: 2 (cached: 2, remote: 0, local: 0)
+2026-07-15T10:30:08.0740052Z [2026-07-15T10:30:08.073+00:00] Network: Up: 271KiB  Down: 95MiB  (GRPC-SESSION-ID)
+";
+
+    /// `record --buck2-job` fills `RunMetrics.buck2` from the buck2 job's
+    /// step timings and log summaries, alongside the bazel stats.
+    #[tokio::test]
+    async fn record_with_buck2_job_ingests_summaries() {
+        causes_crypto::install_default_provider();
+        let gh_mock = wiremock::MockServer::start().await;
+        let bb_mock = wiremock::MockServer::start().await;
+        let run_id = 8888u64;
+        mount_run_and_jobs(&gh_mock, run_id).await;
+        mount_job_log(&gh_mock, 1, "").await;
+        mount_job_log(&gh_mock, 2, BUCK2_JOB_LOG).await;
+
+        let gh = GithubClient::with_base_uri("tk".into(), gh_mock.uri()).unwrap();
+        let bb =
+            BuildBuddyClient::with_base_url(safelog::Sensitive::new("k".into()), bb_mock.uri())
+                .unwrap();
+        let out = tempfile::NamedTempFile::new().unwrap();
+        record(
+            &gh,
+            &bb,
+            RunId(run_id),
+            "build",
+            None,
+            None,
+            Some("buck2"),
+            out.path(),
+        )
+        .await
+        .unwrap();
+
+        let parsed: RunMetrics =
+            serde_json::from_str(&std::fs::read_to_string(out.path()).unwrap()).unwrap();
+        let b = parsed.buck2.expect("buck2 stats recorded");
+        assert_eq!(b.job_wall_seconds, 24.0);
+        assert_eq!(b.build_seconds, 6.0);
+        assert_eq!(b.round_trip_seconds, 4.0);
+        assert_eq!(b.invocations.len(), 2);
+        assert_eq!(b.invocations[0].commands_local, 2);
+        assert_eq!(b.invocations[1].commands_cached, 2);
+        assert_eq!(b.invocations[1].bytes_downloaded, 95 * 1024 * 1024);
+        assert_eq!(b.invocations[1].commands_total, 2);
+    }
+
+    /// The buck2 job entry from `jobs_body`, rewritten as an early failure:
+    /// non-success conclusion, no steps ran.
+    fn jobs_body_failed_buck2(run_id: u64) -> serde_json::Value {
+        let mut jobs = jobs_body(run_id);
+        jobs["jobs"][1]["conclusion"] = "failure".into();
+        jobs["jobs"][1]["steps"] = serde_json::json!([]);
+        jobs
+    }
+
+    /// A failed buck2 job still records — zero step times, whatever
+    /// summaries parsed — matching how bazel stats degrade to zeros on
+    /// failed runs so failed runs keep getting metrics.
+    #[tokio::test]
+    async fn collect_buck2_degrades_when_job_failed() {
+        let gh_mock = wiremock::MockServer::start().await;
+        let run_id = 9998u64;
+        mount_run_with_jobs(&gh_mock, run_id, jobs_body_failed_buck2(run_id)).await;
+        mount_job_log(&gh_mock, 2, "checkout failed before buck2 ran\n").await;
+        let gh = GithubClient::with_base_uri("tk".into(), gh_mock.uri()).unwrap();
+        let b = collect_buck2(&gh, RunId(run_id), "buck2").await.unwrap();
+        assert!(b.invocations.is_empty());
+        assert_eq!(b.job_wall_seconds, 24.0);
+        assert_eq!(b.build_seconds, 0.0);
+        assert_eq!(b.round_trip_seconds, 0.0);
+    }
+
+    /// A *successful* buck2 job always ran two builds, so a log without
+    /// invocation summaries means the parser or build.yml drifted;
+    /// recording must fail loudly rather than silently going hollow.
+    #[tokio::test]
+    async fn collect_buck2_fails_without_summaries() {
+        let gh_mock = wiremock::MockServer::start().await;
+        let run_id = 9999u64;
+        mount_run_and_jobs(&gh_mock, run_id).await;
+        mount_job_log(&gh_mock, 2, "no summaries here\n").await;
+        let gh = GithubClient::with_base_uri("tk".into(), gh_mock.uri()).unwrap();
+        let err = collect_buck2(&gh, RunId(run_id), "buck2")
+            .await
+            .unwrap_err();
+        assert!(
+            err.to_string().contains("no buck2 invocation summaries"),
+            "unexpected error: {err:#}"
+        );
     }
 
     fn run_body(run_id: u64) -> serde_json::Value {
@@ -1095,7 +1278,7 @@ mod tests {
 
     fn jobs_body(run_id: u64) -> serde_json::Value {
         serde_json::json!({
-            "total_count": 1,
+            "total_count": 2,
             "jobs": [{
                 "id": 1,
                 "run_id": run_id,
@@ -1115,6 +1298,39 @@ mod tests {
                 "name": "build",
                 "steps": [],
                 "check_run_url": "https://api.github.com/c/1",
+                "labels": ["ubuntu-latest"],
+                "runner_id": 1,
+                "runner_name": "r",
+                "runner_group_id": 1,
+                "runner_group_name": "g",
+            }, {
+                "id": 2,
+                "run_id": run_id,
+                "workflow_name": "build",
+                "head_branch": "feature/x",
+                "run_url": "https://api.github.com/r/x",
+                "run_attempt": 1,
+                "node_id": "j2",
+                "head_sha": "feedface",
+                "url": "https://api.github.com/j/2",
+                "html_url": "https://github.com/j/2",
+                "status": "completed",
+                "conclusion": "success",
+                "created_at": "2026-05-16T23:59:30Z",
+                "started_at": "2026-05-17T00:00:00Z",
+                "completed_at": "2026-05-17T00:00:24Z",
+                "name": "buck2",
+                "steps": [
+                    {"name": "Build buck2 targets",
+                     "status": "completed", "conclusion": "success", "number": 1,
+                     "started_at": "2026-05-17T00:00:05Z",
+                     "completed_at": "2026-05-17T00:00:11Z"},
+                    {"name": "Verify remote cache round-trip",
+                     "status": "completed", "conclusion": "success", "number": 2,
+                     "started_at": "2026-05-17T00:00:11Z",
+                     "completed_at": "2026-05-17T00:00:15Z"},
+                ],
+                "check_run_url": "https://api.github.com/c/2",
                 "labels": ["ubuntu-latest"],
                 "runner_id": 1,
                 "runner_name": "r",

--- a/tools/ci_health/src/metrics.rs
+++ b/tools/ci_health/src/metrics.rs
@@ -42,6 +42,34 @@ impl BazelStats {
     }
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct Buck2BuildId(pub String);
+
+/// One buck2 invocation's action counts and cache traffic, parsed from the
+/// summary lines buck2 prints at the end of every build.
+/// `bytes_*` come from buck2's humanized `Network:` line (absent in
+/// local-only mode), so they carry display rounding, not exact counts.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct Buck2Invocation {
+    pub build_id: Buck2BuildId,
+    pub commands_total: u64,
+    pub commands_cached: u64,
+    pub commands_remote: u64,
+    pub commands_local: u64,
+    pub bytes_uploaded: u64,
+    pub bytes_downloaded: u64,
+}
+
+/// Timings and per-invocation stats for the CI `buck2` job.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct Buck2Stats {
+    pub job_wall_seconds: f64,
+    pub build_seconds: f64,
+    pub round_trip_seconds: f64,
+    pub invocations: Vec<Buck2Invocation>,
+}
+
 /// One entry from the JSONL file `tools/check.sh` writes when
 /// `CHECK_TIMING_JSONL` is set.
 /// `gate` is the gate name passed to `run_gate` (e.g. `format_check`),
@@ -71,6 +99,10 @@ pub struct RunMetrics {
     /// Empty when `record` was invoked without `--check-timings`.
     #[serde(default)]
     pub gate_timings: Vec<GateTiming>,
+    /// Stats for the CI `buck2` job.
+    /// `None` in artifacts recorded without buck2 job data.
+    #[serde(default)]
+    pub buck2: Option<Buck2Stats>,
 }
 
 #[cfg(test)]
@@ -108,6 +140,20 @@ mod tests {
                 rc: 0,
                 seconds: 4.221,
             }],
+            buck2: Some(Buck2Stats {
+                job_wall_seconds: 24.0,
+                build_seconds: 6.0,
+                round_trip_seconds: 4.0,
+                invocations: vec![Buck2Invocation {
+                    build_id: Buck2BuildId("ac446c1c".into()),
+                    commands_total: 2,
+                    commands_cached: 2,
+                    commands_remote: 0,
+                    commands_local: 0,
+                    bytes_uploaded: 276480,
+                    bytes_downloaded: 94371840,
+                }],
+            }),
         };
         let s = serde_json::to_string(&m).unwrap();
         let back: RunMetrics = serde_json::from_str(&s).unwrap();
@@ -129,5 +175,6 @@ mod tests {
         }"#;
         let m: RunMetrics = serde_json::from_str(legacy).unwrap();
         assert!(m.gate_timings.is_empty());
+        assert!(m.buck2.is_none());
     }
 }

--- a/tools/ci_health/src/trend.rs
+++ b/tools/ci_health/src/trend.rs
@@ -314,6 +314,7 @@ mod tests {
             bb_invocation_ids: vec![],
             metrics_collection_seconds: 0.0,
             gate_timings: vec![],
+            buck2: None,
         }
     }
 


### PR DESCRIPTION
`record --buck2-job <name>` fills a new `RunMetrics.buck2` from the named CI job: step timings for the build and round-trip steps, plus per-invocation command counts and cache traffic parsed from the summary lines buck2 prints into the job log.
No artifact hop and nothing runs under buck2: the job log is the raw source, fetched the same way bazel BuildBuddy invocation IDs already are.
A failed buck2 job degrades like bazel stats do (zero step times, whatever summaries parsed), so failed runs keep getting metrics; a successful job without summaries or expected step names fails loudly — two builds always run, so absence there means parser or build.yml drift.
Parser grounded on the real log of run 29408325080 (remote mode) and a live local build (local mode, no `Network:` line); verified with a live `record` call against that run.
Legacy artifacts deserialize with `buck2: null`; `compare`/`trend`/`query` are unchanged until artifacts accumulate.

Stacked on #396.

🤖 Generated with [Claude Code](https://claude.com/claude-code)