### PR TITLE
api_db: sweep GC only after session/login activity

### DIFF
--- a/lib/rust/api_db/src/admin.rs
+++ b/lib/rust/api_db/src/admin.rs
@@ -417,7 +417,7 @@ mod tests {
 
     #[sqlx::test(migrator = "crate::db::MIGRATIONS")]
     async fn create_admin_inserts_rows(pool: sqlx::PgPool) {
-        let pool = Pool::from_pool(pool, crate::PoolState);
+        let pool = Pool::from_pool(pool, crate::PoolState::default());
 
         let user_id = create_admin(
             &pool,
@@ -451,7 +451,7 @@ mod tests {
 
     #[sqlx::test(migrator = "crate::db::MIGRATIONS")]
     async fn create_user_inserts_rows_without_role(pool: sqlx::PgPool) {
-        let pool = Pool::from_pool(pool, crate::PoolState);
+        let pool = Pool::from_pool(pool, crate::PoolState::default());
 
         let user_id = create_user(
             &pool,
@@ -484,7 +484,7 @@ mod tests {
 
     #[sqlx::test(migrator = "crate::db::MIGRATIONS")]
     async fn user_count_returns_nonnegative(pool: sqlx::PgPool) {
-        let pool = Pool::from_pool(pool, crate::PoolState);
+        let pool = Pool::from_pool(pool, crate::PoolState::default());
 
         let count = user_count(&pool).await.expect("user_count failed");
         assert!(count >= 0);

--- a/lib/rust/api_db/src/db.rs
+++ b/lib/rust/api_db/src/db.rs
@@ -68,7 +68,7 @@ mod tests {
             .expect("database was null");
         let url = format!("postgresql://localhost:{port}/{db}");
 
-        let pool = Pool::connect(&url, crate::PoolState)
+        let pool = Pool::connect(&url, crate::PoolState::default())
             .await
             .expect("Pool::connect failed");
         migrate(&pool).await.expect("migrate failed");
@@ -104,7 +104,7 @@ mod tests {
     /// Verify that instance_id is generated during migration and is a valid UUID.
     #[sqlx::test(migrator = "crate::db::MIGRATIONS")]
     async fn instance_id_is_generated(pool: sqlx::PgPool) {
-        let db = Pool::from_pool(pool, crate::PoolState);
+        let db = Pool::from_pool(pool, crate::PoolState::default());
         let id = instance_id(&db).await.expect("instance_id failed");
         id.parse::<uuid::Uuid>()
             .expect("instance_id is not a valid UUID");
@@ -113,7 +113,7 @@ mod tests {
     /// Verify that running migrations twice preserves the existing instance_id.
     #[sqlx::test(migrator = "crate::db::tests::EMPTY")]
     async fn instance_id_survives_migration_rerun(pool: sqlx::PgPool) {
-        let db = Pool::from_pool(pool, crate::PoolState);
+        let db = Pool::from_pool(pool, crate::PoolState::default());
 
         MIGRATIONS.run(&db.pool()).await.expect("first run failed");
         let original = instance_id(&db).await.expect("instance_id failed");
@@ -127,7 +127,7 @@ mod tests {
     /// Verify that `begin_txn` opens a transaction at REPEATABLE READ.
     #[sqlx::test(migrator = "crate::db::tests::EMPTY")]
     async fn begin_txn_sets_repeatable_read(pool: sqlx::PgPool) {
-        let db = Pool::from_pool(pool, crate::PoolState);
+        let db = Pool::from_pool(pool, crate::PoolState::default());
         let mut tx = begin_txn(&db).await.expect("begin_txn failed");
         let level: String =
             sqlx::query_scalar!("SELECT current_setting('transaction_isolation') AS \"v!\"")
@@ -262,7 +262,7 @@ mod tests {
             .await
             .expect("journal_create_table call failed");
 
-        let db = Pool::from_pool(pool, crate::PoolState);
+        let db = Pool::from_pool(pool, crate::PoolState::default());
         let project_id = seed_project_row(&db.pool()).await;
         let oi = uuid::Uuid::new_v4().to_string();
 
@@ -364,7 +364,7 @@ mod tests {
         .await
         .expect("partial index creation failed");
 
-        let db = Pool::from_pool(pool, crate::PoolState);
+        let db = Pool::from_pool(pool, crate::PoolState::default());
         let project_id = seed_project_row(&db.pool()).await;
         let oi = uuid::Uuid::new_v4().to_string();
 

--- a/lib/rust/api_db/src/lib.rs
+++ b/lib/rust/api_db/src/lib.rs
@@ -6,10 +6,46 @@ mod project;
 mod role;
 mod session;
 
-/// Per-pool state this crate attaches to its connection pool. Empty for
-/// now; grows as the crate needs pool-scoped state.
-#[derive(Clone, Default)]
-pub struct PoolState;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+
+/// Per-pool state this crate attaches to its connection pool: the activity flags its GC sweeps gate on.
+/// A flag is set when a row of that kind is created or observed, and cleared by the matching sweep, so an idle instance's sweep issues no `DELETE`.
+#[derive(Clone)]
+pub struct PoolState {
+    sessions_dirty: Arc<AtomicBool>,
+    pending_logins_dirty: Arc<AtomicBool>,
+}
+
+impl Default for PoolState {
+    /// Start dirty so the first sweep after process start runs.
+    fn default() -> Self {
+        Self {
+            sessions_dirty: Arc::new(AtomicBool::new(true)),
+            pending_logins_dirty: Arc::new(AtomicBool::new(true)),
+        }
+    }
+}
+
+impl PoolState {
+    pub(crate) fn mark_sessions(&self) {
+        self.sessions_dirty.store(true, Ordering::Relaxed);
+    }
+
+    /// Clear the sessions flag, returning whether it was set.
+    pub(crate) fn take_sessions_dirty(&self) -> bool {
+        self.sessions_dirty.swap(false, Ordering::Relaxed)
+    }
+
+    pub(crate) fn mark_pending_logins(&self) {
+        self.pending_logins_dirty.store(true, Ordering::Relaxed);
+    }
+
+    /// Clear the pending-logins flag, returning whether it was set.
+    pub(crate) fn take_pending_logins_dirty(&self) -> bool {
+        self.pending_logins_dirty.swap(false, Ordering::Relaxed)
+    }
+}
 
 /// The connection pool as this crate uses it.
 pub type Pool = db_pool::DbPool<PoolState>;

--- a/lib/rust/api_db/src/pending_login.rs
+++ b/lib/rust/api_db/src/pending_login.rs
@@ -56,6 +56,8 @@ pub async fn create_pending_login(
     .await
     .context("inserting pending login")?;
 
+    pool.state().mark_pending_logins();
+
     Ok(nonce)
 }
 
@@ -91,16 +93,24 @@ pub async fn delete_pending_login(pool: &Pool, nonce: &LoginNonce) -> anyhow::Re
     Ok(())
 }
 
-/// Delete pending logins older than the given age.
+/// Delete pending logins older than `max_age`, if there was a login since the last sweep.
 /// Called periodically to garbage-collect abandoned login attempts.
-pub async fn gc_pending_logins(pool: &Pool, max_age: std::time::Duration) -> anyhow::Result<u64> {
+/// Returns `None` when the sweep is skipped (no activity), or `Some(n)` with the rows deleted when it runs.
+pub async fn gc_pending_logins(
+    pool: &Pool,
+    max_age: std::time::Duration,
+) -> anyhow::Result<Option<u64>> {
+    if !pool.state().take_pending_logins_dirty() {
+        return Ok(None);
+    }
+
     let cutoff = sqlx::types::chrono::Utc::now() - max_age;
     let result = sqlx::query!("DELETE FROM pending_logins WHERE created_at < $1", cutoff,)
         .execute(&pool.pool())
         .await
         .context("garbage-collecting pending logins")?;
 
-    Ok(result.rows_affected())
+    Ok(Some(result.rows_affected()))
 }
 
 // ── Types ─────────────────────────────────────────────────────────────────
@@ -147,7 +157,7 @@ mod tests {
 
     #[sqlx::test(migrator = "crate::db::MIGRATIONS")]
     async fn create_and_lookup_pending_login(pool: sqlx::PgPool) {
-        let pool = Pool::from_pool(pool, crate::PoolState);
+        let pool = Pool::from_pool(pool, crate::PoolState::default());
 
         let nonce = create_pending_login(&pool, "dev-code-xyz", 5)
             .await
@@ -164,7 +174,7 @@ mod tests {
 
     #[sqlx::test(migrator = "crate::db::MIGRATIONS")]
     async fn lookup_missing_nonce_returns_none(pool: sqlx::PgPool) {
-        let pool = Pool::from_pool(pool, crate::PoolState);
+        let pool = Pool::from_pool(pool, crate::PoolState::default());
         let bogus = LoginNonce::from_raw("a".repeat(64)).unwrap();
 
         let row = lookup_pending_login(&pool, &bogus)
@@ -176,7 +186,7 @@ mod tests {
 
     #[sqlx::test(migrator = "crate::db::MIGRATIONS")]
     async fn delete_removes_pending_login(pool: sqlx::PgPool) {
-        let pool = Pool::from_pool(pool, crate::PoolState);
+        let pool = Pool::from_pool(pool, crate::PoolState::default());
 
         let nonce = create_pending_login(&pool, "dev-code", 5)
             .await
@@ -195,7 +205,7 @@ mod tests {
 
     #[sqlx::test(migrator = "crate::db::MIGRATIONS")]
     async fn gc_removes_old_pending_logins(pool: sqlx::PgPool) {
-        let pool = Pool::from_pool(pool, crate::PoolState);
+        let pool = Pool::from_pool(pool, crate::PoolState::default());
 
         // Create a login, then GC with zero max age (everything is "old").
         create_pending_login(&pool, "dev-code", 5)
@@ -206,6 +216,37 @@ mod tests {
             .await
             .expect("gc_pending_logins failed");
 
-        assert_eq!(deleted, 1);
+        assert_eq!(deleted, Some(1));
+    }
+
+    #[sqlx::test(migrator = "crate::db::MIGRATIONS")]
+    async fn gc_pending_logins_runs_only_after_activity(pool: sqlx::PgPool) {
+        let pool = Pool::from_pool(pool, crate::PoolState::default());
+
+        create_pending_login(&pool, "dev-code", 5).await.unwrap();
+        // Clear the flag: the pool starts dirty and the create above marks.
+        pool.state().take_pending_logins_dirty();
+
+        assert_eq!(
+            gc_pending_logins(&pool, std::time::Duration::ZERO)
+                .await
+                .unwrap(),
+            None
+        );
+
+        create_pending_login(&pool, "dev-code-2", 5).await.unwrap();
+
+        assert_eq!(
+            gc_pending_logins(&pool, std::time::Duration::ZERO)
+                .await
+                .unwrap(),
+            Some(2)
+        );
+        assert_eq!(
+            gc_pending_logins(&pool, std::time::Duration::ZERO)
+                .await
+                .unwrap(),
+            None
+        );
     }
 }

--- a/lib/rust/api_db/src/project.rs
+++ b/lib/rust/api_db/src/project.rs
@@ -605,7 +605,7 @@ mod tests {
 
     #[sqlx::test(migrator = "crate::db::MIGRATIONS")]
     async fn create_private_project_succeeds(pool: sqlx::PgPool) {
-        let pool = Pool::from_pool(pool, crate::PoolState);
+        let pool = Pool::from_pool(pool, crate::PoolState::default());
         let user_id = seed_admin(&pool).await;
         let session = session_for(&user_id, false);
 
@@ -631,7 +631,7 @@ mod tests {
 
     #[sqlx::test(migrator = "crate::db::MIGRATIONS")]
     async fn create_project_inserts_row_and_role(pool: sqlx::PgPool) {
-        let pool = Pool::from_pool(pool, crate::PoolState);
+        let pool = Pool::from_pool(pool, crate::PoolState::default());
         let user_id = seed_admin(&pool).await;
         let session = session_for(&user_id, false);
 
@@ -667,7 +667,7 @@ mod tests {
 
     #[sqlx::test(migrator = "crate::db::MIGRATIONS")]
     async fn create_project_rejects_duplicate_name(pool: sqlx::PgPool) {
-        let pool = Pool::from_pool(pool, crate::PoolState);
+        let pool = Pool::from_pool(pool, crate::PoolState::default());
         let user_id = seed_admin(&pool).await;
         let name = ProjectName::new("dupe").unwrap();
 
@@ -682,7 +682,7 @@ mod tests {
 
     #[sqlx::test(migrator = "crate::db::MIGRATIONS")]
     async fn get_project_returns_none_for_missing(pool: sqlx::PgPool) {
-        let pool = Pool::from_pool(pool, crate::PoolState);
+        let pool = Pool::from_pool(pool, crate::PoolState::default());
         let user_id = seed_admin(&pool).await;
         let session = session_for(&user_id, false);
         let pid = ProjectId::new(Uuid::new_v4().to_string()).unwrap();
@@ -694,7 +694,7 @@ mod tests {
 
     #[sqlx::test(migrator = "crate::db::MIGRATIONS")]
     async fn rename_project_updates_name(pool: sqlx::PgPool) {
-        let pool = Pool::from_pool(pool, crate::PoolState);
+        let pool = Pool::from_pool(pool, crate::PoolState::default());
         let user_id = seed_admin(&pool).await;
 
         let pid = create_project(
@@ -718,7 +718,7 @@ mod tests {
 
     #[sqlx::test(migrator = "crate::db::MIGRATIONS")]
     async fn rename_missing_returns_none(pool: sqlx::PgPool) {
-        let pool = Pool::from_pool(pool, crate::PoolState);
+        let pool = Pool::from_pool(pool, crate::PoolState::default());
         let pid = ProjectId::new(Uuid::new_v4().to_string()).unwrap();
         let result = rename_project(&pool, &pid, &ProjectName::new("xx").unwrap())
             .await
@@ -728,7 +728,7 @@ mod tests {
 
     #[sqlx::test(migrator = "crate::db::MIGRATIONS")]
     async fn delete_project_removes_row_and_roles(pool: sqlx::PgPool) {
-        let pool = Pool::from_pool(pool, crate::PoolState);
+        let pool = Pool::from_pool(pool, crate::PoolState::default());
         let user_id = seed_admin(&pool).await;
         let session = session_for(&user_id, false);
 
@@ -758,14 +758,14 @@ mod tests {
 
     #[sqlx::test(migrator = "crate::db::MIGRATIONS")]
     async fn delete_missing_returns_false(pool: sqlx::PgPool) {
-        let pool = Pool::from_pool(pool, crate::PoolState);
+        let pool = Pool::from_pool(pool, crate::PoolState::default());
         let pid = ProjectId::new(Uuid::new_v4().to_string()).unwrap();
         assert!(!delete_project(&pool, &pid).await.unwrap());
     }
 
     #[sqlx::test(migrator = "crate::db::MIGRATIONS")]
     async fn list_projects_returns_all(pool: sqlx::PgPool) {
-        let pool = Pool::from_pool(pool, crate::PoolState);
+        let pool = Pool::from_pool(pool, crate::PoolState::default());
         let user_id = seed_admin(&pool).await;
         let session = session_for(&user_id, false);
 
@@ -798,7 +798,7 @@ mod tests {
 
     #[sqlx::test(migrator = "crate::db::MIGRATIONS")]
     async fn full_lifecycle(pool: sqlx::PgPool) {
-        let pool = Pool::from_pool(pool, crate::PoolState);
+        let pool = Pool::from_pool(pool, crate::PoolState::default());
         let user_id = seed_admin(&pool).await;
         let session = session_for(&user_id, false);
 
@@ -902,7 +902,7 @@ mod tests {
 
     #[sqlx::test(migrator = "crate::db::MIGRATIONS")]
     async fn get_project_hides_private_from_stranger(pool: sqlx::PgPool) {
-        let pool = Pool::from_pool(pool, crate::PoolState);
+        let pool = Pool::from_pool(pool, crate::PoolState::default());
         let creator = seed_admin(&pool).await;
         let stranger = seed_user(&pool, "stranger@example.com").await;
         let stranger_session = session_for(&stranger, false);
@@ -927,7 +927,7 @@ mod tests {
 
     #[sqlx::test(migrator = "crate::db::MIGRATIONS")]
     async fn get_project_shows_private_to_member(pool: sqlx::PgPool) {
-        let pool = Pool::from_pool(pool, crate::PoolState);
+        let pool = Pool::from_pool(pool, crate::PoolState::default());
         let creator = seed_admin(&pool).await;
         let session = session_for(&creator, false);
 
@@ -951,7 +951,7 @@ mod tests {
 
     #[sqlx::test(migrator = "crate::db::MIGRATIONS")]
     async fn get_project_shows_private_to_unrestricted_admin(pool: sqlx::PgPool) {
-        let pool = Pool::from_pool(pool, crate::PoolState);
+        let pool = Pool::from_pool(pool, crate::PoolState::default());
         let admin = seed_admin(&pool).await;
         let other = seed_user(&pool, "other@example.com").await;
         let admin_session = session_for(&admin, false); // unrestricted
@@ -977,7 +977,7 @@ mod tests {
 
     #[sqlx::test(migrator = "crate::db::MIGRATIONS")]
     async fn get_project_hides_private_from_restricted_admin(pool: sqlx::PgPool) {
-        let pool = Pool::from_pool(pool, crate::PoolState);
+        let pool = Pool::from_pool(pool, crate::PoolState::default());
         let admin = seed_admin(&pool).await;
         let other = seed_user(&pool, "other@example.com").await;
         let restricted_session = session_for(&admin, true); // restricted
@@ -1003,7 +1003,7 @@ mod tests {
 
     #[sqlx::test(migrator = "crate::db::MIGRATIONS")]
     async fn list_projects_filters_private(pool: sqlx::PgPool) {
-        let pool = Pool::from_pool(pool, crate::PoolState);
+        let pool = Pool::from_pool(pool, crate::PoolState::default());
         let creator = seed_admin(&pool).await;
         let stranger = seed_user(&pool, "stranger@example.com").await;
         let creator_session = session_for(&creator, false);
@@ -1042,7 +1042,7 @@ mod tests {
 
     #[sqlx::test(migrator = "crate::db::MIGRATIONS")]
     async fn find_project_by_name_hides_private(pool: sqlx::PgPool) {
-        let pool = Pool::from_pool(pool, crate::PoolState);
+        let pool = Pool::from_pool(pool, crate::PoolState::default());
         let creator = seed_admin(&pool).await;
         let stranger = seed_user(&pool, "stranger@example.com").await;
         let creator_session = session_for(&creator, false);
@@ -1107,7 +1107,7 @@ mod tests {
 
         use futures::StreamExt;
 
-        let pool = Pool::from_pool(pool, crate::PoolState);
+        let pool = Pool::from_pool(pool, crate::PoolState::default());
         let user_id = seed_admin(&pool).await;
         let session = session_for(&user_id, false);
 

--- a/lib/rust/api_db/src/role.rs
+++ b/lib/rust/api_db/src/role.rs
@@ -258,7 +258,7 @@ mod tests {
 
     #[sqlx::test(migrator = "crate::db::MIGRATIONS")]
     async fn get_user_roles_empty_for_new_user(pool: sqlx::PgPool) {
-        let pool = Pool::from_pool(pool, crate::PoolState);
+        let pool = Pool::from_pool(pool, crate::PoolState::default());
         let user_id = crate::admin::create_user(
             &pool,
             &DisplayName::new("Nobody").unwrap(),
@@ -275,7 +275,7 @@ mod tests {
 
     #[sqlx::test(migrator = "crate::db::MIGRATIONS")]
     async fn get_user_roles_returns_admin_role(pool: sqlx::PgPool) {
-        let pool = Pool::from_pool(pool, crate::PoolState);
+        let pool = Pool::from_pool(pool, crate::PoolState::default());
         let user_id = seed_admin(&pool).await;
 
         let roles = get_user_roles(&pool, &user_id).await.unwrap();
@@ -286,7 +286,7 @@ mod tests {
 
     #[sqlx::test(migrator = "crate::db::MIGRATIONS")]
     async fn assign_and_get_role(pool: sqlx::PgPool) {
-        let pool = Pool::from_pool(pool, crate::PoolState);
+        let pool = Pool::from_pool(pool, crate::PoolState::default());
         let user_id = seed_admin(&pool).await;
 
         assign_role(&pool, &user_id, &None, Role::Developer)
@@ -302,7 +302,7 @@ mod tests {
 
     #[sqlx::test(migrator = "crate::db::MIGRATIONS")]
     async fn assign_role_is_idempotent(pool: sqlx::PgPool) {
-        let pool = Pool::from_pool(pool, crate::PoolState);
+        let pool = Pool::from_pool(pool, crate::PoolState::default());
         let user_id = seed_admin(&pool).await;
 
         assign_role(&pool, &user_id, &None, Role::Developer)
@@ -318,7 +318,7 @@ mod tests {
 
     #[sqlx::test(migrator = "crate::db::MIGRATIONS")]
     async fn get_user_project_roles_includes_instance_level(pool: sqlx::PgPool) {
-        let pool = Pool::from_pool(pool, crate::PoolState);
+        let pool = Pool::from_pool(pool, crate::PoolState::default());
         let user_id = seed_admin(&pool).await;
 
         // create_project assigns project-maintainer to the creator
@@ -343,7 +343,7 @@ mod tests {
 
     #[sqlx::test(migrator = "crate::db::MIGRATIONS")]
     async fn get_user_project_roles_excludes_other_projects(pool: sqlx::PgPool) {
-        let pool = Pool::from_pool(pool, crate::PoolState);
+        let pool = Pool::from_pool(pool, crate::PoolState::default());
         let user_id = seed_admin(&pool).await;
 
         let project_a = crate::project::create_project(
@@ -382,7 +382,7 @@ mod tests {
 
     #[sqlx::test(migrator = "crate::db::MIGRATIONS")]
     async fn assign_role_rejects_missing_project(pool: sqlx::PgPool) {
-        let pool = Pool::from_pool(pool, crate::PoolState);
+        let pool = Pool::from_pool(pool, crate::PoolState::default());
         let user_id = seed_admin(&pool).await;
         let bogus_project = ProjectId::new(uuid::Uuid::new_v4().to_string()).unwrap();
 

--- a/lib/rust/api_db/src/session.rs
+++ b/lib/rust/api_db/src/session.rs
@@ -89,6 +89,11 @@ pub async fn lookup_session(
     .await
     .context("looking up session")?;
 
+    // A present row is session activity; a miss (unknown token) is not.
+    if row.is_some() {
+        pool.state().mark_sessions();
+    }
+
     row.map(RawSessionRow::try_into).transpose()
 }
 
@@ -143,15 +148,20 @@ pub async fn find_user_by_email(pool: &Pool, email: &str) -> anyhow::Result<Opti
     }
 }
 
-/// Delete expired sessions.
+/// Delete expired sessions, if there was session activity since the last sweep.
 /// Called periodically to garbage-collect sessions past their `expires_at`.
-pub async fn gc_expired_sessions(pool: &Pool) -> anyhow::Result<u64> {
+/// Returns `None` when the sweep is skipped (no activity), or `Some(n)` with the rows deleted when it runs.
+pub async fn gc_expired_sessions(pool: &Pool) -> anyhow::Result<Option<u64>> {
+    if !pool.state().take_sessions_dirty() {
+        return Ok(None);
+    }
+
     let result = sqlx::query!("DELETE FROM sessions WHERE expires_at < now()")
         .execute(&pool.pool())
         .await
         .context("garbage-collecting expired sessions")?;
 
-    Ok(result.rows_affected())
+    Ok(Some(result.rows_affected()))
 }
 
 // ── Internal types ────────────────────────────────────────────────────────
@@ -258,7 +268,7 @@ mod tests {
 
     #[sqlx::test(migrator = "crate::db::MIGRATIONS")]
     async fn create_and_lookup_session(pool: sqlx::PgPool) {
-        let pool = Pool::from_pool(pool, crate::PoolState);
+        let pool = Pool::from_pool(pool, crate::PoolState::default());
         let user_id = seed_admin(&pool).await;
 
         let token = create_session(&pool, &user_id, std::time::Duration::from_secs(3600), true)
@@ -277,7 +287,7 @@ mod tests {
 
     #[sqlx::test(migrator = "crate::db::MIGRATIONS")]
     async fn create_unrestricted_session(pool: sqlx::PgPool) {
-        let pool = Pool::from_pool(pool, crate::PoolState);
+        let pool = Pool::from_pool(pool, crate::PoolState::default());
         let user_id = seed_admin(&pool).await;
 
         let token = create_session(&pool, &user_id, std::time::Duration::from_secs(3600), false)
@@ -295,19 +305,40 @@ mod tests {
 
     #[sqlx::test(migrator = "crate::db::MIGRATIONS")]
     async fn lookup_missing_token_returns_none(pool: sqlx::PgPool) {
-        let pool = Pool::from_pool(pool, crate::PoolState);
+        let pool = Pool::from_pool(pool, crate::PoolState::default());
         let bogus = SessionToken::from_raw("a".repeat(64)).unwrap();
 
+        // A miss must not mark, so scanners can't drive GC wakeups.
+        pool.state().take_sessions_dirty();
         let row = lookup_session(&pool, &bogus)
             .await
             .expect("lookup_session failed");
 
         assert!(row.is_none());
+        assert!(!pool.state().take_sessions_dirty());
+    }
+
+    #[sqlx::test(migrator = "crate::db::MIGRATIONS")]
+    async fn gc_expired_sessions_runs_only_after_activity(pool: sqlx::PgPool) {
+        let pool = Pool::from_pool(pool, crate::PoolState::default());
+        let user_id = seed_admin(&pool).await;
+        // Zero duration → already expired by the time a sweep runs.
+        let token = create_session(&pool, &user_id, std::time::Duration::from_secs(0), true)
+            .await
+            .unwrap();
+
+        // Clear the flag the pool starts dirty with.
+        pool.state().take_sessions_dirty();
+
+        assert_eq!(gc_expired_sessions(&pool).await.unwrap(), None);
+        assert!(lookup_session(&pool, &token).await.unwrap().is_some());
+        assert_eq!(gc_expired_sessions(&pool).await.unwrap(), Some(1));
+        assert_eq!(gc_expired_sessions(&pool).await.unwrap(), None);
     }
 
     #[sqlx::test(migrator = "crate::db::MIGRATIONS")]
     async fn find_user_by_identity_returns_match(pool: sqlx::PgPool) {
-        let pool = Pool::from_pool(pool, crate::PoolState);
+        let pool = Pool::from_pool(pool, crate::PoolState::default());
         let user_id = seed_admin(&pool).await;
 
         let found = find_user_by_identity(&pool, "accounts.google.com", "test-sub-42")
@@ -319,7 +350,7 @@ mod tests {
 
     #[sqlx::test(migrator = "crate::db::MIGRATIONS")]
     async fn find_user_by_identity_returns_none_for_unknown(pool: sqlx::PgPool) {
-        let pool = Pool::from_pool(pool, crate::PoolState);
+        let pool = Pool::from_pool(pool, crate::PoolState::default());
 
         let found = find_user_by_identity(&pool, "unknown.issuer", "no-such-sub")
             .await
@@ -330,7 +361,7 @@ mod tests {
 
     #[sqlx::test(migrator = "crate::db::MIGRATIONS")]
     async fn find_user_by_id_returns_match(pool: sqlx::PgPool) {
-        let pool = Pool::from_pool(pool, crate::PoolState);
+        let pool = Pool::from_pool(pool, crate::PoolState::default());
         let user_id = seed_admin(&pool).await;
 
         let row = find_user_by_id(&pool, &user_id)
@@ -344,7 +375,7 @@ mod tests {
 
     #[sqlx::test(migrator = "crate::db::MIGRATIONS")]
     async fn find_user_by_id_returns_none_for_unknown(pool: sqlx::PgPool) {
-        let pool = Pool::from_pool(pool, crate::PoolState);
+        let pool = Pool::from_pool(pool, crate::PoolState::default());
         let bogus = UserId::new();
 
         let row = find_user_by_id(&pool, &bogus)

--- a/services/causes_api/src/store.rs
+++ b/services/causes_api/src/store.rs
@@ -51,8 +51,8 @@ pub trait Store: Send + Sync + 'static {
         nonce: &api_db::LoginNonce,
     ) -> anyhow::Result<Option<api_db::PendingLoginRow>>;
     async fn delete_pending_login(&self, nonce: &api_db::LoginNonce) -> anyhow::Result<()>;
-    async fn gc_pending_logins(&self, max_age: std::time::Duration) -> anyhow::Result<u64>;
-    async fn gc_expired_sessions(&self) -> anyhow::Result<u64>;
+    async fn gc_pending_logins(&self, max_age: std::time::Duration) -> anyhow::Result<Option<u64>>;
+    async fn gc_expired_sessions(&self) -> anyhow::Result<Option<u64>>;
     async fn get_user_roles(
         &self,
         user_id: &api_db::UserId,
@@ -186,11 +186,11 @@ impl Store for api_db::Pool {
         api_db::delete_pending_login(self, nonce).await
     }
 
-    async fn gc_pending_logins(&self, max_age: std::time::Duration) -> anyhow::Result<u64> {
+    async fn gc_pending_logins(&self, max_age: std::time::Duration) -> anyhow::Result<Option<u64>> {
         api_db::gc_pending_logins(self, max_age).await
     }
 
-    async fn gc_expired_sessions(&self) -> anyhow::Result<u64> {
+    async fn gc_expired_sessions(&self) -> anyhow::Result<Option<u64>> {
         api_db::gc_expired_sessions(self).await
     }
 


### PR DESCRIPTION
An hourly GC sweep issues `DELETE`s that wake a paused Aurora Serverless cluster; run unconditionally it wakes the cluster every hour with no traffic.

`PoolState` carries a per-aggregate activity flag. `lookup_session` sets the sessions flag on a present row; `create_pending_login` sets the pending-logins flag. `gc_expired_sessions` and `gc_pending_logins` clear their flag at entry, returning `None` when it was unset (skipped) and `Some(n)` with the rows deleted when they run. Flags start dirty so the first sweep after startup runs. A token miss does not mark, so anonymous scanning cannot drive sweeps.

The state rides on the pool via db_pool's `DbPool<E>` slot, so db_pool stays generic and the service is unchanged — its GC loop calls the same functions, which now self-gate.

The `Option<u64>` return makes the gating tests unambiguous: `None` is a skip, distinct from the `Some(0)` a sweep that ran and found nothing returns. api_db DB-integration tests assert each `gc_*` returns `None` on a clean flag and `Some(n)` after the corresponding activity, plus that a token miss doesn't mark; mutation runs (invert the gate; return `Some(0)` on skip) confirmed the tests fail against a broken implementation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
