### PR TITLE
ci: track github-sourced BUCK pins in renovate

### DIFF
--- a/.github/workflows/renovate-sha.yml
+++ b/.github/workflows/renovate-sha.yml
@@ -17,6 +17,7 @@ on:
       - tools/buckle/install.sh
       - tools/nativelink/install.sh
       - tools/crane/install.sh
+      - "**/BUCK"
 permissions:
   contents: write
 # Shared with renovate-lockfile: fixers on the same branch run one at a
@@ -42,11 +43,21 @@ jobs:
           bash tools/renovate/update_sha.sh tools/buckle/install.sh
           bash tools/renovate/update_sha.sh tools/nativelink/install.sh
           bash tools/renovate/update_sha.sh tools/crane/install.sh
+      # BUCK pins are diff-gated against master: only a download whose URL the
+      # bump changed is re-fetched, so an unchanged pin keeps its reviewed sha.
+      - name: Recompute BUCK sha256 pins
+        run: |
+          git fetch -q --depth=1 origin master
+          git diff --name-only FETCH_HEAD -- '*BUCK' | while read -r buck; do
+            base="$(mktemp)"
+            git show "FETCH_HEAD:$buck" >"$base" 2>/dev/null || : >"$base"
+            bash tools/renovate/update_buck_shas.sh "$buck" "$base"
+          done
       - name: Push fix if the pins changed
         run: |
           git diff --quiet && exit 0
           git config user.name "github-actions[bot]"
           git config user.email \
             "41898282+github-actions[bot]@users.noreply.github.com"
-          git commit -am "chore: recompute installer sha256 pins"
+          git commit -am "chore: recompute pinned sha256 checksums"
           git push

--- a/renovate.json
+++ b/renovate.json
@@ -114,6 +114,17 @@
       "depNameTemplate": "google/go-containerregistry",
       "datasourceTemplate": "github-releases",
       "extractVersionTemplate": "^v(?<version>.*)$"
+    },
+    {
+      "description": "Any GitHub-release download pinned in a BUCK file; the renovate-sha workflow recomputes the sha256 on the bump PR (renovatebot/renovate#22183).",
+      "customType": "regex",
+      "managerFilePatterns": [
+        "/(^|/)BUCK$/"
+      ],
+      "matchStrings": [
+        "https://github\\.com/(?<depName>[^/\"]+/[^/\"]+)/releases/download/(?<currentValue>[^/\"]+)/"
+      ],
+      "datasourceTemplate": "github-releases"
     }
   ]
 }

--- a/tools/BUILD.bazel
+++ b/tools/BUILD.bazel
@@ -159,6 +159,17 @@ sh_test(
     ],
 )
 
+# Exercises the diff-gating in update_buck_shas.sh: only pins whose URL changed
+# vs the base are re-fetched, so an unchanged pin keeps its reviewed sha.
+sh_test(
+    name = "update_buck_shas_test",
+    srcs = ["renovate/update_buck_shas_test.sh"],
+    data = [
+        "renovate/update_buck_shas.sh",
+        "@bazel_tools//tools/bash/runfiles",
+    ],
+)
+
 # PreToolUse action guard, wired into .claude/settings.json.  Denies forbidden
 # agent actions at the moment of action: native tooling instead of the Bazel
 # wrappers, lockfile destruction, and mod.rs creation.  Decision logic lives in

--- a/tools/renovate/update_buck_shas.sh
+++ b/tools/renovate/update_buck_shas.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# Recompute sha256 pins in a BUCK file for downloads whose URL changed vs the
+# base version, and only those.
+# An unchanged pin keeps its reviewed sha, so a silently re-published upstream
+# artifact fails the build rather than being relocked to the new bytes.
+# Usage: update_buck_shas.sh <buck-file> <base-buck-file>
+# The base file is the base-branch version of <buck-file>; an empty or absent
+# base treats every pin as new.
+set -euo pipefail
+
+# The `<name>_url` value in file $1, or empty if the file or name is absent.
+url_of() {
+	[[ -f "$1" ]] || return 0
+	sed -n "s/.*${2}_url = \"\\([^\"]*\\)\".*/\\1/p" "$1"
+}
+
+# Names in BUCK $1 whose `<name>_url` differs from base $2.
+changed_names() {
+	local buck="$1" base="$2" name
+	grep -oE '[A-Za-z0-9_]+_url = "[^"]*"' "$buck" | sed -E 's/_url = .*//' |
+		while read -r name; do
+			[[ "$(url_of "$buck" "$name")" != "$(url_of "$base" "$name")" ]] && echo "$name"
+		done
+}
+
+main() {
+	local buck="${1:?usage: update_buck_shas.sh <buck-file> <base-buck-file>}"
+	local base="${2:-}" name url tmp sha
+	for name in $(changed_names "$buck" "$base"); do
+		url="$(url_of "$buck" "$name")"
+		tmp="$(mktemp)"
+		curl -fsSL "$url" -o "$tmp"
+		sha="$(sha256sum "$tmp" | awk '{print $1}')"
+		rm -f "$tmp"
+		sed -i "s/\\(${name}_sha256 = \"\\)[0-9a-f]*\\(\"\\)/\\1${sha}\\2/" "$buck"
+	done
+}
+
+[[ -n "${_UPDATE_BUCK_SHAS_SOURCED:-}" ]] || main "$@"

--- a/tools/renovate/update_buck_shas_test.sh
+++ b/tools/renovate/update_buck_shas_test.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+# Test driver for the diff-gating logic in update_buck_shas.sh.
+# Sources the script (with _UPDATE_BUCK_SHAS_SOURCED=1 to skip main) and checks
+# that `changed_names` selects exactly the pins whose URL differs from the base
+# — the property that keeps an unchanged pin's reviewed sha from being relocked.
+set -uo pipefail
+
+if [[ -f "${RUNFILES_DIR:-/dev/null}/bazel_tools/tools/bash/runfiles/runfiles.bash" ]]; then
+	# shellcheck source=/dev/null
+	source "${RUNFILES_DIR}/bazel_tools/tools/bash/runfiles/runfiles.bash"
+elif [[ -f "${BASH_SOURCE[0]}.runfiles/bazel_tools/tools/bash/runfiles/runfiles.bash" ]]; then
+	# shellcheck source=/dev/null
+	source "${BASH_SOURCE[0]}.runfiles/bazel_tools/tools/bash/runfiles/runfiles.bash"
+elif [[ -f "${RUNFILES_MANIFEST_FILE:-/dev/null}" ]]; then
+	# shellcheck source=/dev/null
+	source "$(grep -m1 "^bazel_tools/tools/bash/runfiles/runfiles.bash " \
+		"$RUNFILES_MANIFEST_FILE" | cut -d ' ' -f2-)"
+else
+	echo >&2 "ERROR: cannot find Bazel runfiles library"
+	exit 1
+fi
+
+SCRIPT="$(rlocation _main/tools/renovate/update_buck_shas.sh)"
+if [[ ! -f "$SCRIPT" ]]; then
+	echo "ERROR: cannot locate update_buck_shas.sh via runfiles" >&2
+	exit 1
+fi
+
+# shellcheck source=/dev/null
+_UPDATE_BUCK_SHAS_SOURCED=1 source "$SCRIPT"
+
+PASS=0
+FAIL=0
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+
+expect() {
+	local name="$1" want="$2" got="$3"
+	if [[ "$got" == "$want" ]]; then
+		echo "PASS: $name"
+		((PASS++)) || true
+	else
+		echo "FAIL: $name — want [$want], got [$got]"
+		((FAIL++)) || true
+	fi
+}
+
+names() { changed_names "$1" "$2" | sort | tr '\n' ' '; }
+
+cat >"$tmp/base" <<'EOF'
+foo_url = "https://example/foo/v1/a.tgz"
+foo_sha256 = "aaaa"
+bar_url = "https://example/bar/v9/b.tgz"
+bar_sha256 = "bbbb"
+EOF
+
+# One URL bumped, the other untouched.
+cat >"$tmp/work" <<'EOF'
+foo_url = "https://example/foo/v2/a.tgz"
+foo_sha256 = "aaaa"
+bar_url = "https://example/bar/v9/b.tgz"
+bar_sha256 = "bbbb"
+EOF
+expect "only the changed url is selected" "foo " "$(names "$tmp/work" "$tmp/base")"
+
+# A pin absent from the base is new, so selected.
+cp "$tmp/work" "$tmp/work2"
+{
+	echo 'baz_url = "https://example/baz/v1/c.tgz"'
+	echo 'baz_sha256 = "cccc"'
+} >>"$tmp/work2"
+expect "a new pin is selected" "baz foo " "$(names "$tmp/work2" "$tmp/base")"
+
+# Identical to base: nothing selected, so an unchanged pin is never re-fetched
+# and cannot be relocked to a silently-mutated upstream artifact.
+expect "identical file selects nothing" "" "$(names "$tmp/base" "$tmp/base")"
+
+# Absent base: every pin is new.
+expect "absent base selects every pin" "bar foo " "$(names "$tmp/base" "$tmp/nope")"
+
+echo ""
+echo "$PASS passed, $FAIL failed"
+[[ "$FAIL" -eq 0 ]]


### PR DESCRIPTION
Track downloads pinned in BUCK files (`<name>_url` + `<name>_sha256`) with one Renovate pattern and one workflow trigger — no per-download wiring.

- One generic customManager matches any GitHub-release download URL in a BUCK file, capturing `owner/repo` and the release tag (`github-releases` datasource). Adding a new GitHub-sourced pin is then zero-config.
- `update_buck_shas.sh` recomputes the `sha256` of only the pins whose URL differs from master; the `renovate-sha` workflow runs it when a BUCK changes.

Diff-gating is the security property: an unchanged pin keeps its reviewed sha, so a silently re-published or re-tagged upstream artifact fails the `download_file` check rather than being relocked to the new bytes. `update_buck_shas_test.sh` covers the selection logic.

Non-GitHub sources (busybox from busybox.net) aren't matched by the GitHub manager; busybox will be tracked via a `docker` datasource once the image rule sources it from the busybox image.
