### PR TITLE
rules: drop dangling narrative-against-base link

### DIFF
--- a/.claude/rules/feedback/feedback_review_0_before_push.md
+++ b/.claude/rules/feedback/feedback_review_0_before_push.md
@@ -25,7 +25,7 @@ A still-accurate, non-obvious comment dropped during a rewrite is a regression â
 ## 3. Narrative reads against the base, never prior drafts of this branch
 
 Comments, docs, the commit message, and the PR body describe what the code IS versus the base.
-Flag "no longer", "instead of", "previously", "no default", "avoids X", "rather than", and any reference to a concept not present in the base (see [[feedback_narrative_against_base]]).
+Flag "no longer", "instead of", "previously", "no default", "avoids X", "rather than", and any reference to a concept not present in the base.
 
 ## 4. Comments earn their place
 


### PR DESCRIPTION
The standalone narrative-against-base rule is not landing — its content is already stated in full by this rule's item 3, and every rule file is read into context each session, so a duplicate isn't carrying its weight.

Remove the trailing `(see [[feedback_narrative_against_base]])` pointer so it doesn't dangle.
