### PR TITLE
buck2: execute all actions on NativeLink

### DIFF
--- a/.buckconfig
+++ b/.buckconfig
@@ -1,7 +1,10 @@
+# `probes` is a separate cell so `buck2 build //...` (the root cell) never
+# includes its deliberately-failing targets.
 [cells]
   root = .
   prelude = prelude
   toolchains = toolchains
+  probes = probes
   none = none
 
 [cell_aliases]
@@ -15,15 +18,24 @@
 [external_cells]
   prelude = bundled
 
-# SHA256 keeps local digests interchangeable with the BuildBuddy CAS
-# regardless of whether the remote cache (.buckconfig.local) is enabled.
+# SHA256 keeps local digests interchangeable with the BuildBuddy CAS.
 [buck2]
   digest_algorithms = SHA256
+
+# Every action executes on the local NativeLink worker — see
+# tools/nativelink/. Building without it running fails immediately with a
+# connection error; there is no unsandboxed fallback.
+[buck2_re_client]
+  engine_address = 127.0.0.1:50051
+  action_cache_address = 127.0.0.1:50051
+  cas_address = 127.0.0.1:50051
+  tls = false
 
 [parser]
   target_platform_detector_spec = target:root//...->root//platforms:default \
     target:prelude//...->root//platforms:default \
-    target:toolchains//...->root//platforms:default
+    target:toolchains//...->root//platforms:default \
+    target:probes//...->root//platforms:default
 
 [build]
   execution_platforms = root//platforms:default

--- a/.buckconfig.local.template
+++ b/.buckconfig.local.template
@@ -1,9 +1,0 @@
-# BuildBuddy remote cache for local buck2 builds.
-# Copy this file to .buckconfig.local and replace YOUR_KEY_HERE with your API
-# key from https://app.buildbuddy.io/settings/org/api-keys
-# Without this file buck2 builds purely locally.
-[buck2_re_client]
-  engine_address = remote.buildbuddy.io
-  action_cache_address = remote.buildbuddy.io
-  cas_address = remote.buildbuddy.io
-  http_headers = x-buildbuddy-api-key:YOUR_KEY_HERE

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -73,27 +73,28 @@ jobs:
         run: |
           sed "s/YOUR_KEY_HERE/${BUILDBUDDY_API_KEY}/" \
             tools/nativelink/config-bb.json5.template > .nativelink.json5
-      # Same opt-in mechanism as local dev (.buckconfig.local.template):
-      # enables the BuildBuddy remote cache for the build below.
-      - name: Enable BuildBuddy remote cache
-        env:
-          BUILDBUDDY_API_KEY: ${{ secrets.BUILDBUDDY_ORG_API_KEY }}
-        run: |
-          sed "s/YOUR_KEY_HERE/${BUILDBUDDY_API_KEY}/" \
-            .buckconfig.local.template > .buckconfig.local
       - name: Build buck2 targets
         run: buck2 build //...
       # A green cached build cannot distinguish "cache works" from
       # "permanently missing"; only a demonstrated hit proves the read path.
-      # Killing the daemon after clean destroys all local state (buck-out and
-      # the in-memory graph), so the required hits can only come from
-      # BuildBuddy.
+      # buck2 clean + kill destroys buck2's local state, so the required
+      # hits prove our buck2 config round-trips through the executor's
+      # cache.
       - name: Verify remote cache round-trip
         run: |
           buck2 clean
           buck2 kill
           buck2 build //... 2>&1 | tee rebuild.log
           grep -q 'Cache hits: 100%' rebuild.log
+      # An action reading an undeclared repo file must fail under input
+      # staging. Validates that the reference configuration exercised in
+      # CI is isolating actions; it makes no claim about dev environments.
+      - name: Verify undeclared inputs are invisible
+        run: |
+          if buck2 build probes//:undeclared_read; then
+            echo "undeclared read unexpectedly succeeded" >&2
+            exit 1
+          fi
       - name: Show NativeLink log on failure
         if: failure()
         run: cat ~/.cache/causes-nativelink/nativelink.log || true

--- a/platforms/defs.bzl
+++ b/platforms/defs.bzl
@@ -1,14 +1,14 @@
-# The one platform every target and action uses. The BuildBuddy remote cache
-# is enabled iff `[buck2_re_client] engine_address` is configured (via the
-# gitignored .buckconfig.local — see .buckconfig.local.template), so a
-# checkout without credentials builds purely locally with the same platform
-# and the whole graph keeps a single configuration in both modes.
+# The one platform every target and action uses. Every action executes on
+# the local NativeLink worker ([buck2_re_client] in .buckconfig): inputs
+# are staged from the CAS, so an action sees exactly its declared inputs.
+# Unsandboxed local execution is not a path — a cached result carries no
+# record of how it was produced, so allowing both would launder impure
+# results into the shared cache.
 #
 # Invariant: everything in `//...` is a cacheable pure function of its
 # declared inputs, so caching is platform-wide with no per-target opt-out.
 # A target that cannot satisfy this must be redesigned or become a `run`
 # target.
-_REMOTE_CACHE = read_root_config("buck2_re_client", "engine_address") != None
 
 def _impl(ctx: AnalysisContext) -> list[Provider]:
     constraints = dict()
@@ -21,10 +21,11 @@ def _impl(ctx: AnalysisContext) -> list[Provider]:
         label = name,
         configuration = cfg,
         executor_config = CommandExecutorConfig(
-            local_enabled = True,
-            remote_enabled = False,
-            remote_cache_enabled = _REMOTE_CACHE,
-            allow_cache_uploads = _REMOTE_CACHE,
+            local_enabled = False,
+            remote_enabled = True,
+            remote_cache_enabled = True,
+            allow_cache_uploads = True,
+            remote_execution_properties = {},
             remote_execution_use_case = "buck2-default",
             use_windows_path_separators = False,
         ),

--- a/probes/BUCK
+++ b/probes/BUCK
@@ -1,0 +1,3 @@
+load(":defs.bzl", "undeclared_read")
+
+undeclared_read(name = "undeclared_read")

--- a/probes/defs.bzl
+++ b/probes/defs.bzl
@@ -1,0 +1,15 @@
+# An action that reads a repo file it never declared as an input; under
+# input staging the file is absent from the exec root, so the build MUST
+# fail.
+# This target exists to validate that the reference configuration
+# exercised in CI is isolating actions; it makes no claim about other
+# environments or other sandbox dimensions.
+def _undeclared_read_impl(ctx: AnalysisContext) -> list[Provider]:
+    out = ctx.actions.declare_output("out.txt")
+    ctx.actions.run(
+        cmd_args("/bin/sh", "-c", 'cat README.md > "$1"', "probe", out.as_output()),
+        category = "undeclared_read",
+    )
+    return [DefaultInfo(default_output = out)]
+
+undeclared_read = rule(impl = _undeclared_read_impl, attrs = {})


### PR DESCRIPTION
The engine address goes in the tracked `.buckconfig`: every action executes on the sandboxed worker with exactly its declared inputs staged, and there is no unsandboxed fallback — a cached result carries no record of how it was produced, so an unsandboxed path would launder impure results into the shared cache. Building without the executor fails immediately with a connection error naming the port.
`.buckconfig.local.template` is deleted (buck2 needs no credential; the key lives in the NativeLink overlay).
CI asserts both halves of the platform invariant: the cache round-trip (clean + kill, rebuild, 100% hits), and a probe reading an undeclared repo file that must fail. The probe lives in a separate `probes` cell so `buck2 build //...` never includes it.

Verified locally from cold at this commit: auto-started sandboxed `//...` build; `//...` contains no probe targets; clean+kill round-trip at 100%; probe fails with `cat: README.md: No such file or directory`; without NativeLink the build fails with `Connection refused (127.0.0.1:50051)`.

Stacked on #401.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
