### PR TITLE
rules: user requirements are settled, not choices

### DIFF
--- a/.claude/rules/feedback/feedback_requirements_are_settled.md
+++ b/.claude/rules/feedback/feedback_requirements_are_settled.md
@@ -1,0 +1,9 @@
+# A requirement from the user is settled, not a standing choice
+
+When the user states a requirement, treat it as a fixed premise from then on, like a law of physics.
+Do not re-surface it as "the X you're keeping" or otherwise frame it as an open decision to re-ratify each turn.
+
+Accept it, build on it, and highlight implications only as they actually arise — the way "gravity holds" simply leads to "the ball falls," with no restating of gravity as a choice.
+
+**How to apply:** once a requirement is given, stop offering it back for reconfirmation.
+Reference it only when a consequence of it needs stating.


### PR DESCRIPTION
A stated requirement is a fixed premise from then on, like a law of physics — not an open decision to re-ratify each turn.
Reference it only when a consequence of it needs stating.
