### PR TITLE
tools: pin crane for OCI image assembly

### DIFF
--- a/.github/workflows/renovate-sha.yml
+++ b/.github/workflows/renovate-sha.yml
@@ -16,6 +16,7 @@ on:
     paths:
       - tools/buckle/install.sh
       - tools/nativelink/install.sh
+      - tools/crane/install.sh
 permissions:
   contents: write
 # Shared with renovate-lockfile: fixers on the same branch run one at a
@@ -32,7 +33,7 @@ jobs:
         with:
           ref: ${{ github.ref_name }}
           token: ${{ secrets.AUTO_QUEUE_TOKEN }}
-      # Both installers, unconditionally: an untouched pin is a no-op, so
+      # Every installer, unconditionally: an untouched pin is a no-op, so
       # diff-detection logic is unnecessary.
       - name: Recompute installer sha256 pins
         env:
@@ -40,6 +41,7 @@ jobs:
         run: |
           bash tools/renovate/update_sha.sh tools/buckle/install.sh
           bash tools/renovate/update_sha.sh tools/nativelink/install.sh
+          bash tools/renovate/update_sha.sh tools/crane/install.sh
       - name: Push fix if the pins changed
         run: |
           git diff --quiet && exit 0

--- a/renovate.json
+++ b/renovate.json
@@ -77,7 +77,7 @@
       "extractVersionTemplate": "^v(?<version>.*)$"
     },
     {
-      "description": "Bump PRs fail the installer's sha256 check until the pinned checksum is updated by hand.",
+      "description": "Renovate cannot update the sha256 (renovatebot/renovate#22183); the renovate-sha workflow recomputes it on the bump PR.",
       "customType": "regex",
       "managerFilePatterns": [
         "/^tools/nativelink/install\\.sh$/"
@@ -90,7 +90,7 @@
       "extractVersionTemplate": "^v(?<version>.*)$"
     },
     {
-      "description": "Bump PRs fail the installer's sha256 check until the pinned checksum is updated by hand.",
+      "description": "Renovate cannot update the sha256 (renovatebot/renovate#22183); the renovate-sha workflow recomputes it on the bump PR.",
       "customType": "regex",
       "managerFilePatterns": [
         "/^tools/buckle/install\\.sh$/"
@@ -99,6 +99,19 @@
         "BUCKLE_VERSION=(?<currentValue>\\S+)"
       ],
       "depNameTemplate": "benbrittain/buckle",
+      "datasourceTemplate": "github-releases",
+      "extractVersionTemplate": "^v(?<version>.*)$"
+    },
+    {
+      "description": "Renovate cannot update the sha256 (renovatebot/renovate#22183); the renovate-sha workflow recomputes it on the bump PR.",
+      "customType": "regex",
+      "managerFilePatterns": [
+        "/^tools/crane/install\\.sh$/"
+      ],
+      "matchStrings": [
+        "CRANE_VERSION=(?<currentValue>\\S+)"
+      ],
+      "depNameTemplate": "google/go-containerregistry",
       "datasourceTemplate": "github-releases",
       "extractVersionTemplate": "^v(?<version>.*)$"
     }

--- a/tools/crane/install.sh
+++ b/tools/crane/install.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+# Install the pinned crane binary into $1 (default /usr/local/bin).
+set -euo pipefail
+
+BINDIR="${1:-/usr/local/bin}"
+CRANE_VERSION=0.20.2
+CRANE_SHA256=c14340087103ba9dadf61d45acd20675490fd0ccbd56ac7901fc1b502137f44b
+
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+
+curl -fsSL \
+	"https://github.com/google/go-containerregistry/releases/download/v${CRANE_VERSION}/go-containerregistry_Linux_x86_64.tar.gz" \
+	-o "$tmp/crane.tar.gz"
+echo "${CRANE_SHA256}  $tmp/crane.tar.gz" | sha256sum -c -
+tar xzf "$tmp/crane.tar.gz" -C "$tmp" crane
+install -m 0755 "$tmp/crane" "$BINDIR/crane"

--- a/tools/renovate/update_sha.sh
+++ b/tools/renovate/update_sha.sh
@@ -20,6 +20,11 @@ tools/nativelink/install.sh)
 	VAR=NATIVELINK
 	ASSET='nativelink-VERSION-x86_64-unknown-linux-musl.tar.gz'
 	;;
+tools/crane/install.sh)
+	REPO=google/go-containerregistry
+	VAR=CRANE
+	ASSET='go-containerregistry_Linux_x86_64.tar.gz'
+	;;
 *)
 	echo "unknown installer: $INSTALLER" >&2
 	exit 1


### PR DESCRIPTION
Pin the `crane` binary (google/go-containerregistry) by sha256, mirroring the nativelink and buckle installers.

crane is for assembling a minimal OCI image, used to run build tasks in a controlled root filesystem.

Renovate tracks the version, and crane is wired into the `renovate-sha` workflow + `update_sha.sh` so a bump's stale pin is recomputed automatically, like the other installers (otherwise it lands a stale sha and fails CI's checksum check).

Also corrects all three installer-manager `description` fields, which said the sha is "updated by hand" — stale since #407 wired `renovate-sha` to recompute them automatically.

Verified: `install.sh` fetches, checksum-verifies, and installs crane 0.20.2; a corrupted pin is rejected by the sha256 check.
