### PR TITLE
db_pool: parameterize DbPool by consumer state

### DIFF
--- a/lib/rust/api_db/src/admin.rs
+++ b/lib/rust/api_db/src/admin.rs
@@ -1,5 +1,6 @@
+use crate::Pool;
 use anyhow::Context;
-use db_pool::{DbPool, QueryAccess};
+use db_pool::QueryAccess;
 use uuid::Uuid;
 
 use crate::db::begin_txn;
@@ -188,7 +189,7 @@ impl std::fmt::Display for ServiceAccountId {
 // ── Public API ─────────────────────────────────────────────────────────────
 
 /// Return the number of rows in the `users` table.
-pub async fn user_count(pool: &DbPool) -> anyhow::Result<i64> {
+pub async fn user_count(pool: &Pool) -> anyhow::Result<i64> {
     Ok(sqlx::query_scalar!("SELECT COUNT(*) FROM users")
         .fetch_one(&pool.pool())
         .await
@@ -200,7 +201,7 @@ pub async fn user_count(pool: &DbPool) -> anyhow::Result<i64> {
 ///
 /// `auth_provider` is the issuer URL (e.g. "accounts.google.com").
 pub async fn create_admin(
-    pool: &DbPool,
+    pool: &Pool,
     display_name: &DisplayName,
     email: &Email,
     auth_provider: &AuthProvider,
@@ -247,7 +248,7 @@ pub async fn create_admin(
 /// Unlike [`create_admin`], this does **not** insert any `role_assignments`.
 /// The caller is responsible for granting roles separately.
 pub async fn create_user(
-    pool: &DbPool,
+    pool: &Pool,
     display_name: &DisplayName,
     email: &Email,
     auth_provider: &AuthProvider,
@@ -416,7 +417,7 @@ mod tests {
 
     #[sqlx::test(migrator = "crate::db::MIGRATIONS")]
     async fn create_admin_inserts_rows(pool: sqlx::PgPool) {
-        let pool = DbPool::from_pool(pool);
+        let pool = Pool::from_pool(pool, crate::PoolState);
 
         let user_id = create_admin(
             &pool,
@@ -450,7 +451,7 @@ mod tests {
 
     #[sqlx::test(migrator = "crate::db::MIGRATIONS")]
     async fn create_user_inserts_rows_without_role(pool: sqlx::PgPool) {
-        let pool = DbPool::from_pool(pool);
+        let pool = Pool::from_pool(pool, crate::PoolState);
 
         let user_id = create_user(
             &pool,
@@ -483,7 +484,7 @@ mod tests {
 
     #[sqlx::test(migrator = "crate::db::MIGRATIONS")]
     async fn user_count_returns_nonnegative(pool: sqlx::PgPool) {
-        let pool = DbPool::from_pool(pool);
+        let pool = Pool::from_pool(pool, crate::PoolState);
 
         let count = user_count(&pool).await.expect("user_count failed");
         assert!(count >= 0);

--- a/lib/rust/api_db/src/db.rs
+++ b/lib/rust/api_db/src/db.rs
@@ -1,12 +1,13 @@
+use crate::Pool;
 use anyhow::Context;
-use db_pool::{DbPool, QueryAccess};
+use db_pool::QueryAccess;
 
 /// Embedded migrations, compiled from `migrations/` at build time.
 pub(crate) static MIGRATIONS: sqlx::migrate::Migrator = sqlx::migrate!("./migrations");
 
 /// Run all pending migrations.
 #[tracing::instrument(skip(pool), fields(db.system = "postgresql"))]
-pub async fn migrate(pool: &DbPool) -> anyhow::Result<()> {
+pub async fn migrate(pool: &Pool) -> anyhow::Result<()> {
     MIGRATIONS
         .run(&pool.pool())
         .await
@@ -17,7 +18,7 @@ pub async fn migrate(pool: &DbPool) -> anyhow::Result<()> {
 ///
 /// Generated once during migration 007 and stored in `instance_config`.
 /// This value never changes for the lifetime of the database.
-pub async fn instance_id(pool: &DbPool) -> anyhow::Result<String> {
+pub async fn instance_id(pool: &Pool) -> anyhow::Result<String> {
     let row = sqlx::query_scalar!("SELECT value FROM instance_config WHERE key = 'instance_id'")
         .fetch_one(&pool.pool())
         .await
@@ -32,7 +33,7 @@ pub async fn instance_id(pool: &DbPool) -> anyhow::Result<String> {
 /// direct `.begin()` calls elsewhere.
 #[allow(clippy::disallowed_methods)] // The one legitimate caller of sqlx::Pool::begin.
 pub(crate) async fn begin_txn(
-    pool: &DbPool,
+    pool: &Pool,
 ) -> anyhow::Result<sqlx::Transaction<'_, sqlx::Postgres>> {
     let mut tx = pool.pool().begin().await.context("beginning transaction")?;
     sqlx::query!("SET TRANSACTION ISOLATION LEVEL REPEATABLE READ")
@@ -47,7 +48,7 @@ mod tests {
     use super::*;
 
     /// An empty migrator — gives us a bare database from `#[sqlx::test]` so we
-    /// can exercise `DbPool::connect` and `migrate` ourselves.
+    /// can exercise `Pool::connect` and `migrate` ourselves.
     /// `Migrator::DEFAULT` already carries empty migrations and the standard
     /// flags, so we reuse it rather than spelling out the struct literal —
     /// that keeps us compiling across sqlx releases that add fields.
@@ -67,7 +68,9 @@ mod tests {
             .expect("database was null");
         let url = format!("postgresql://localhost:{port}/{db}");
 
-        let pool = DbPool::connect(&url).await.expect("DbPool::connect failed");
+        let pool = Pool::connect(&url, crate::PoolState)
+            .await
+            .expect("Pool::connect failed");
         migrate(&pool).await.expect("migrate failed");
     }
 
@@ -101,7 +104,7 @@ mod tests {
     /// Verify that instance_id is generated during migration and is a valid UUID.
     #[sqlx::test(migrator = "crate::db::MIGRATIONS")]
     async fn instance_id_is_generated(pool: sqlx::PgPool) {
-        let db = DbPool::from_pool(pool);
+        let db = Pool::from_pool(pool, crate::PoolState);
         let id = instance_id(&db).await.expect("instance_id failed");
         id.parse::<uuid::Uuid>()
             .expect("instance_id is not a valid UUID");
@@ -110,7 +113,7 @@ mod tests {
     /// Verify that running migrations twice preserves the existing instance_id.
     #[sqlx::test(migrator = "crate::db::tests::EMPTY")]
     async fn instance_id_survives_migration_rerun(pool: sqlx::PgPool) {
-        let db = DbPool::from_pool(pool);
+        let db = Pool::from_pool(pool, crate::PoolState);
 
         MIGRATIONS.run(&db.pool()).await.expect("first run failed");
         let original = instance_id(&db).await.expect("instance_id failed");
@@ -124,7 +127,7 @@ mod tests {
     /// Verify that `begin_txn` opens a transaction at REPEATABLE READ.
     #[sqlx::test(migrator = "crate::db::tests::EMPTY")]
     async fn begin_txn_sets_repeatable_read(pool: sqlx::PgPool) {
-        let db = DbPool::from_pool(pool);
+        let db = Pool::from_pool(pool, crate::PoolState);
         let mut tx = begin_txn(&db).await.expect("begin_txn failed");
         let level: String =
             sqlx::query_scalar!("SELECT current_setting('transaction_isolation') AS \"v!\"")
@@ -259,7 +262,7 @@ mod tests {
             .await
             .expect("journal_create_table call failed");
 
-        let db = DbPool::from_pool(pool);
+        let db = Pool::from_pool(pool, crate::PoolState);
         let project_id = seed_project_row(&db.pool()).await;
         let oi = uuid::Uuid::new_v4().to_string();
 
@@ -361,7 +364,7 @@ mod tests {
         .await
         .expect("partial index creation failed");
 
-        let db = DbPool::from_pool(pool);
+        let db = Pool::from_pool(pool, crate::PoolState);
         let project_id = seed_project_row(&db.pool()).await;
         let oi = uuid::Uuid::new_v4().to_string();
 

--- a/lib/rust/api_db/src/lib.rs
+++ b/lib/rust/api_db/src/lib.rs
@@ -6,6 +6,14 @@ mod project;
 mod role;
 mod session;
 
+/// Per-pool state this crate attaches to its connection pool. Empty for
+/// now; grows as the crate needs pool-scoped state.
+#[derive(Clone, Default)]
+pub struct PoolState;
+
+/// The connection pool as this crate uses it.
+pub type Pool = db_pool::DbPool<PoolState>;
+
 /// Re-export chrono types used in public structs (e.g. `SessionRow.expires_at`).
 pub use sqlx::types::chrono;
 

--- a/lib/rust/api_db/src/pending_login.rs
+++ b/lib/rust/api_db/src/pending_login.rs
@@ -1,5 +1,6 @@
+use crate::Pool;
 use anyhow::Context;
-use db_pool::{DbPool, QueryAccess};
+use db_pool::QueryAccess;
 use uuid::Uuid;
 
 // ── Newtypes ──────────────────────────────────────────────────────────────
@@ -38,7 +39,7 @@ impl LoginNonce {
 
 /// Persist a pending device-flow login and return the nonce.
 pub async fn create_pending_login(
-    pool: &DbPool,
+    pool: &Pool,
     device_code: &str,
     interval_secs: i32,
 ) -> anyhow::Result<LoginNonce> {
@@ -61,7 +62,7 @@ pub async fn create_pending_login(
 /// Look up a pending login by nonce.
 /// Returns `None` if the nonce does not exist (consumed or never created).
 pub async fn lookup_pending_login(
-    pool: &DbPool,
+    pool: &Pool,
     nonce: &LoginNonce,
 ) -> anyhow::Result<Option<PendingLoginRow>> {
     let row = sqlx::query_as!(
@@ -78,7 +79,7 @@ pub async fn lookup_pending_login(
 }
 
 /// Delete a pending login after successful completion.
-pub async fn delete_pending_login(pool: &DbPool, nonce: &LoginNonce) -> anyhow::Result<()> {
+pub async fn delete_pending_login(pool: &Pool, nonce: &LoginNonce) -> anyhow::Result<()> {
     sqlx::query!(
         "DELETE FROM pending_logins WHERE nonce = $1",
         nonce.as_str(),
@@ -92,7 +93,7 @@ pub async fn delete_pending_login(pool: &DbPool, nonce: &LoginNonce) -> anyhow::
 
 /// Delete pending logins older than the given age.
 /// Called periodically to garbage-collect abandoned login attempts.
-pub async fn gc_pending_logins(pool: &DbPool, max_age: std::time::Duration) -> anyhow::Result<u64> {
+pub async fn gc_pending_logins(pool: &Pool, max_age: std::time::Duration) -> anyhow::Result<u64> {
     let cutoff = sqlx::types::chrono::Utc::now() - max_age;
     let result = sqlx::query!("DELETE FROM pending_logins WHERE created_at < $1", cutoff,)
         .execute(&pool.pool())
@@ -146,7 +147,7 @@ mod tests {
 
     #[sqlx::test(migrator = "crate::db::MIGRATIONS")]
     async fn create_and_lookup_pending_login(pool: sqlx::PgPool) {
-        let pool = DbPool::from_pool(pool);
+        let pool = Pool::from_pool(pool, crate::PoolState);
 
         let nonce = create_pending_login(&pool, "dev-code-xyz", 5)
             .await
@@ -163,7 +164,7 @@ mod tests {
 
     #[sqlx::test(migrator = "crate::db::MIGRATIONS")]
     async fn lookup_missing_nonce_returns_none(pool: sqlx::PgPool) {
-        let pool = DbPool::from_pool(pool);
+        let pool = Pool::from_pool(pool, crate::PoolState);
         let bogus = LoginNonce::from_raw("a".repeat(64)).unwrap();
 
         let row = lookup_pending_login(&pool, &bogus)
@@ -175,7 +176,7 @@ mod tests {
 
     #[sqlx::test(migrator = "crate::db::MIGRATIONS")]
     async fn delete_removes_pending_login(pool: sqlx::PgPool) {
-        let pool = DbPool::from_pool(pool);
+        let pool = Pool::from_pool(pool, crate::PoolState);
 
         let nonce = create_pending_login(&pool, "dev-code", 5)
             .await
@@ -194,7 +195,7 @@ mod tests {
 
     #[sqlx::test(migrator = "crate::db::MIGRATIONS")]
     async fn gc_removes_old_pending_logins(pool: sqlx::PgPool) {
-        let pool = DbPool::from_pool(pool);
+        let pool = Pool::from_pool(pool, crate::PoolState);
 
         // Create a login, then GC with zero max age (everything is "old").
         create_pending_login(&pool, "dev-code", 5)

--- a/lib/rust/api_db/src/project.rs
+++ b/lib/rust/api_db/src/project.rs
@@ -5,7 +5,8 @@ use futures::StreamExt;
 use sqlx::types::chrono;
 use uuid::Uuid;
 
-use db_pool::{DbPool, QueryAccess};
+use crate::Pool;
+use db_pool::QueryAccess;
 
 use crate::admin::UserId;
 use crate::db::begin_txn;
@@ -155,7 +156,7 @@ pub struct ProjectRow {
 /// Atomic: both the project insert and the role assignment happen in a
 /// single transaction.
 pub async fn create_project(
-    pool: &DbPool,
+    pool: &Pool,
     name: &ProjectName,
     description: &str,
     visibility: ProjectVisibility,
@@ -211,7 +212,7 @@ pub async fn create_project(
 /// Returns `Visible(row)` if the caller can see it, `AccessDenied` if the
 /// project exists but is invisible, or `NotFound` if it doesn't exist.
 pub async fn get_project(
-    pool: &DbPool,
+    pool: &Pool,
     project_id: &ProjectId,
     session: &SessionRow,
 ) -> anyhow::Result<ProjectAccess> {
@@ -249,7 +250,7 @@ pub async fn get_project(
 }
 
 /// Check whether this session belongs to an unrestricted instance-admin.
-async fn is_unrestricted_admin(pool: &DbPool, session: &SessionRow) -> anyhow::Result<bool> {
+async fn is_unrestricted_admin(pool: &Pool, session: &SessionRow) -> anyhow::Result<bool> {
     if session.restricted {
         return Ok(false);
     }
@@ -271,7 +272,7 @@ async fn is_unrestricted_admin(pool: &DbPool, session: &SessionRow) -> anyhow::R
 /// - Otherwise, a single bulk query checks which private project IDs the
 ///   caller has a role on (via `ANY($1)` on the role_assignments index).
 async fn visible_projects(
-    pool: &DbPool,
+    pool: &Pool,
     session: &SessionRow,
     admin: bool,
     projects: Vec<ProjectRow>,
@@ -313,7 +314,7 @@ async fn visible_projects(
 ///
 /// Returns the same three-state `ProjectAccess` as `get_project`.
 pub async fn find_project_by_name(
-    pool: &DbPool,
+    pool: &Pool,
     name: &str,
     session: &SessionRow,
 ) -> anyhow::Result<ProjectAccess> {
@@ -368,7 +369,7 @@ const VISIBILITY_BATCH_SIZE: usize = 50;
 /// Each visibility-filtered batch is yielded through the stream. Dropping
 /// the stream cancels production after the current batch completes.
 pub async fn list_projects(
-    pool: &DbPool,
+    pool: &Pool,
     session: &SessionRow,
 ) -> anyhow::Result<ProjectBatchStream> {
     let admin = is_unrestricted_admin(pool, session).await?;
@@ -456,7 +457,7 @@ pub async fn list_projects(
 
 /// Rename a project. Returns the updated row, or `None` if not found.
 pub async fn rename_project(
-    pool: &DbPool,
+    pool: &Pool,
     project_id: &ProjectId,
     new_name: &ProjectName,
 ) -> Result<Option<ProjectRow>, ProjectError> {
@@ -489,7 +490,7 @@ pub async fn rename_project(
 }
 
 /// Delete a project and its role assignments. Returns false if not found.
-pub async fn delete_project(pool: &DbPool, project_id: &ProjectId) -> anyhow::Result<bool> {
+pub async fn delete_project(pool: &Pool, project_id: &ProjectId) -> anyhow::Result<bool> {
     let mut tx = begin_txn(pool).await?;
 
     sqlx::query!(
@@ -575,7 +576,7 @@ mod tests {
 
     // ── DB-backed tests ──────────────────────────────────────────────
 
-    async fn collect_all_projects(pool: &DbPool, session: &SessionRow) -> Vec<ProjectRow> {
+    async fn collect_all_projects(pool: &Pool, session: &SessionRow) -> Vec<ProjectRow> {
         use futures::TryStreamExt;
         let stream = list_projects(pool, session).await.unwrap();
         let batches: Vec<Vec<ProjectRow>> = stream.try_collect().await.unwrap();
@@ -590,7 +591,7 @@ mod tests {
         }
     }
 
-    async fn seed_admin(pool: &DbPool) -> UserId {
+    async fn seed_admin(pool: &Pool) -> UserId {
         create_admin(
             pool,
             &DisplayName::new("Test Admin").unwrap(),
@@ -604,7 +605,7 @@ mod tests {
 
     #[sqlx::test(migrator = "crate::db::MIGRATIONS")]
     async fn create_private_project_succeeds(pool: sqlx::PgPool) {
-        let pool = DbPool::from_pool(pool);
+        let pool = Pool::from_pool(pool, crate::PoolState);
         let user_id = seed_admin(&pool).await;
         let session = session_for(&user_id, false);
 
@@ -630,7 +631,7 @@ mod tests {
 
     #[sqlx::test(migrator = "crate::db::MIGRATIONS")]
     async fn create_project_inserts_row_and_role(pool: sqlx::PgPool) {
-        let pool = DbPool::from_pool(pool);
+        let pool = Pool::from_pool(pool, crate::PoolState);
         let user_id = seed_admin(&pool).await;
         let session = session_for(&user_id, false);
 
@@ -666,7 +667,7 @@ mod tests {
 
     #[sqlx::test(migrator = "crate::db::MIGRATIONS")]
     async fn create_project_rejects_duplicate_name(pool: sqlx::PgPool) {
-        let pool = DbPool::from_pool(pool);
+        let pool = Pool::from_pool(pool, crate::PoolState);
         let user_id = seed_admin(&pool).await;
         let name = ProjectName::new("dupe").unwrap();
 
@@ -681,7 +682,7 @@ mod tests {
 
     #[sqlx::test(migrator = "crate::db::MIGRATIONS")]
     async fn get_project_returns_none_for_missing(pool: sqlx::PgPool) {
-        let pool = DbPool::from_pool(pool);
+        let pool = Pool::from_pool(pool, crate::PoolState);
         let user_id = seed_admin(&pool).await;
         let session = session_for(&user_id, false);
         let pid = ProjectId::new(Uuid::new_v4().to_string()).unwrap();
@@ -693,7 +694,7 @@ mod tests {
 
     #[sqlx::test(migrator = "crate::db::MIGRATIONS")]
     async fn rename_project_updates_name(pool: sqlx::PgPool) {
-        let pool = DbPool::from_pool(pool);
+        let pool = Pool::from_pool(pool, crate::PoolState);
         let user_id = seed_admin(&pool).await;
 
         let pid = create_project(
@@ -717,7 +718,7 @@ mod tests {
 
     #[sqlx::test(migrator = "crate::db::MIGRATIONS")]
     async fn rename_missing_returns_none(pool: sqlx::PgPool) {
-        let pool = DbPool::from_pool(pool);
+        let pool = Pool::from_pool(pool, crate::PoolState);
         let pid = ProjectId::new(Uuid::new_v4().to_string()).unwrap();
         let result = rename_project(&pool, &pid, &ProjectName::new("xx").unwrap())
             .await
@@ -727,7 +728,7 @@ mod tests {
 
     #[sqlx::test(migrator = "crate::db::MIGRATIONS")]
     async fn delete_project_removes_row_and_roles(pool: sqlx::PgPool) {
-        let pool = DbPool::from_pool(pool);
+        let pool = Pool::from_pool(pool, crate::PoolState);
         let user_id = seed_admin(&pool).await;
         let session = session_for(&user_id, false);
 
@@ -757,14 +758,14 @@ mod tests {
 
     #[sqlx::test(migrator = "crate::db::MIGRATIONS")]
     async fn delete_missing_returns_false(pool: sqlx::PgPool) {
-        let pool = DbPool::from_pool(pool);
+        let pool = Pool::from_pool(pool, crate::PoolState);
         let pid = ProjectId::new(Uuid::new_v4().to_string()).unwrap();
         assert!(!delete_project(&pool, &pid).await.unwrap());
     }
 
     #[sqlx::test(migrator = "crate::db::MIGRATIONS")]
     async fn list_projects_returns_all(pool: sqlx::PgPool) {
-        let pool = DbPool::from_pool(pool);
+        let pool = Pool::from_pool(pool, crate::PoolState);
         let user_id = seed_admin(&pool).await;
         let session = session_for(&user_id, false);
 
@@ -797,7 +798,7 @@ mod tests {
 
     #[sqlx::test(migrator = "crate::db::MIGRATIONS")]
     async fn full_lifecycle(pool: sqlx::PgPool) {
-        let pool = DbPool::from_pool(pool);
+        let pool = Pool::from_pool(pool, crate::PoolState);
         let user_id = seed_admin(&pool).await;
         let session = session_for(&user_id, false);
 
@@ -887,7 +888,7 @@ mod tests {
 
     // ── Visibility tests ─────────────────────────────────────────────
 
-    async fn seed_user(pool: &DbPool, email: &str) -> UserId {
+    async fn seed_user(pool: &Pool, email: &str) -> UserId {
         crate::admin::create_user(
             pool,
             &DisplayName::new("User").unwrap(),
@@ -901,7 +902,7 @@ mod tests {
 
     #[sqlx::test(migrator = "crate::db::MIGRATIONS")]
     async fn get_project_hides_private_from_stranger(pool: sqlx::PgPool) {
-        let pool = DbPool::from_pool(pool);
+        let pool = Pool::from_pool(pool, crate::PoolState);
         let creator = seed_admin(&pool).await;
         let stranger = seed_user(&pool, "stranger@example.com").await;
         let stranger_session = session_for(&stranger, false);
@@ -926,7 +927,7 @@ mod tests {
 
     #[sqlx::test(migrator = "crate::db::MIGRATIONS")]
     async fn get_project_shows_private_to_member(pool: sqlx::PgPool) {
-        let pool = DbPool::from_pool(pool);
+        let pool = Pool::from_pool(pool, crate::PoolState);
         let creator = seed_admin(&pool).await;
         let session = session_for(&creator, false);
 
@@ -950,7 +951,7 @@ mod tests {
 
     #[sqlx::test(migrator = "crate::db::MIGRATIONS")]
     async fn get_project_shows_private_to_unrestricted_admin(pool: sqlx::PgPool) {
-        let pool = DbPool::from_pool(pool);
+        let pool = Pool::from_pool(pool, crate::PoolState);
         let admin = seed_admin(&pool).await;
         let other = seed_user(&pool, "other@example.com").await;
         let admin_session = session_for(&admin, false); // unrestricted
@@ -976,7 +977,7 @@ mod tests {
 
     #[sqlx::test(migrator = "crate::db::MIGRATIONS")]
     async fn get_project_hides_private_from_restricted_admin(pool: sqlx::PgPool) {
-        let pool = DbPool::from_pool(pool);
+        let pool = Pool::from_pool(pool, crate::PoolState);
         let admin = seed_admin(&pool).await;
         let other = seed_user(&pool, "other@example.com").await;
         let restricted_session = session_for(&admin, true); // restricted
@@ -1002,7 +1003,7 @@ mod tests {
 
     #[sqlx::test(migrator = "crate::db::MIGRATIONS")]
     async fn list_projects_filters_private(pool: sqlx::PgPool) {
-        let pool = DbPool::from_pool(pool);
+        let pool = Pool::from_pool(pool, crate::PoolState);
         let creator = seed_admin(&pool).await;
         let stranger = seed_user(&pool, "stranger@example.com").await;
         let creator_session = session_for(&creator, false);
@@ -1041,7 +1042,7 @@ mod tests {
 
     #[sqlx::test(migrator = "crate::db::MIGRATIONS")]
     async fn find_project_by_name_hides_private(pool: sqlx::PgPool) {
-        let pool = DbPool::from_pool(pool);
+        let pool = Pool::from_pool(pool, crate::PoolState);
         let creator = seed_admin(&pool).await;
         let stranger = seed_user(&pool, "stranger@example.com").await;
         let creator_session = session_for(&creator, false);
@@ -1106,7 +1107,7 @@ mod tests {
 
         use futures::StreamExt;
 
-        let pool = DbPool::from_pool(pool);
+        let pool = Pool::from_pool(pool, crate::PoolState);
         let user_id = seed_admin(&pool).await;
         let session = session_for(&user_id, false);
 

--- a/lib/rust/api_db/src/role.rs
+++ b/lib/rust/api_db/src/role.rs
@@ -1,5 +1,6 @@
+use crate::Pool;
 use anyhow::Context;
-use db_pool::{DbPool, QueryAccess};
+use db_pool::QueryAccess;
 use uuid::Uuid;
 
 use crate::admin::UserId;
@@ -95,10 +96,7 @@ pub struct RoleAssignment {
 }
 
 /// Get all roles for a user (both instance-level and project-level).
-pub async fn get_user_roles(
-    pool: &DbPool,
-    user_id: &UserId,
-) -> anyhow::Result<Vec<RoleAssignment>> {
+pub async fn get_user_roles(pool: &Pool, user_id: &UserId) -> anyhow::Result<Vec<RoleAssignment>> {
     let rows = sqlx::query!(
         "SELECT project_id, role FROM role_assignments WHERE user_id = $1",
         user_id.as_str(),
@@ -118,7 +116,7 @@ pub async fn get_user_roles(
 }
 
 /// Get instance-level roles for a user (project_id IS NULL).
-pub async fn get_user_instance_roles(pool: &DbPool, user_id: &UserId) -> anyhow::Result<Vec<Role>> {
+pub async fn get_user_instance_roles(pool: &Pool, user_id: &UserId) -> anyhow::Result<Vec<Role>> {
     let rows = sqlx::query_scalar!(
         "SELECT role FROM role_assignments WHERE user_id = $1 AND project_id IS NULL",
         user_id.as_str(),
@@ -132,7 +130,7 @@ pub async fn get_user_instance_roles(pool: &DbPool, user_id: &UserId) -> anyhow:
 
 /// Get roles for a user scoped to a specific project, including instance-level roles.
 pub async fn get_user_project_roles(
-    pool: &DbPool,
+    pool: &Pool,
     user_id: &UserId,
     project_id: &ProjectId,
 ) -> anyhow::Result<Vec<Role>> {
@@ -153,7 +151,7 @@ pub async fn get_user_project_roles(
 ///
 /// `project_id` is `None` for instance-level roles.
 pub async fn assign_role(
-    pool: &DbPool,
+    pool: &Pool,
     user_id: &UserId,
     project_id: &Option<ProjectId>,
     role: Role,
@@ -246,7 +244,7 @@ mod tests {
 
     use crate::admin::{AuthProvider, DisplayName, Email, Subject, create_admin};
 
-    async fn seed_admin(pool: &DbPool) -> UserId {
+    async fn seed_admin(pool: &Pool) -> UserId {
         create_admin(
             pool,
             &DisplayName::new("Test Admin").unwrap(),
@@ -260,7 +258,7 @@ mod tests {
 
     #[sqlx::test(migrator = "crate::db::MIGRATIONS")]
     async fn get_user_roles_empty_for_new_user(pool: sqlx::PgPool) {
-        let pool = DbPool::from_pool(pool);
+        let pool = Pool::from_pool(pool, crate::PoolState);
         let user_id = crate::admin::create_user(
             &pool,
             &DisplayName::new("Nobody").unwrap(),
@@ -277,7 +275,7 @@ mod tests {
 
     #[sqlx::test(migrator = "crate::db::MIGRATIONS")]
     async fn get_user_roles_returns_admin_role(pool: sqlx::PgPool) {
-        let pool = DbPool::from_pool(pool);
+        let pool = Pool::from_pool(pool, crate::PoolState);
         let user_id = seed_admin(&pool).await;
 
         let roles = get_user_roles(&pool, &user_id).await.unwrap();
@@ -288,7 +286,7 @@ mod tests {
 
     #[sqlx::test(migrator = "crate::db::MIGRATIONS")]
     async fn assign_and_get_role(pool: sqlx::PgPool) {
-        let pool = DbPool::from_pool(pool);
+        let pool = Pool::from_pool(pool, crate::PoolState);
         let user_id = seed_admin(&pool).await;
 
         assign_role(&pool, &user_id, &None, Role::Developer)
@@ -304,7 +302,7 @@ mod tests {
 
     #[sqlx::test(migrator = "crate::db::MIGRATIONS")]
     async fn assign_role_is_idempotent(pool: sqlx::PgPool) {
-        let pool = DbPool::from_pool(pool);
+        let pool = Pool::from_pool(pool, crate::PoolState);
         let user_id = seed_admin(&pool).await;
 
         assign_role(&pool, &user_id, &None, Role::Developer)
@@ -320,7 +318,7 @@ mod tests {
 
     #[sqlx::test(migrator = "crate::db::MIGRATIONS")]
     async fn get_user_project_roles_includes_instance_level(pool: sqlx::PgPool) {
-        let pool = DbPool::from_pool(pool);
+        let pool = Pool::from_pool(pool, crate::PoolState);
         let user_id = seed_admin(&pool).await;
 
         // create_project assigns project-maintainer to the creator
@@ -345,7 +343,7 @@ mod tests {
 
     #[sqlx::test(migrator = "crate::db::MIGRATIONS")]
     async fn get_user_project_roles_excludes_other_projects(pool: sqlx::PgPool) {
-        let pool = DbPool::from_pool(pool);
+        let pool = Pool::from_pool(pool, crate::PoolState);
         let user_id = seed_admin(&pool).await;
 
         let project_a = crate::project::create_project(
@@ -384,7 +382,7 @@ mod tests {
 
     #[sqlx::test(migrator = "crate::db::MIGRATIONS")]
     async fn assign_role_rejects_missing_project(pool: sqlx::PgPool) {
-        let pool = DbPool::from_pool(pool);
+        let pool = Pool::from_pool(pool, crate::PoolState);
         let user_id = seed_admin(&pool).await;
         let bogus_project = ProjectId::new(uuid::Uuid::new_v4().to_string()).unwrap();
 

--- a/lib/rust/api_db/src/session.rs
+++ b/lib/rust/api_db/src/session.rs
@@ -1,5 +1,6 @@
+use crate::Pool;
 use anyhow::Context;
-use db_pool::{DbPool, QueryAccess};
+use db_pool::QueryAccess;
 use sqlx::types::chrono;
 use uuid::Uuid;
 
@@ -50,7 +51,7 @@ impl std::fmt::Display for SessionToken {
 /// When `restricted` is true, authorization helpers suppress elevated roles
 /// (e.g. instance-admin) for this session.
 pub async fn create_session(
-    pool: &DbPool,
+    pool: &Pool,
     user_id: &UserId,
     duration: std::time::Duration,
     restricted: bool,
@@ -76,7 +77,7 @@ pub async fn create_session(
 /// Look up a session by token. Returns `None` if the token does not exist.
 /// The caller must check `expires_at` to determine if the session is still valid.
 pub async fn lookup_session(
-    pool: &DbPool,
+    pool: &Pool,
     token: &SessionToken,
 ) -> anyhow::Result<Option<SessionRow>> {
     let row = sqlx::query_as!(
@@ -94,7 +95,7 @@ pub async fn lookup_session(
 /// Find a local user by their external identity (issuer + subject).
 /// Returns `None` if the identity is not linked to any user.
 pub async fn find_user_by_identity(
-    pool: &DbPool,
+    pool: &Pool,
     issuer: &str,
     subject: &str,
 ) -> anyhow::Result<Option<UserId>> {
@@ -113,7 +114,7 @@ pub async fn find_user_by_identity(
 
 /// Fetch a user's display name and email by their id.
 /// Returns `None` if the user does not exist.
-pub async fn find_user_by_id(pool: &DbPool, user_id: &UserId) -> anyhow::Result<Option<UserRow>> {
+pub async fn find_user_by_id(pool: &Pool, user_id: &UserId) -> anyhow::Result<Option<UserRow>> {
     let row = sqlx::query_as!(
         RawUserRow,
         "SELECT display_name, email FROM users WHERE id = $1",
@@ -129,7 +130,7 @@ pub async fn find_user_by_id(pool: &DbPool, user_id: &UserId) -> anyhow::Result<
 /// Find a user by email address. Returns the user ID if exactly one user matches.
 /// Returns `None` if no user has this email.
 /// Errors if multiple users share the same email (ambiguous).
-pub async fn find_user_by_email(pool: &DbPool, email: &str) -> anyhow::Result<Option<UserId>> {
+pub async fn find_user_by_email(pool: &Pool, email: &str) -> anyhow::Result<Option<UserId>> {
     let rows = sqlx::query_scalar!("SELECT id FROM users WHERE email = $1", email,)
         .fetch_all(&pool.pool())
         .await
@@ -144,7 +145,7 @@ pub async fn find_user_by_email(pool: &DbPool, email: &str) -> anyhow::Result<Op
 
 /// Delete expired sessions.
 /// Called periodically to garbage-collect sessions past their `expires_at`.
-pub async fn gc_expired_sessions(pool: &DbPool) -> anyhow::Result<u64> {
+pub async fn gc_expired_sessions(pool: &Pool) -> anyhow::Result<u64> {
     let result = sqlx::query!("DELETE FROM sessions WHERE expires_at < now()")
         .execute(&pool.pool())
         .await
@@ -243,7 +244,7 @@ mod tests {
     // ── DB-backed tests ───────────────────────────────────────────────────
 
     /// Helper: create a test admin and return their UserId.
-    async fn seed_admin(pool: &DbPool) -> UserId {
+    async fn seed_admin(pool: &Pool) -> UserId {
         create_admin(
             pool,
             &DisplayName::new("Test Admin").unwrap(),
@@ -257,7 +258,7 @@ mod tests {
 
     #[sqlx::test(migrator = "crate::db::MIGRATIONS")]
     async fn create_and_lookup_session(pool: sqlx::PgPool) {
-        let pool = DbPool::from_pool(pool);
+        let pool = Pool::from_pool(pool, crate::PoolState);
         let user_id = seed_admin(&pool).await;
 
         let token = create_session(&pool, &user_id, std::time::Duration::from_secs(3600), true)
@@ -276,7 +277,7 @@ mod tests {
 
     #[sqlx::test(migrator = "crate::db::MIGRATIONS")]
     async fn create_unrestricted_session(pool: sqlx::PgPool) {
-        let pool = DbPool::from_pool(pool);
+        let pool = Pool::from_pool(pool, crate::PoolState);
         let user_id = seed_admin(&pool).await;
 
         let token = create_session(&pool, &user_id, std::time::Duration::from_secs(3600), false)
@@ -294,7 +295,7 @@ mod tests {
 
     #[sqlx::test(migrator = "crate::db::MIGRATIONS")]
     async fn lookup_missing_token_returns_none(pool: sqlx::PgPool) {
-        let pool = DbPool::from_pool(pool);
+        let pool = Pool::from_pool(pool, crate::PoolState);
         let bogus = SessionToken::from_raw("a".repeat(64)).unwrap();
 
         let row = lookup_session(&pool, &bogus)
@@ -306,7 +307,7 @@ mod tests {
 
     #[sqlx::test(migrator = "crate::db::MIGRATIONS")]
     async fn find_user_by_identity_returns_match(pool: sqlx::PgPool) {
-        let pool = DbPool::from_pool(pool);
+        let pool = Pool::from_pool(pool, crate::PoolState);
         let user_id = seed_admin(&pool).await;
 
         let found = find_user_by_identity(&pool, "accounts.google.com", "test-sub-42")
@@ -318,7 +319,7 @@ mod tests {
 
     #[sqlx::test(migrator = "crate::db::MIGRATIONS")]
     async fn find_user_by_identity_returns_none_for_unknown(pool: sqlx::PgPool) {
-        let pool = DbPool::from_pool(pool);
+        let pool = Pool::from_pool(pool, crate::PoolState);
 
         let found = find_user_by_identity(&pool, "unknown.issuer", "no-such-sub")
             .await
@@ -329,7 +330,7 @@ mod tests {
 
     #[sqlx::test(migrator = "crate::db::MIGRATIONS")]
     async fn find_user_by_id_returns_match(pool: sqlx::PgPool) {
-        let pool = DbPool::from_pool(pool);
+        let pool = Pool::from_pool(pool, crate::PoolState);
         let user_id = seed_admin(&pool).await;
 
         let row = find_user_by_id(&pool, &user_id)
@@ -343,7 +344,7 @@ mod tests {
 
     #[sqlx::test(migrator = "crate::db::MIGRATIONS")]
     async fn find_user_by_id_returns_none_for_unknown(pool: sqlx::PgPool) {
-        let pool = DbPool::from_pool(pool);
+        let pool = Pool::from_pool(pool, crate::PoolState);
         let bogus = UserId::new();
 
         let row = find_user_by_id(&pool, &bogus)

--- a/lib/rust/db_aws/src/lib.rs
+++ b/lib/rust/db_aws/src/lib.rs
@@ -15,8 +15,13 @@ pub use iam::IamParams;
 /// configuration (env vars, instance profile, etc). The returned pool has
 /// a refresher closure attached so [`db_pool::DbPool::start_background_refresh`]
 /// rotates the IAM token on the production schedule.
-#[tracing::instrument(fields(db.system = "postgresql"))]
-pub async fn connect_iam(host: &str, port: u16, user: &str) -> anyhow::Result<db_pool::DbPool> {
+#[tracing::instrument(skip(state), fields(db.system = "postgresql"))]
+pub async fn connect_iam<E>(
+    host: &str,
+    port: u16,
+    user: &str,
+    state: E,
+) -> anyhow::Result<db_pool::DbPool<E>> {
     // `aws-config`'s default-https-client feature is disabled at the workspace level (see Cargo.toml) so that the SDK does not silently pull in `rustls-aws-lc` and double up rustls providers — every other workspace member uses ring. We provide the HttpClient explicitly here with the ring CryptoMode.
     use aws_smithy_http_client::{Builder, tls};
     let http_client = Builder::new()
@@ -29,7 +34,7 @@ pub async fn connect_iam(host: &str, port: u16, user: &str) -> anyhow::Result<db
         .load()
         .await;
     let params = IamParams::new(host.to_owned(), port, user.to_owned());
-    connect_iam_with_sdk(params, sdk_config).await
+    connect_iam_with_sdk(params, sdk_config, state).await
 }
 
 /// How often the background refresher re-signs the IAM token.
@@ -47,11 +52,12 @@ const ACQUIRE_TIMEOUT: Duration = Duration::from_secs(60);
 /// Same as [`connect_iam`] but takes a pre-built [`aws_types::SdkConfig`].
 /// Use this when integrating with code that already has an SDK config
 /// (shared credentials provider, custom region, test overrides).
-#[tracing::instrument(skip(sdk_config), fields(db.system = "postgresql"))]
-pub async fn connect_iam_with_sdk(
+#[tracing::instrument(skip(sdk_config, state), fields(db.system = "postgresql"))]
+pub async fn connect_iam_with_sdk<E>(
     params: IamParams,
     sdk_config: aws_types::SdkConfig,
-) -> anyhow::Result<db_pool::DbPool> {
+    state: E,
+) -> anyhow::Result<db_pool::DbPool<E>> {
     let pool = build_iam_pool::<sqlx::PgPool>(&params, &sdk_config).await?;
     let refresher = iam_refresher(params, sdk_config);
 
@@ -59,6 +65,7 @@ pub async fn connect_iam_with_sdk(
         pool,
         REFRESH_INTERVAL,
         refresher,
+        state,
     ))
 }
 

--- a/lib/rust/db_connect/src/lib.rs
+++ b/lib/rust/db_connect/src/lib.rs
@@ -48,20 +48,21 @@ fn connect_mode(
     }
 }
 
-/// Build a [`db_pool::DbPool`] from environment-style configuration.
+/// Build a [`db_pool::DbPool`] from environment-style configuration,
+/// attaching the consumer's default pool state `E`.
 #[tracing::instrument(skip(database_url), fields(db.system = "postgresql"))]
-pub async fn connect(
+pub async fn connect<E: Default>(
     db_host: Option<&str>,
     db_user: Option<&str>,
     db_port: u16,
     database_url: Option<&str>,
-) -> anyhow::Result<db_pool::DbPool> {
+) -> anyhow::Result<db_pool::DbPool<E>> {
     match connect_mode(db_host, db_user, db_port, database_url)? {
         ConnectMode::AwsIam { host, user, port } => {
             tracing::info!("using AWS IAM database authentication");
-            db_aws::connect_iam(&host, port, &user).await
+            db_aws::connect_iam(&host, port, &user, E::default()).await
         }
-        ConnectMode::Static { url } => db_pool::DbPool::connect(&url).await,
+        ConnectMode::Static { url } => db_pool::DbPool::connect(&url, E::default()).await,
     }
 }
 

--- a/lib/rust/db_pool/src/lib.rs
+++ b/lib/rust/db_pool/src/lib.rs
@@ -37,56 +37,70 @@ pub type PoolRefresher = Arc<
         + Sync,
 >;
 
-/// Opaque pool handle.
+/// Opaque pool handle carrying a consumer-provided value `E` — a place
+/// for a query crate to attach its own per-pool state, set at
+/// construction and read via [`Self::state`]. Cloning the pool clones
+/// `E`, so an `Arc`-backed `E` is shared across clones.
 ///
 /// Static mode: a fixed pool, [`Self::start_background_refresh`] returns `None`.
 ///
 /// Refreshing mode: a refresher closure is attached; the background
 /// task periodically calls it to rotate the pool's credentials.
 #[derive(Clone)]
-pub struct DbPool {
+pub struct DbPool<E> {
     inner: sqlx::PgPool,
     refresher: Option<PoolRefresher>,
     refresh_interval: Duration,
+    state: E,
 }
 
-impl sealed::Sealed for DbPool {}
+impl<E> sealed::Sealed for DbPool<E> {}
 
-impl DbPool {
-    /// Create a connection pool from a static database URL.
-    #[tracing::instrument(skip(database_url), fields(db.system = "postgresql"))]
-    pub async fn connect(database_url: &str) -> anyhow::Result<Self> {
+impl<E> DbPool<E> {
+    /// Create a connection pool from a static database URL, attaching `state`.
+    #[tracing::instrument(skip(database_url, state), fields(db.system = "postgresql"))]
+    pub async fn connect(database_url: &str, state: E) -> anyhow::Result<Self> {
         let pool = PgPoolOptions::new()
             .max_connections(5)
             .connect(database_url)
             .await
             .context("connecting to PostgreSQL")?;
-        Ok(Self::from_pool(pool))
+        Ok(Self::from_pool(pool, state))
     }
 
-    /// Wrap an existing pool with a refresher closure. Provider crates use
-    /// this to attach token-rotation logic (e.g. `db_aws::connect_iam`).
+    /// Wrap an existing pool with a refresher closure, attaching `state`.
+    /// Provider crates use this to attach token-rotation logic (e.g.
+    /// `db_aws::connect_iam`).
     pub fn from_pool_with_refresher(
         pool: sqlx::PgPool,
         refresh_interval: Duration,
         refresher: PoolRefresher,
+        state: E,
     ) -> Self {
         Self {
             inner: pool,
             refresher: Some(refresher),
             refresh_interval,
+            state,
         }
     }
 
-    /// Wrap an existing pool with no refresher. Use [`Self::connect`] for
-    /// the static URL path; this is mainly for `#[sqlx::test]` fixtures
-    /// and other scenarios where the pool already exists.
-    pub fn from_pool(pool: sqlx::PgPool) -> Self {
+    /// Wrap an existing pool with no refresher, attaching `state`. Use
+    /// [`Self::connect`] for the static URL path; this is mainly for
+    /// `#[sqlx::test]` fixtures and other scenarios where the pool already
+    /// exists.
+    pub fn from_pool(pool: sqlx::PgPool, state: E) -> Self {
         Self {
             inner: pool,
             refresher: None,
             refresh_interval: Duration::from_secs(6 * 3600),
+            state,
         }
+    }
+
+    /// The attached state.
+    pub fn state(&self) -> &E {
+        &self.state
     }
 
     /// Spawn a background task that periodically rebuilds the pool via
@@ -125,7 +139,7 @@ pub trait QueryAccess: sealed::Sealed {
     fn pool(&self) -> sqlx::PgPool;
 }
 
-impl QueryAccess for DbPool {
+impl<E> QueryAccess for DbPool<E> {
     fn pool(&self) -> sqlx::PgPool {
         self.inner.clone()
     }
@@ -136,13 +150,16 @@ mod tests {
     use super::*;
 
     #[test]
-    fn from_pool_has_no_refresher() {
-        // Construct a sentinel pool via PgPoolOptions::new() — never connected,
-        // but proves the type construction path. start_background_refresh
-        // should be None when no refresher is attached.
+    fn from_pool_attaches_state_without_refresher() {
+        // Sentinel pool — never connected — proves the construction path.
         let pool = sqlx::postgres::PgPool::connect_lazy("postgresql://invalid")
             .expect("lazy connect builds options");
-        let db = DbPool::from_pool(pool);
+        let db = DbPool::from_pool(pool, 7u32);
+
+        assert_eq!(*db.state(), 7);
+        // Cloning clones the state.
+        assert_eq!(*db.clone().state(), 7);
+        // No refresher was attached.
         assert!(db.start_background_refresh().is_none());
     }
 }

--- a/services/causes_api/src/main.rs
+++ b/services/causes_api/src/main.rs
@@ -28,7 +28,7 @@ async fn main() -> anyhow::Result<()> {
     let cfg = config::Config::parse();
 
     info!("connecting to database");
-    let pool = db_connect::connect(
+    let pool: api_db::Pool = db_connect::connect(
         cfg.db_host.as_deref(),
         cfg.db_user.as_deref(),
         cfg.db_port,

--- a/services/causes_api/src/store.rs
+++ b/services/causes_api/src/store.rs
@@ -103,7 +103,7 @@ pub trait Store: Send + Sync + 'static {
 }
 
 #[tonic::async_trait]
-impl Store for db_connect::DbPool {
+impl Store for api_db::Pool {
     async fn migrate(&self) -> anyhow::Result<()> {
         api_db::migrate(self).await
     }


### PR DESCRIPTION
`DbPool` gains a type parameter `E`, set at construction and read via `state()`. The three constructors — `connect`, `from_pool`, `from_pool_with_refresher` — take `E` and return `DbPool<E>`.

`db_aws` and `db_connect` thread `E` through: `connect_iam` takes `E` by value; `connect` takes `E: Default` and supplies `E::default()`.

`api_db` pins its own alias — `struct PoolState` (empty for now) and `type Pool = DbPool<PoolState>` — and takes `&Pool` everywhere. It depends only on `db_pool`, never `db_connect`, so it pulls in no AWS. The service, holding both, wires them: `DbPool<PoolState>` from `db_connect::connect` and `impl Store for api_db::Pool`.

Pure refactor — `E` is `PoolState` (empty) throughout, no behaviour change. Full test suite (including the api_db DB-integration tests) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
