### PR TITLE
buck2: configure and auto-start NativeLink

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -24,17 +24,9 @@ RUN curl -fsSL \
       -o /usr/local/bin/buildifier \
     && chmod +x /usr/local/bin/buildifier
 
-# Install Buckle as `buck2` — reads .buckversion to pick the right Buck2 release.
-ARG BUCKLE_VERSION=1.1.0
-ARG BUCKLE_SHA256=dad88b264b1139ff12c30b81c5a71b9ddee54b4148e0f45a2708f7d809bd151d
-RUN curl -fsSL \
-      "https://github.com/benbrittain/buckle/releases/download/v${BUCKLE_VERSION}/buckle-x86_64-unknown-linux-gnu.tar.xz" \
-      -o /tmp/buckle.tar.xz \
-    && echo "${BUCKLE_SHA256}  /tmp/buckle.tar.xz" | sha256sum -c - \
-    && tar xf /tmp/buckle.tar.xz -C /tmp \
-    && install -m 0755 /tmp/buckle-x86_64-unknown-linux-gnu/buckle /usr/local/bin/buckle \
-    && ln -sf buckle /usr/local/bin/buck2 \
-    && rm -rf /tmp/buckle.tar.xz /tmp/buckle-x86_64-unknown-linux-gnu
+# buckle (and the buck2 launcher) are installed from the checkout by
+# postCreateCommand via tools/buckle/install.sh, so the pinned version
+# tracks the checkout rather than the image.
 
 # Install Jujutsu (jj) — version control layered over Git.
 ARG JJ_VERSION=0.41.0

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -22,5 +22,5 @@
       ]
     }
   },
-  "postCreateCommand": "bazel version && sudo bash tools/nativelink/install.sh /usr/local/bin && npm install -g @anthropic-ai/claude-code && (jj git init --colocate 2>/dev/null || true) && jj config set --user ui.default-command log && jj config set --user user.name \"$(git config user.name)\" && jj config set --user user.email \"$(git config user.email)\""
+  "postCreateCommand": "bazel version && sudo bash tools/nativelink/install.sh /usr/local/bin && sudo bash tools/buckle/install.sh /usr/local/bin && npm install -g @anthropic-ai/claude-code && (jj git init --colocate 2>/dev/null || true) && jj config set --user ui.default-command log && jj config set --user user.name \"$(git config user.name)\" && jj config set --user user.email \"$(git config user.email)\""
 }

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -65,6 +65,14 @@ jobs:
         run: sudo bash tools/buckle/install.sh /usr/local/bin
       - name: Install NativeLink
         run: sudo bash tools/nativelink/install.sh /usr/local/bin
+      # The buck2 launcher auto-starts NativeLink with this overlay, whose
+      # stores write through to BuildBuddy (NativeLink holds the key).
+      - name: Configure NativeLink BuildBuddy overlay
+        env:
+          BUILDBUDDY_API_KEY: ${{ secrets.BUILDBUDDY_ORG_API_KEY }}
+        run: |
+          sed "s/YOUR_KEY_HERE/${BUILDBUDDY_API_KEY}/" \
+            tools/nativelink/config-bb.json5.template > .nativelink.json5
       # Same opt-in mechanism as local dev (.buckconfig.local.template):
       # enables the BuildBuddy remote cache for the build below.
       - name: Enable BuildBuddy remote cache
@@ -86,9 +94,14 @@ jobs:
           buck2 kill
           buck2 build //... 2>&1 | tee rebuild.log
           grep -q 'Cache hits: 100%' rebuild.log
+      - name: Show NativeLink log on failure
+        if: failure()
+        run: cat ~/.cache/causes-nativelink/nativelink.log || true
       - name: Shut down buck2 daemon
         if: always()
-        run: buck2 kill || true
+        run: |
+          buck2 kill || true
+          pkill -x nativelink || true
   # Metrics collection runs as a separate job depending on `build` and
   # `buck2` so that their step logs are finalized by the time `record`
   # reads them. Inside a job, the GH logs endpoint 404s on the

--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ infra/github/terraform.tfvars
 # Buck2 — build output tree and per-dev remote-cache credentials
 /buck-out
 .buckconfig.local
+.nativelink.json5
 
 # Node / pnpm
 node_modules/

--- a/tools/buckle/buck2.sh
+++ b/tools/buckle/buck2.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# buck2 launcher: ensure the local NativeLink executor is up, then hand
+# over to buckle (which selects the pinned buck2 from .buckversion).
+# Config selection: the gitignored `.nativelink.json5` at the repo root
+# (the BuildBuddy overlay, see tools/nativelink/config-bb.json5.template)
+# when present, else the committed local-only tools/nativelink/config.json5.
+set -euo pipefail
+
+port_open() {
+	(exec 3<>/dev/tcp/127.0.0.1/50051) 2>/dev/null
+}
+
+# Outside a repo there is nothing to execute on; hand over directly.
+root="$PWD"
+while [[ ! -e "$root/.buckroot" && "$root" != / ]]; do
+	root="$(dirname "$root")"
+done
+
+if [[ -e "$root/.buckroot" ]] && ! port_open; then
+	cfg="$root/.nativelink.json5"
+	[[ -f "$cfg" ]] || cfg="$root/tools/nativelink/config.json5"
+	mkdir -p "$HOME/.cache/causes-nativelink"
+	(
+		flock -n 9 || exit 0
+		port_open && exit 0
+		nohup nativelink "$cfg" \
+			>>"$HOME/.cache/causes-nativelink/nativelink.log" 2>&1 &
+	) 9>"$HOME/.cache/causes-nativelink/launch.lock"
+	for _ in $(seq 100); do
+		port_open && break
+		sleep 0.1
+	done
+	if ! port_open; then
+		echo "warning: NativeLink did not become ready on 127.0.0.1:50051;" \
+			"see ~/.cache/causes-nativelink/nativelink.log" >&2
+	fi
+fi
+
+exec buckle "$@"

--- a/tools/buckle/install.sh
+++ b/tools/buckle/install.sh
@@ -15,4 +15,4 @@ curl -fsSL \
 echo "${BUCKLE_SHA256}  $tmp/buckle.tar.xz" | sha256sum -c -
 tar xf "$tmp/buckle.tar.xz" -C "$tmp"
 install -m 0755 "$tmp/buckle-x86_64-unknown-linux-gnu/buckle" "$BINDIR/buckle"
-ln -sf buckle "$BINDIR/buck2"
+install -m 0755 "$(dirname "$0")/buck2.sh" "$BINDIR/buck2"

--- a/tools/nativelink/config-bb.json5.template
+++ b/tools/nativelink/config-bb.json5.template
@@ -1,0 +1,130 @@
+// config.json5 plus the BuildBuddy cache composition: the fast/slow
+// stores write through to BuildBuddy, so this machine, other devs, and CI
+// share one cache truth. NativeLink holds the BuildBuddy API key; buck2
+// never sees it.
+//
+// Set up (the buck2 launcher auto-starts NativeLink with the gitignored
+// .nativelink.json5 when present, else the committed local-only config):
+//   sed "s/YOUR_KEY_HERE/<api key>/" tools/nativelink/config-bb.json5.template \
+//     > .nativelink.json5
+{
+  stores: [
+    {
+      name: "BB_CAS",
+      grpc: {
+        instance_name: "",
+        endpoints: [
+          {
+            address: "grpcs://remote.buildbuddy.io",
+            tls_config: { use_native_roots: true },
+          },
+        ],
+        store_type: "cas",
+        headers: { "x-buildbuddy-api-key": "YOUR_KEY_HERE" },
+      },
+    },
+    {
+      name: "BB_AC",
+      grpc: {
+        instance_name: "",
+        endpoints: [
+          {
+            address: "grpcs://remote.buildbuddy.io",
+            tls_config: { use_native_roots: true },
+          },
+        ],
+        store_type: "ac",
+        headers: { "x-buildbuddy-api-key": "YOUR_KEY_HERE" },
+      },
+    },
+    {
+      name: "CAS_MAIN_STORE",
+      fast_slow: {
+        fast: {
+          filesystem: {
+            content_path: "${HOME}/.cache/causes-nativelink/data/content_path-cas",
+            temp_path: "${HOME}/.cache/causes-nativelink/data/tmp_path-cas",
+            eviction_policy: { max_bytes: 2000000000 },
+          },
+        },
+        slow: { ref_store: { name: "BB_CAS" } },
+      },
+    },
+    {
+      name: "AC_MAIN_STORE",
+      fast_slow: {
+        fast: {
+          filesystem: {
+            content_path: "${HOME}/.cache/causes-nativelink/data/content_path-ac",
+            temp_path: "${HOME}/.cache/causes-nativelink/data/tmp_path-ac",
+            eviction_policy: { max_bytes: 200000000 },
+          },
+        },
+        slow: { ref_store: { name: "BB_AC" } },
+      },
+    },
+    {
+      // The worker hardlinks each action's sandbox out of its fast store.
+      name: "WORKER_FAST_SLOW_STORE",
+      fast_slow: {
+        fast: {
+          filesystem: {
+            content_path: "${HOME}/.cache/causes-nativelink/data/content_path-worker",
+            temp_path: "${HOME}/.cache/causes-nativelink/data/tmp_path-worker",
+            eviction_policy: { max_bytes: 2000000000 },
+          },
+        },
+        slow: { ref_store: { name: "CAS_MAIN_STORE" } },
+      },
+    },
+  ],
+  schedulers: [
+    {
+      name: "MAIN_SCHEDULER",
+      simple: {
+        supported_platform_properties: {
+          cpu_count: "minimum",
+          OSFamily: "priority",
+          "container-image": "priority",
+        },
+      },
+    },
+  ],
+  workers: [
+    {
+      local: {
+        worker_api_endpoint: { uri: "grpc://127.0.0.1:50061" },
+        cas_fast_slow_store: "WORKER_FAST_SLOW_STORE",
+        upload_action_result: { ac_store: "AC_MAIN_STORE" },
+        work_directory: "${HOME}/.cache/causes-nativelink/work",
+        platform_properties: {
+          cpu_count: { query_cmd: "nproc" },
+          OSFamily: { query_cmd: "uname -s" },
+          "container-image": { values: [""] },
+        },
+      },
+    },
+  ],
+  servers: [
+    {
+      name: "local",
+      listener: { http: { socket_address: "127.0.0.1:50051" } },
+      services: {
+        cas: [{ cas_store: "CAS_MAIN_STORE" }],
+        ac: [{ ac_store: "AC_MAIN_STORE" }],
+        bytestream: [{ cas_store: "CAS_MAIN_STORE" }],
+        execution: [
+          { cas_store: "CAS_MAIN_STORE", scheduler: "MAIN_SCHEDULER" },
+        ],
+        capabilities: [{ remote_execution: { scheduler: "MAIN_SCHEDULER" } }],
+      },
+    },
+    {
+      // Worker-to-scheduler port; buck2 never talks to this one.
+      name: "worker_api",
+      listener: { http: { socket_address: "127.0.0.1:50061" } },
+      services: { worker_api: { scheduler: "MAIN_SCHEDULER" }, health: {} },
+    },
+  ],
+  global: { max_open_files: 24576 },
+}

--- a/tools/nativelink/config.json5
+++ b/tools/nativelink/config.json5
@@ -1,0 +1,94 @@
+// NativeLink on localhost: CAS, action cache, scheduler, and a sandboxed
+// worker in one process, serving the remote-execution API on
+// 127.0.0.1:50051. Actions executed here see exactly their declared
+// inputs, staged from the CAS, instead of the whole checkout.
+//
+// This config is self-contained: local stores only, no credentials.
+// To also share the BuildBuddy cache with CI and other devs, generate the
+// overlay from config-bb.json5.template and run NativeLink with that
+// instead.
+//
+//   nativelink tools/nativelink/config.json5 &
+{
+  stores: [
+    {
+      name: "CAS_MAIN_STORE",
+      filesystem: {
+        content_path: "${HOME}/.cache/causes-nativelink/data/content_path-cas",
+        temp_path: "${HOME}/.cache/causes-nativelink/data/tmp_path-cas",
+        eviction_policy: { max_bytes: 2000000000 },
+      },
+    },
+    {
+      name: "AC_MAIN_STORE",
+      filesystem: {
+        content_path: "${HOME}/.cache/causes-nativelink/data/content_path-ac",
+        temp_path: "${HOME}/.cache/causes-nativelink/data/tmp_path-ac",
+        eviction_policy: { max_bytes: 200000000 },
+      },
+    },
+    {
+      // The worker hardlinks each action's sandbox out of its fast store.
+      name: "WORKER_FAST_SLOW_STORE",
+      fast_slow: {
+        fast: {
+          filesystem: {
+            content_path: "${HOME}/.cache/causes-nativelink/data/content_path-worker",
+            temp_path: "${HOME}/.cache/causes-nativelink/data/tmp_path-worker",
+            eviction_policy: { max_bytes: 2000000000 },
+          },
+        },
+        slow: { ref_store: { name: "CAS_MAIN_STORE" } },
+      },
+    },
+  ],
+  schedulers: [
+    {
+      name: "MAIN_SCHEDULER",
+      simple: {
+        supported_platform_properties: {
+          cpu_count: "minimum",
+          OSFamily: "priority",
+          "container-image": "priority",
+        },
+      },
+    },
+  ],
+  workers: [
+    {
+      local: {
+        worker_api_endpoint: { uri: "grpc://127.0.0.1:50061" },
+        cas_fast_slow_store: "WORKER_FAST_SLOW_STORE",
+        upload_action_result: { ac_store: "AC_MAIN_STORE" },
+        work_directory: "${HOME}/.cache/causes-nativelink/work",
+        platform_properties: {
+          cpu_count: { query_cmd: "nproc" },
+          OSFamily: { query_cmd: "uname -s" },
+          "container-image": { values: [""] },
+        },
+      },
+    },
+  ],
+  servers: [
+    {
+      name: "local",
+      listener: { http: { socket_address: "127.0.0.1:50051" } },
+      services: {
+        cas: [{ cas_store: "CAS_MAIN_STORE" }],
+        ac: [{ ac_store: "AC_MAIN_STORE" }],
+        bytestream: [{ cas_store: "CAS_MAIN_STORE" }],
+        execution: [
+          { cas_store: "CAS_MAIN_STORE", scheduler: "MAIN_SCHEDULER" },
+        ],
+        capabilities: [{ remote_execution: { scheduler: "MAIN_SCHEDULER" } }],
+      },
+    },
+    {
+      // Worker-to-scheduler port; buck2 never talks to this one.
+      name: "worker_api",
+      listener: { http: { socket_address: "127.0.0.1:50061" } },
+      services: { worker_api: { scheduler: "MAIN_SCHEDULER" }, health: {} },
+    },
+  ],
+  global: { max_open_files: 24576 },
+}


### PR DESCRIPTION
Two configs: the committed `tools/nativelink/config.json5` is self-contained (sandboxed worker, local stores, no credentials); `config-bb.json5.template` generates the gitignored `.nativelink.json5` overlay whose stores write through to BuildBuddy (NativeLink holds the API key).
`buck2` becomes a launcher script — the single start path for every environment: if nothing listens on 50051 it starts NativeLink with whichever config is present, waits for readiness, and hands over to buckle. Outside a repo, or with the executor already up, it hands over directly.
CI writes the overlay and relies on the launcher.
The devcontainer installs buckle and the launcher from the checkout via `tools/buckle/install.sh` in `postCreateCommand`; the Dockerfile buckle bake is removed, so the pinned version tracks the checkout and install logic exists in exactly one place.

Verified locally: fresh install into a scratch bindir; `buck2 build` from cold auto-starts NativeLink; `buck2 --version` outside a repo starts nothing.

Stacked on #400.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
