### PR TITLE
buck2: install NativeLink

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -22,5 +22,5 @@
       ]
     }
   },
-  "postCreateCommand": "bazel version && npm install -g @anthropic-ai/claude-code && (jj git init --colocate 2>/dev/null || true) && jj config set --user ui.default-command log && jj config set --user user.name \"$(git config user.name)\" && jj config set --user user.email \"$(git config user.email)\""
+  "postCreateCommand": "bazel version && sudo bash tools/nativelink/install.sh /usr/local/bin && npm install -g @anthropic-ai/claude-code && (jj git init --colocate 2>/dev/null || true) && jj config set --user ui.default-command log && jj config set --user user.name \"$(git config user.name)\" && jj config set --user user.email \"$(git config user.email)\""
 }

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -63,6 +63,8 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
       - name: Install buckle
         run: sudo bash tools/buckle/install.sh /usr/local/bin
+      - name: Install NativeLink
+        run: sudo bash tools/nativelink/install.sh /usr/local/bin
       # Same opt-in mechanism as local dev (.buckconfig.local.template):
       # enables the BuildBuddy remote cache for the build below.
       - name: Enable BuildBuddy remote cache

--- a/renovate.json
+++ b/renovate.json
@@ -75,6 +75,19 @@
       "depNameTemplate": "jj-vcs/jj",
       "datasourceTemplate": "github-releases",
       "extractVersionTemplate": "^v(?<version>.*)$"
+    },
+    {
+      "description": "Bump PRs fail the installer's sha256 check until the pinned checksum is updated by hand.",
+      "customType": "regex",
+      "managerFilePatterns": [
+        "/^tools/nativelink/install\\.sh$/"
+      ],
+      "matchStrings": [
+        "NATIVELINK_VERSION=(?<currentValue>\\S+)"
+      ],
+      "depNameTemplate": "TraceMachina/nativelink",
+      "datasourceTemplate": "github-releases",
+      "extractVersionTemplate": "^v(?<version>.*)$"
     }
   ]
 }

--- a/tools/nativelink/install.sh
+++ b/tools/nativelink/install.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+# Install the pinned NativeLink binary into $1 (default /usr/local/bin).
+set -euo pipefail
+
+BINDIR="${1:-/usr/local/bin}"
+NATIVELINK_VERSION=1.6.1
+NATIVELINK_SHA256=cd861c1acd8c14f023741d35a310f89527aeadcb681e9818d8e823ee72ae017c
+
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+
+curl -fsSL \
+	"https://github.com/TraceMachina/nativelink/releases/download/v${NATIVELINK_VERSION}/nativelink-${NATIVELINK_VERSION}-x86_64-unknown-linux-musl.tar.gz" \
+	-o "$tmp/nativelink.tar.gz"
+echo "${NATIVELINK_SHA256}  $tmp/nativelink.tar.gz" | sha256sum -c -
+tar xzf "$tmp/nativelink.tar.gz" -C "$tmp"
+install -m 0755 "$tmp/nativelink" "$BINDIR/nativelink"


### PR DESCRIPTION
Pinned v1.6.1 static binary, sha256-checked.
One install script, used by both the CI buck2 job and the devcontainer (`postCreateCommand`) — no duplicated install logic.
A Renovate regex manager tracks NATIVELINK_VERSION against github-releases; bump PRs fail the sha256 check until the checksum is hand-updated.
The binary is unused until the stack's later PRs configure and adopt it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
