### PR TITLE
claude: answers go in turn-final messages only

### DIFF
--- a/.claude/rules/feedback/feedback_answers_in_final_message.md
+++ b/.claude/rules/feedback/feedback_answers_in_final_message.md
@@ -1,0 +1,6 @@
+# Substantive answers go in turn-final messages only
+
+Text emitted alongside a `tool_use` block is not rendered; answers delivered there are silently lost.
+
+**How to apply:** answers, findings, and conclusions go only in the message that ends the turn; text before a tool call is disposable status.
+Answer mid-turn questions itemised in the turn-final message.


### PR DESCRIPTION
Feedback memory: text emitted alongside tool calls is not rendered; answers belong in the turn-final message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)