### PR TITLE
db_aws: keep IAM token fresh, survive resume

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1370,7 +1370,6 @@ name = "db_pool"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "arc-swap",
  "futures",
  "sqlx",
  "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -85,7 +85,6 @@ mockall = "0.14"
 tempfile = "3"
 rcgen = "0.14"
 wiremock = "0.6"
-arc-swap = "1"
 chrono = { version = "0.4", default-features = false, features = [
   "std",
   "serde",

--- a/lib/rust/db_aws/src/lib.rs
+++ b/lib/rust/db_aws/src/lib.rs
@@ -6,7 +6,7 @@ mod iam;
 use std::sync::Arc;
 use std::time::Duration;
 
-use anyhow::Context;
+use db_pool::SetConnectOptions;
 use sqlx::postgres::{PgConnectOptions, PgPoolOptions, PgSslMode};
 
 pub use iam::IamParams;
@@ -32,6 +32,18 @@ pub async fn connect_iam(host: &str, port: u16, user: &str) -> anyhow::Result<db
     connect_iam_with_sdk(params, sdk_config).await
 }
 
+/// How often the background refresher re-signs the IAM token.
+/// Must stay below the 15-minute token lifetime RDS enforces, so the
+/// pool's stored password is always a valid token when a reconnect
+/// happens.
+const REFRESH_INTERVAL: Duration = Duration::from_secs(10 * 60);
+
+/// How long a connection acquire may wait, covering Aurora Serverless
+/// resume-from-auto-pause (observed up to ~34s).
+/// Must stay below client budgets (browser fetch, gRPC callers) so the
+/// caller sees the query outcome rather than its own timeout.
+const ACQUIRE_TIMEOUT: Duration = Duration::from_secs(60);
+
 /// Same as [`connect_iam`] but takes a pre-built [`aws_types::SdkConfig`].
 /// Use this when integrating with code that already has an SDK config
 /// (shared credentials provider, custom region, test overrides).
@@ -40,28 +52,29 @@ pub async fn connect_iam_with_sdk(
     params: IamParams,
     sdk_config: aws_types::SdkConfig,
 ) -> anyhow::Result<db_pool::DbPool> {
-    let pool = build_iam_pool(&params, &sdk_config).await?;
-
-    // SdkConfig and IamParams are both Clone+Send+Sync, so the closure is too.
-    let p = params.clone();
-    let s = sdk_config.clone();
-    let refresher: db_pool::PoolRefresher = Arc::new(move || {
-        let p = p.clone();
-        let s = s.clone();
-        Box::pin(async move { build_iam_pool(&p, &s).await })
-    });
+    let pool = build_iam_pool::<sqlx::PgPool>(&params, &sdk_config).await?;
+    let refresher = iam_refresher(params, sdk_config);
 
     Ok(db_pool::DbPool::from_pool_with_refresher(
         pool,
-        Duration::from_secs(6 * 3600),
+        REFRESH_INTERVAL,
         refresher,
     ))
 }
 
+/// Build the refresher closure that rotates the IAM token of whatever
+/// pool [`db_pool`] hands it, via [`set_pool_token`]. Live connections
+/// are untouched; the next reconnect picks up the new password.
+fn iam_refresher(params: IamParams, sdk_config: aws_types::SdkConfig) -> db_pool::PoolRefresher {
+    // SdkConfig and IamParams are both Clone+Send+Sync, so the closure is too.
+    Arc::new(move |pool| {
+        let p = params.clone();
+        let s = sdk_config.clone();
+        Box::pin(async move { set_pool_token(pool, &p, &s).await })
+    })
+}
+
 /// Construct the `PgConnectOptions` for an IAM-authenticated connection.
-/// Pulled out of [`build_iam_pool`] so the field-construction logic is
-/// directly testable; the actual `PgPoolOptions::connect_with` call is a
-/// thin sqlx pass-through that needs a live database to exercise.
 fn iam_connect_options(params: &IamParams, token: &str) -> PgConnectOptions {
     PgConnectOptions::new()
         .host(&params.hostname)
@@ -72,21 +85,135 @@ fn iam_connect_options(params: &IamParams, token: &str) -> PgConnectOptions {
         .ssl_mode(PgSslMode::Require)
 }
 
-async fn build_iam_pool(
+/// The full set of effectful pool operations the IAM flow performs,
+/// behind a trait so tests can substitute a recorder and assert what
+/// the flow actually passes. Verbs match the sqlx methods they
+/// delegate to; production is `sqlx::PgPool` itself.
+trait PoolOps: SetConnectOptions + Sized {
+    fn connect_lazy_with(pool_opts: PgPoolOptions, connect_opts: PgConnectOptions) -> Self;
+}
+
+impl PoolOps for sqlx::PgPool {
+    fn connect_lazy_with(pool_opts: PgPoolOptions, connect_opts: PgConnectOptions) -> Self {
+        pool_opts.connect_lazy_with(connect_opts)
+    }
+}
+
+/// The placeholder options are never used: the pool is lazy and the
+/// real token is installed before anything can acquire.
+async fn build_iam_pool<P: PoolOps>(
     params: &IamParams,
     sdk_config: &aws_types::SdkConfig,
-) -> anyhow::Result<sqlx::PgPool> {
-    let token = params.generate_token(sdk_config).await?;
-    PgPoolOptions::new()
+) -> anyhow::Result<P> {
+    let pool_opts = PgPoolOptions::new()
         .max_connections(5)
-        .connect_with(iam_connect_options(params, &token))
-        .await
-        .context("connecting to PostgreSQL with IAM token")
+        .acquire_timeout(ACQUIRE_TIMEOUT);
+    let pool = P::connect_lazy_with(pool_opts, PgConnectOptions::new());
+    set_pool_token(&pool, params, sdk_config).await?;
+    Ok(pool)
+}
+
+/// Token generation is local SigV4 signing — no network I/O.
+async fn set_pool_token<P: SetConnectOptions + ?Sized>(
+    pool: &P,
+    params: &IamParams,
+    sdk_config: &aws_types::SdkConfig,
+) -> anyhow::Result<()> {
+    let token = params.generate_token(sdk_config).await?;
+    pool.set_connect_options(iam_connect_options(params, &token));
+    Ok(())
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use aws_credential_types::Credentials;
+    use aws_credential_types::provider::SharedCredentialsProvider;
+    use aws_smithy_async::test_util::ManualTimeSource;
+    use std::time::UNIX_EPOCH;
+
+    fn test_sdk_config() -> aws_types::SdkConfig {
+        let time_source = ManualTimeSource::new(UNIX_EPOCH + Duration::from_secs(1_724_709_600));
+        aws_types::SdkConfig::builder()
+            .credentials_provider(SharedCredentialsProvider::new(Credentials::new(
+                "AKID", "secret", None, None, "test",
+            )))
+            .time_source(time_source)
+            .build()
+    }
+
+    /// One recorded call on the [`PoolOps`] double, in order.
+    enum Call {
+        ConnectLazyWith(PgPoolOptions),
+        SetConnectOptions(PgConnectOptions),
+    }
+
+    /// Test double recording what the IAM flow passes to the pool layer.
+    #[derive(Default)]
+    struct RecordingPool {
+        calls: std::sync::Mutex<Vec<Call>>,
+    }
+
+    impl SetConnectOptions for RecordingPool {
+        fn set_connect_options(&self, connect_opts: PgConnectOptions) {
+            self.calls
+                .lock()
+                .unwrap()
+                .push(Call::SetConnectOptions(connect_opts));
+        }
+    }
+
+    impl PoolOps for RecordingPool {
+        fn connect_lazy_with(pool_opts: PgPoolOptions, _connect_opts: PgConnectOptions) -> Self {
+            let pool = Self::default();
+            pool.calls
+                .lock()
+                .unwrap()
+                .push(Call::ConnectLazyWith(pool_opts));
+            pool
+        }
+    }
+
+    fn test_params() -> IamParams {
+        IamParams::new("db.invalid".into(), 5432, "causes".into())
+    }
+
+    #[tokio::test]
+    async fn build_creates_pool_then_installs_token() {
+        let pool = build_iam_pool::<RecordingPool>(&test_params(), &test_sdk_config())
+            .await
+            .unwrap();
+
+        let calls = pool.calls.lock().unwrap();
+        let (pool_opts, token_opts) = match calls.as_slice() {
+            [
+                Call::ConnectLazyWith(pool_opts),
+                Call::SetConnectOptions(token_opts),
+            ] => (pool_opts, token_opts),
+            other => panic!("unexpected call sequence ({} calls)", other.len()),
+        };
+        // Above worst-case Aurora resume-from-pause (~34s observed),
+        // below every client budget in the stack.
+        assert_eq!(pool_opts.get_acquire_timeout(), ACQUIRE_TIMEOUT);
+        assert!(ACQUIRE_TIMEOUT >= Duration::from_secs(45));
+        assert!(ACQUIRE_TIMEOUT <= Duration::from_secs(90));
+        assert_eq!(token_opts.get_host(), "db.invalid");
+        assert_eq!(token_opts.get_username(), "causes");
+    }
+
+    #[tokio::test]
+    async fn refresher_installs_token_on_the_pool_it_is_given() {
+        let pool = RecordingPool::default();
+        let refresher = iam_refresher(test_params(), test_sdk_config());
+        refresher(&pool).await.unwrap();
+
+        let calls = pool.calls.lock().unwrap();
+        let token_opts = match calls.as_slice() {
+            [Call::SetConnectOptions(token_opts)] => token_opts,
+            _ => panic!("token refresh must install options exactly once"),
+        };
+        assert_eq!(token_opts.get_host(), "db.invalid");
+    }
 
     #[test]
     fn iam_connect_options_carries_params_through() {

--- a/lib/rust/db_pool/BUILD.bazel
+++ b/lib/rust/db_pool/BUILD.bazel
@@ -14,7 +14,6 @@ rust_library(
     visibility = ["//visibility:public"],
     deps = [
         "@crates//:anyhow",
-        "@crates//:arc-swap",
         "@crates//:sqlx",
         "@crates//:tokio",
         "@crates//:tracing",

--- a/lib/rust/db_pool/Cargo.toml
+++ b/lib/rust/db_pool/Cargo.toml
@@ -7,7 +7,6 @@ license.workspace = true
 [dependencies]
 sqlx.workspace = true
 anyhow.workspace = true
-arc-swap.workspace = true
 tokio.workspace = true
 tracing.workspace = true
 futures.workspace = true

--- a/lib/rust/db_pool/README.md
+++ b/lib/rust/db_pool/README.md
@@ -8,7 +8,8 @@ Key decisions:
   Crates that legitimately write SQL (api_db today; future analytics_db etc.) depend on this crate and `use db_pool::QueryAccess` to reach `pool()` / the underlying `sqlx::PgPool`.
   Business-logic crates (services/causes_api etc.) depend on `db_connect` for the type only and never see the trait, so they cannot construct queries even if an AI tries to write them.
 - **The pool type is opaque to consumers.**
-  `DbPool` wraps `sqlx::PgPool` in an `ArcSwap` so the connection can be atomically swapped (production IAM token rotation does this).
   Consumers see `Clone`, `start_background_refresh`, and the type's existence — nothing about sqlx.
+- **Refreshers only get the `SetConnectOptions` capability.**
+  `start_background_refresh` hands the refresher `&dyn SetConnectOptions`, never the pool, so credential rotation (production IAM tokens) can install new connect options but cannot query or connect.
 - **No transaction policy here.**
   Isolation level is a schema concern (e.g. api_db's journal trigger requires REPEATABLE READ); each query crate owns its own `begin_txn` helper.

--- a/lib/rust/db_pool/src/lib.rs
+++ b/lib/rust/db_pool/src/lib.rs
@@ -6,30 +6,46 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use anyhow::Context;
-use arc_swap::ArcSwap;
-use sqlx::postgres::PgPoolOptions;
+use sqlx::postgres::{PgConnectOptions, PgPoolOptions};
 
 mod sealed {
     pub trait Sealed {}
 }
 
-/// Closure that rebuilds the underlying pool. Supplied by provider crates
-/// (e.g. `db_aws`) for IAM auth token rotation; called by
-/// [`DbPool::start_background_refresh`].
+/// Installing connect options on a pool: the only capability the
+/// refresh system grants a [`PoolRefresher`], so refreshers cannot
+/// connect. The verb matches the sqlx method it delegates to.
+pub trait SetConnectOptions {
+    fn set_connect_options(&self, connect_opts: PgConnectOptions);
+}
+
+impl SetConnectOptions for sqlx::PgPool {
+    fn set_connect_options(&self, connect_opts: PgConnectOptions) {
+        sqlx::PgPool::set_connect_options(self, connect_opts);
+    }
+}
+
+/// Closure that refreshes the pool's credentials in place. Supplied by
+/// provider crates (e.g. `db_aws`) for IAM auth token rotation;
+/// [`DbPool::start_background_refresh`] calls it with the pool it
+/// holds.
 pub type PoolRefresher = Arc<
-    dyn Fn() -> Pin<Box<dyn Future<Output = anyhow::Result<sqlx::PgPool>> + Send>> + Send + Sync,
+    dyn for<'a> Fn(
+            &'a (dyn SetConnectOptions + Sync),
+        ) -> Pin<Box<dyn Future<Output = anyhow::Result<()>> + Send + 'a>>
+        + Send
+        + Sync,
 >;
 
 /// Opaque pool handle.
 ///
 /// Static mode: a fixed pool, [`Self::start_background_refresh`] returns `None`.
 ///
-/// Refreshing mode: `ArcSwap`-wrapped pool with a refresher closure attached;
-/// the background task periodically calls the refresher and atomically swaps
-/// in the new pool.
+/// Refreshing mode: a refresher closure is attached; the background
+/// task periodically calls it to rotate the pool's credentials.
 #[derive(Clone)]
 pub struct DbPool {
-    inner: Arc<ArcSwap<sqlx::PgPool>>,
+    inner: sqlx::PgPool,
     refresher: Option<PoolRefresher>,
     refresh_interval: Duration,
 }
@@ -56,7 +72,7 @@ impl DbPool {
         refresher: PoolRefresher,
     ) -> Self {
         Self {
-            inner: Arc::new(ArcSwap::from_pointee(pool)),
+            inner: pool,
             refresher: Some(refresher),
             refresh_interval,
         }
@@ -67,7 +83,7 @@ impl DbPool {
     /// and other scenarios where the pool already exists.
     pub fn from_pool(pool: sqlx::PgPool) -> Self {
         Self {
-            inner: Arc::new(ArcSwap::from_pointee(pool)),
+            inner: pool,
             refresher: None,
             refresh_interval: Duration::from_secs(6 * 3600),
         }
@@ -78,7 +94,7 @@ impl DbPool {
     /// [`Self::connect`] / [`Self::from_pool`] (no refresher attached).
     pub fn start_background_refresh(&self) -> Option<tokio::task::JoinHandle<()>> {
         let refresher = self.refresher.clone()?;
-        let inner = self.inner.clone();
+        let pool = self.inner.clone();
         let interval_dur = self.refresh_interval;
         Some(tokio::spawn(async move {
             let mut interval = tokio::time::interval(interval_dur);
@@ -86,10 +102,9 @@ impl DbPool {
             interval.tick().await;
             loop {
                 interval.tick().await;
-                match refresher().await {
-                    Ok(new_pool) => {
-                        inner.store(Arc::new(new_pool));
-                        tracing::info!("database pool refreshed");
+                match refresher(&pool).await {
+                    Ok(()) => {
+                        tracing::info!("database pool credentials refreshed");
                     }
                     Err(e) => {
                         tracing::warn!("database pool refresh failed: {e}");
@@ -106,15 +121,13 @@ impl DbPool {
 /// `db_connect` (which re-exports `DbPool` but not this trait) cannot
 /// reach the pool.
 pub trait QueryAccess: sealed::Sealed {
-    /// Return a `sqlx::PgPool` snapshot. Cheap (internally Arc-counted).
-    /// In refreshing mode the underlying pool may be swapped at any time;
-    /// callers get a snapshot that remains valid until dropped.
+    /// Return the `sqlx::PgPool`. Cheap (internally Arc-counted).
     fn pool(&self) -> sqlx::PgPool;
 }
 
 impl QueryAccess for DbPool {
     fn pool(&self) -> sqlx::PgPool {
-        (**self.inner.load()).clone()
+        self.inner.clone()
     }
 }
 


### PR DESCRIPTION
Fixes the login outage on the deployed instance.

Aurora Serverless resume-from-pause now takes ~26-34s; the 6-hourly pool refresh connected eagerly and timed out at sqlx's default 30s acquire timeout on every attempt since 2026-07-07.
Between refreshes the pool held a token past its 15-minute RDS-enforced lifetime, so every reconnect failed auth; the only logins this deployment ever served were in the first minutes after the April deploy.

- `set_pool_token` signs a fresh token every 10 minutes (local SigV4, no I/O) and installs it with `Pool::set_connect_options`; refresh cannot time out and never wakes the paused cluster.
- `db_pool` owns the `SetConnectOptions` capability and hands the refresher only that (`Fn(&dyn SetConnectOptions) -> Result<()>` each tick): refreshers cannot connect (compile-time, for any provider crate) and necessarily target the pool `DbPool` holds; the `ArcSwap` pool-swap machinery and `arc-swap` dependency are removed.
- Acquire timeout raised to 60s: above worst-case observed resume, below every client budget in the stack.
- The pool is built lazily with the token installed before any connection is attempted; the schema migration every consumer must run first exercises connectivity, so a broken configuration still fails the deploy.

Verified: the pool operations sit behind local traits implemented on `sqlx::PgPool` (verbs matching sqlx); a recording double asserts the startup sequence (create, then set token) with the 60s timeout; mutation runs confirmed each assertion fails against a broken implementation; server run against local postgres serves `POST /auth/login` with a 200 and a pending-login row inserted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
