### PR TITLE
ci: enable worker namespace isolation

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -67,12 +67,18 @@ jobs:
         run: sudo bash tools/nativelink/install.sh /usr/local/bin
       # The buck2 launcher auto-starts NativeLink with this overlay, whose
       # stores write through to BuildBuddy (NativeLink holds the key).
+      # Worker namespace isolation is injected here rather than committed:
+      # unprivileged Docker (the devcontainer) cannot unshare, so the
+      # committed configs must run without it; runner VMs can.
       - name: Configure NativeLink BuildBuddy overlay
         env:
           BUILDBUDDY_API_KEY: ${{ secrets.BUILDBUDDY_ORG_API_KEY }}
         run: |
-          sed "s/YOUR_KEY_HERE/${BUILDBUDDY_API_KEY}/" \
+          sed -e "s/YOUR_KEY_HERE/${BUILDBUDDY_API_KEY}/" \
+            -e '/work_directory:/a\        use_namespaces: true,' \
+            -e '/work_directory:/a\        use_mount_namespace: true,' \
             tools/nativelink/config-bb.json5.template > .nativelink.json5
+          grep -q use_mount_namespace .nativelink.json5
       - name: Build buck2 targets
         run: buck2 build //...
       # A green cached build cannot distinguish "cache works" from


### PR DESCRIPTION
NativeLink worker `use_namespaces` + `use_mount_namespace` (zombie reaping, mount-isolated worker root), injected when CI generates its overlay.
Not in the committed configs: unprivileged Docker (the devcontainer) cannot `unshare` (verified: EPERM), and the worker exits at startup when the flags are set unsupported.
The grep fails the step if the insertion pattern drifts.
This PR's own buck2 job is the support test on runner VMs — the worker exits loudly if namespaces are unavailable there too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)