### PR TITLE
infra: pin Aurora engine_version to 16.11

### DIFF
--- a/infra/terraform/aurora.tf
+++ b/infra/terraform/aurora.tf
@@ -70,7 +70,7 @@ resource "aws_db_subnet_group" "causes" {
 resource "aws_rds_cluster" "causes" {
   cluster_identifier          = "causes"
   engine                      = "aurora-postgresql"
-  engine_version              = "16.6"
+  engine_version              = "16.11"
   database_name               = "causes"
   master_username             = "postgres"
   manage_master_user_password              = true


### PR DESCRIPTION
The config pinned 16.6, but Aurora auto-upgraded the live cluster to 16.11.
`apply` then tried to downgrade 16.11 → 16.6, which RDS rejects (`Cannot find upgrade target from 16.11 with requested version 16.6`), aborting the deploy after it had already destroyed the EC2 instance.

Pinning to 16.11 matches the live cluster; the recreate apply then succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
