### PR TITLE
ci: auto-fix installer sha256 on Renovate bumps

### DIFF
--- a/.github/workflows/renovate-lockfile.yml
+++ b/.github/workflows/renovate-lockfile.yml
@@ -24,6 +24,12 @@ on:
       - "requirements_lock.txt"
 permissions:
   contents: write
+# Shared with renovate-sha: fixers on the same branch run one at a time,
+# and the waiter checks out by branch name, so it sees the winner's push
+# instead of racing it.
+concurrency:
+  group: renovate-fix-${{ github.ref }}
+  cancel-in-progress: false
 jobs:
   update-lockfile:
     runs-on: ubuntu-latest

--- a/.github/workflows/renovate-sha.yml
+++ b/.github/workflows/renovate-sha.yml
@@ -1,0 +1,50 @@
+name: renovate-sha
+# Renovate regex managers cannot update checksums
+# (renovatebot/renovate#22183), so its installer version bumps arrive
+# with a stale sha256 pin. Recompute it and push the fix back to the
+# Renovate branch before CI runs, like renovate-lockfile does for
+# lockfiles.
+#
+# The push uses AUTO_QUEUE_TOKEN (not the default GITHUB_TOKEN) because
+# pushes performed with GITHUB_TOKEN do not create new workflow runs,
+# which would leave the PR's checks stuck on the pre-fix commit.
+# Our own fix push retriggers this workflow; the script is idempotent,
+# so that run finds nothing to change and stops.
+on:
+  push:
+    branches: ["renovate/**"]
+    paths:
+      - tools/buckle/install.sh
+      - tools/nativelink/install.sh
+permissions:
+  contents: write
+# Shared with renovate-lockfile: fixers on the same branch run one at a
+# time, and the waiter checks out by branch name, so it sees the winner's
+# push instead of racing it.
+concurrency:
+  group: renovate-fix-${{ github.ref }}
+  cancel-in-progress: false
+jobs:
+  fix-sha:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
+        with:
+          ref: ${{ github.ref_name }}
+          token: ${{ secrets.AUTO_QUEUE_TOKEN }}
+      # Both installers, unconditionally: an untouched pin is a no-op, so
+      # diff-detection logic is unnecessary.
+      - name: Recompute installer sha256 pins
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          bash tools/renovate/update_sha.sh tools/buckle/install.sh
+          bash tools/renovate/update_sha.sh tools/nativelink/install.sh
+      - name: Push fix if the pins changed
+        run: |
+          git diff --quiet && exit 0
+          git config user.name "github-actions[bot]"
+          git config user.email \
+            "41898282+github-actions[bot]@users.noreply.github.com"
+          git commit -am "chore: recompute installer sha256 pins"
+          git push

--- a/tools/renovate/update_sha.sh
+++ b/tools/renovate/update_sha.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# Rewrite the pinned sha256 in an installer script to match the release
+# asset of the pinned version. Idempotent: no change when the pin is
+# already correct.
+# The digest comes from the GitHub release-asset digest API when present
+# (assets uploaded since 2025-06); older assets are downloaded and hashed.
+# Usage: update_sha.sh <installer-path>
+set -euo pipefail
+
+INSTALLER="$1"
+
+case "$INSTALLER" in
+tools/buckle/install.sh)
+	REPO=benbrittain/buckle
+	VAR=BUCKLE
+	ASSET='buckle-x86_64-unknown-linux-gnu.tar.xz'
+	;;
+tools/nativelink/install.sh)
+	REPO=TraceMachina/nativelink
+	VAR=NATIVELINK
+	ASSET='nativelink-VERSION-x86_64-unknown-linux-musl.tar.gz'
+	;;
+*)
+	echo "unknown installer: $INSTALLER" >&2
+	exit 1
+	;;
+esac
+
+VERSION="$(sed -n "s/^${VAR}_VERSION=//p" "$INSTALLER")"
+if [[ -z "$VERSION" ]]; then
+	echo "no ${VAR}_VERSION in $INSTALLER" >&2
+	exit 1
+fi
+ASSET="${ASSET//VERSION/$VERSION}"
+
+DIGEST="$(gh api "repos/${REPO}/releases/tags/v${VERSION}" \
+	--jq ".assets[] | select(.name == \"${ASSET}\") | .digest // empty")"
+if [[ -n "$DIGEST" ]]; then
+	SHA="${DIGEST#sha256:}"
+else
+	tmp="$(mktemp)"
+	trap 'rm -f "$tmp"' EXIT
+	curl -fsSL \
+		"https://github.com/${REPO}/releases/download/v${VERSION}/${ASSET}" \
+		-o "$tmp"
+	SHA="$(sha256sum "$tmp" | awk '{print $1}')"
+fi
+
+sed -i "s/^${VAR}_SHA256=.*/${VAR}_SHA256=${SHA}/" "$INSTALLER"
+grep -q "^${VAR}_SHA256=${SHA}\$" "$INSTALLER"


### PR DESCRIPTION
Renovate regex managers cannot update checksums (renovatebot/renovate#22183), so installer bump PRs arrive with stale sha256 pins. This workflow recomputes them and pushes the fix back to the Renovate branch before CI runs — mirroring `renovate-lockfile` (same `AUTO_QUEUE_TOKEN`, same GITHUB_TOKEN-does-not-retrigger rationale), completing the loop: bump lands → sha fixed → CI green → automerge.
Digest source: the GitHub release-asset digest API (assets uploaded since 2025-06); older assets are downloaded and hashed. The script is idempotent, so both installers run unconditionally and the fix push's own retrigger terminates as a no-op.
Both fixer workflows share a `renovate-fix-${ref}` concurrency group: on an overlapping PR they run serially, and the waiter checks out by branch name so it builds on the winner's push instead of racing it.
Script verified locally: no-op on correct pins; a simulated nativelink 1.6.0 bump rewrote the pin to exactly the API digest; a corrupted buckle pin (digest-less 2024 asset) was restored via the download path.
No new secrets: `AUTO_QUEUE_TOKEN` already exists for exactly this pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)