### PR TITLE
renovate: track buckle releases

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -88,6 +88,19 @@
       "depNameTemplate": "TraceMachina/nativelink",
       "datasourceTemplate": "github-releases",
       "extractVersionTemplate": "^v(?<version>.*)$"
+    },
+    {
+      "description": "Bump PRs fail the installer's sha256 check until the pinned checksum is updated by hand.",
+      "customType": "regex",
+      "managerFilePatterns": [
+        "/^tools/buckle/install\\.sh$/"
+      ],
+      "matchStrings": [
+        "BUCKLE_VERSION=(?<currentValue>\\S+)"
+      ],
+      "depNameTemplate": "benbrittain/buckle",
+      "datasourceTemplate": "github-releases",
+      "extractVersionTemplate": "^v(?<version>.*)$"
     }
   ]
 }


### PR DESCRIPTION
BUCKLE_VERSION (tools/buckle/install.sh) was invisible to Renovate.
Bump PRs fail the sha256 check until the pinned checksum is updated by hand; automerge is gated on green, so they act as a new-version signal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)