### PR TITLE
check: allow the json5 config extension

### DIFF
--- a/tools/check.sh
+++ b/tools/check.sh
@@ -201,6 +201,8 @@ BEGIN {
 	master_ext_set["buckversion"] = 1
 	master_ext_set["buckroot"] = 1
 	master_ext_set["buckconfig"] = 1
+	# json5: the NativeLink config format (JSON with comments), not a language.
+	master_ext_set["json5"] = 1
 	n_violations = 0
 	file = ""
 	is_bazelrc = 0


### PR DESCRIPTION
The new-extension detector flags `tools/nativelink/config.json5` (#400); json5 is the NativeLink config format, not a language.

🤖 Generated with [Claude Code](https://claude.com/claude-code)