### PR TITLE
nativelink: worker image build rule

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -109,6 +109,19 @@
       "extractVersionTemplate": "^v(?<version>.*)$"
     },
     {
+      "description": "crane release pinned in a BUCK file. Renovate cannot recompute the sha256 (renovatebot/renovate#22183); the renovate-sha workflow recomputes it on the bump PR.",
+      "customType": "regex",
+      "managerFilePatterns": [
+        "/(^|/)BUCK$/"
+      ],
+      "matchStrings": [
+        "go-containerregistry/releases/download/v(?<currentValue>[0-9][^/]+)/"
+      ],
+      "depNameTemplate": "google/go-containerregistry",
+      "datasourceTemplate": "github-releases",
+      "extractVersionTemplate": "^v(?<version>.*)$"
+    },
+    {
       "description": "cpython version pinned in a BUCK file. Renovate cannot recompute the sha256 (renovatebot/renovate#22183), so a bump needs the checksum updated separately.",
       "customType": "regex",
       "managerFilePatterns": [

--- a/third_party/crane/BUCK
+++ b/third_party/crane/BUCK
@@ -1,0 +1,9 @@
+load("//tools:defs.bzl", "cached_http_archive")
+
+cached_http_archive(
+    name = "crane",
+    sha256 = "c14340087103ba9dadf61d45acd20675490fd0ccbd56ac7901fc1b502137f44b",
+    sub_targets = ["crane"],
+    urls = ["https://github.com/google/go-containerregistry/releases/download/v0.20.2/go-containerregistry_Linux_x86_64.tar.gz"],
+    visibility = ["//tools/nativelink:"],
+)

--- a/tools/nativelink/BUCK
+++ b/tools/nativelink/BUCK
@@ -1,0 +1,10 @@
+load("//tools/nativelink:image.bzl", "worker_image")
+
+worker_image(
+    name = "worker_image",
+    assemble = "assemble_image.sh",
+    busybox_sha256 = "6e123e7f3202a8c1e9b1f94d8941580a25135382b99e8d3e34fb858bba311348",
+    busybox_url = "https://busybox.net/downloads/binaries/1.35.0-x86_64-linux-musl/busybox",
+    crane = "//third_party/crane:crane[crane]",
+    visibility = ["PUBLIC"],
+)

--- a/tools/nativelink/assemble_image.sh
+++ b/tools/nativelink/assemble_image.sh
@@ -1,0 +1,25 @@
+#!/bin/sh
+# Assemble a from-scratch OCI image (pinned static busybox rootfs) from the
+# inputs staged by the worker_image rule and write it to $3.
+# Args: $1 busybox binary, $2 crane binary, $3 output image tar.
+# Deterministic: fixed rootfs layout, sorted/zeroed tar.
+set -eu
+
+busybox="$1"
+crane="$2"
+out="$3"
+
+work="$(mktemp -d)"
+root="$work/rootfs"
+mkdir -p "$root/bin" "$root/tmp" "$root/proc" "$root/dev" "$root/etc"
+install -m 0755 "$busybox" "$root/bin/busybox"
+"$busybox" --list | while read -r applet; do
+	[ "$applet" = busybox ] && continue
+	ln -sf busybox "$root/bin/$applet"
+done
+
+tar --sort=name --mtime='UTC 1970-01-01' --owner=0 --group=0 --numeric-owner \
+	--format=gnu -C "$root" -cf "$work/layer.tar" .
+
+"$crane" append --oci-empty-base -f "$work/layer.tar" -o "$out" \
+	-t causes-worker:local >&2

--- a/tools/nativelink/image.bzl
+++ b/tools/nativelink/image.bzl
@@ -1,0 +1,29 @@
+# Build the NativeLink worker's from-scratch OCI image as a cacheable action.
+# busybox is downloaded by pinned sha256; crane is a pinned cached_http_archive.
+# The image is a pure function of them, so its output digest is stable.
+def _worker_image_impl(ctx: AnalysisContext) -> list[Provider]:
+    busybox = ctx.actions.declare_output("busybox")
+    ctx.actions.download_file(
+        busybox.as_output(),
+        ctx.attrs.busybox_url,
+        sha256 = ctx.attrs.busybox_sha256,
+        is_executable = True,
+    )
+    crane = ctx.attrs.crane[DefaultInfo].default_outputs[0]
+    out = ctx.actions.declare_output("worker.tar")
+    ctx.actions.run(
+        cmd_args("/bin/sh", ctx.attrs.assemble, busybox, crane, out.as_output()),
+        category = "worker_image",
+        allow_cache_upload = True,
+    )
+    return [DefaultInfo(default_output = out)]
+
+worker_image = rule(
+    impl = _worker_image_impl,
+    attrs = {
+        "assemble": attrs.source(),
+        "busybox_sha256": attrs.string(),
+        "busybox_url": attrs.string(),
+        "crane": attrs.dep(providers = [DefaultInfo]),
+    },
+)


### PR DESCRIPTION
`worker_image`: a buck2 rule that builds a from-scratch busybox OCI image as a cacheable action.

busybox and crane are downloaded by pinned sha256 as declared inputs, then assembled — fixed rootfs layout, sorted/zeroed tar, crane empty base — into an image tar. The image is a pure function of its pinned inputs, so its manifest digest is stable, which is what lets it key the shared cache and be distributed by digest.

Building it as an action (rather than out-of-band) needs no worker image itself: its correctness rests on the inputs being declared and content-pinned, so it runs on a bare bootstrap worker.

Verified: builds as a remote action on the local NativeLink worker; `crane validate` passes; two builds and the reference assembly all agree on `sha256:d72f78e6…`.
