### PR TITLE
devcontainer: cap-add SYS_ADMIN for namespaces

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,7 @@
 {
   "name": "Causes",
   "build": { "dockerfile": "Dockerfile" },
+  "runArgs": ["--cap-add=SYS_ADMIN"],
   "features": {
     "ghcr.io/devcontainers/features/node:1": {},
     "ghcr.io/devcontainers/features/github-cli:1": {},


### PR DESCRIPTION
Grant `CAP_SYS_ADMIN` to the dev container so `unshare`/`mount`/`pivot_root` succeed inside it.

This permits future use of `crun` (a container runtime) to run local NativeLink build tasks in an isolated, reproducible root filesystem, rather than directly in the dev container.

Docker's default capability set drops `SYS_ADMIN`, and its default seccomp profile gates those syscalls on the capability — so adding the cap unlocks both. No `--privileged`, no `seccomp=unconfined`; narrower than the docker socket already mounted.

Verified after a container rebuild: `unshare -Urm true` and `sudo unshare --mount --pid --fork true` both exit 0 (both were EPERM before).
