### PR TITLE
buck2: stage the full cpython tree for //tools:py

### DIFF
--- a/third_party/python/BUCK
+++ b/third_party/python/BUCK
@@ -4,7 +4,6 @@ cached_http_archive(
     name = "cpython",
     sha256 = "c218f50baeb2c06a30c2f03db5986b2bad6ab7c8a52faad2d5a59bda0677b93a",
     strip_components = 1,
-    sub_targets = ["bin/python3"],
     urls = ["https://github.com/astral-sh/python-build-standalone/releases/download/20260610/cpython-3.12.13+20260610-x86_64-unknown-linux-gnu-install_only.tar.gz"],
     visibility = ["PUBLIC"],
 )

--- a/tools/BUCK
+++ b/tools/BUCK
@@ -1,8 +1,9 @@
-load(":defs.bzl", "cached_check")
+load(":defs.bzl", "cached_check", "tree_tool")
 
-command_alias(
+tree_tool(
     name = "py",
-    exe = "//third_party/python:cpython[bin/python3]",
+    path = "bin/python3",
+    tree = "//third_party/python:cpython",
     visibility = ["PUBLIC"],
 )
 

--- a/tools/defs.bzl
+++ b/tools/defs.bzl
@@ -21,6 +21,24 @@ cached_check = rule(
     },
 )
 
+# Tool at a path inside a directory artifact.
+# Projecting a path declares only that subtree as an action input, so a
+# tool that reads sibling files at runtime (python3 finds its stdlib
+# relative to the binary) breaks under input staging; the whole tree
+# rides along as a hidden input instead.
+def _tree_tool_impl(ctx: AnalysisContext) -> list[Provider]:
+    tree = ctx.attrs.tree[DefaultInfo].default_outputs[0]
+    exe = tree.project(ctx.attrs.path)
+    return [DefaultInfo(), RunInfo(args = cmd_args(exe, hidden = tree))]
+
+tree_tool = rule(
+    impl = _tree_tool_impl,
+    attrs = {
+        "path": attrs.string(),
+        "tree": attrs.dep(providers = [DefaultInfo]),
+    },
+)
+
 # http_archive whose unpacked tree is remotely cached.
 # The prelude's http_archive never sets `allow_cache_upload` on its unpack
 # action, so its output can be read from the cache but never repopulates it.


### PR DESCRIPTION
Projecting `bin/python3` out of the cpython tree declares only that subtree as an action input; the interpreter finds its stdlib relative to the binary, so under RE input staging it dies with `No module named encodings`. The unsandboxed local executor masked this by having the whole materialized tree on disk.
New `tree_tool` rule returns a `RunInfo` whose argv is the projected binary with the whole tree as a hidden input.
Verified against a localhost NativeLink worker: `buck2 build --remote-only //...` failed with the encodings error before, passes after; pure-local build unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
