### PR TITLE
renovate: auto-track the cpython pin

### DIFF
--- a/.github/workflows/renovate-sha.yml
+++ b/.github/workflows/renovate-sha.yml
@@ -17,6 +17,7 @@ on:
       - tools/buckle/install.sh
       - tools/nativelink/install.sh
       - tools/crane/install.sh
+      - "**/BUCK"
 permissions:
   contents: write
 # Shared with renovate-lockfile: fixers on the same branch run one at a
@@ -42,11 +43,21 @@ jobs:
           bash tools/renovate/update_sha.sh tools/buckle/install.sh
           bash tools/renovate/update_sha.sh tools/nativelink/install.sh
           bash tools/renovate/update_sha.sh tools/crane/install.sh
+      # Each changed BUCK's archive pins: only a URL that changed vs master is
+      # re-fetched, so an unchanged pin keeps its first-seen checksum.
+      - name: Recompute BUCK archive sha256 pins
+        run: |
+          git fetch -q --depth=1 origin master
+          git diff --name-only FETCH_HEAD -- ':(glob)**/BUCK' | while read -r buck; do
+            base="$(mktemp)"
+            git show "FETCH_HEAD:$buck" >"$base" 2>/dev/null || : >"$base"
+            bash tools/renovate/update_archive_sha.sh "$buck" "$base"
+          done
       - name: Push fix if the pins changed
         run: |
           git diff --quiet && exit 0
           git config user.name "github-actions[bot]"
           git config user.email \
             "41898282+github-actions[bot]@users.noreply.github.com"
-          git commit -am "chore: recompute installer sha256 pins"
+          git commit -am "chore: recompute pinned sha256 checksums"
           git push

--- a/renovate.json
+++ b/renovate.json
@@ -37,6 +37,12 @@
         "/^sqlx($|-)/"
       ],
       "groupName": "sqlx"
+    },
+    {
+      "description": "cpython version and python-build-standalone date share one URL, grouped into one PR. The two datasources max independently, so a version/date desync yields a URL that 404s until the matching build ships. separateMajorMinor is off because the 8-digit date bumps as a major.",
+      "matchDepNames": ["python/cpython", "astral-sh/python-build-standalone"],
+      "groupName": "cpython",
+      "separateMajorMinor": false
     }
   ],
   "customManagers": [
@@ -114,6 +120,33 @@
       "depNameTemplate": "google/go-containerregistry",
       "datasourceTemplate": "github-releases",
       "extractVersionTemplate": "^v(?<version>.*)$"
+    },
+    {
+      "description": "cpython version pinned in a BUCK file. Renovate cannot recompute the sha256 (renovatebot/renovate#22183), so a bump needs the checksum updated separately.",
+      "customType": "regex",
+      "managerFilePatterns": [
+        "/(^|/)BUCK$/"
+      ],
+      "matchStrings": [
+        "cpython-(?<currentValue>\\d+\\.\\d+\\.\\d+)\\+"
+      ],
+      "depNameTemplate": "python/cpython",
+      "datasourceTemplate": "github-tags",
+      "extractVersionTemplate": "^v(?<version>.*)$"
+    },
+    {
+      "description": "python-build-standalone build date pinned in a BUCK file; the date is in both the release tag and the asset filename, so both are captured.",
+      "customType": "regex",
+      "managerFilePatterns": [
+        "/(^|/)BUCK$/"
+      ],
+      "matchStrings": [
+        "releases/download/(?<currentValue>\\d{8})/",
+        "\\+(?<currentValue>\\d{8})-"
+      ],
+      "depNameTemplate": "astral-sh/python-build-standalone",
+      "datasourceTemplate": "github-releases",
+      "versioningTemplate": "loose"
     }
   ]
 }

--- a/tools/BUILD.bazel
+++ b/tools/BUILD.bazel
@@ -159,6 +159,15 @@ sh_test(
     ],
 )
 
+sh_test(
+    name = "update_archive_sha_test",
+    srcs = ["renovate/update_archive_sha_test.sh"],
+    data = [
+        "renovate/update_archive_sha.sh",
+        "@bazel_tools//tools/bash/runfiles",
+    ],
+)
+
 # PreToolUse action guard, wired into .claude/settings.json.  Denies forbidden
 # agent actions at the moment of action: native tooling instead of the Bazel
 # wrappers, lockfile destruction, and mod.rs creation.  Decision logic lives in

--- a/tools/renovate/update_archive_sha.sh
+++ b/tools/renovate/update_archive_sha.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# Recompute cached_http_archive sha256 pins in a BUCK file for the archives
+# whose URL changed vs the base version, and only those.
+# An unchanged URL keeps its first-seen sha, so a silently re-published upstream
+# artifact fails the build rather than being relocked to the new bytes.
+# Renovate rewrites a version in the URL but cannot compute the sha256
+# (renovatebot/renovate#22183); this closes that gap on the bump branch.
+# Usage: update_archive_sha.sh <buck-file> <base-buck-file>
+set -euo pipefail
+
+# Emit "name<TAB>sha256<TAB>url" for each archive in file $1 — a rule block that
+# carries both a `sha256 = "..."` and a single-element `urls = ["..."]`.
+archives_of() {
+	[[ -f "$1" ]] || return 0
+	local line name="" sha="" url=""
+	while IFS= read -r line; do
+		[[ "$line" == *'name = "'* ]] && name="$(sed -n 's/.*name = "\([^"]*\)".*/\1/p' <<<"$line")"
+		[[ "$line" == *'sha256 = "'* ]] && sha="$(sed -n 's/.*sha256 = "\([^"]*\)".*/\1/p' <<<"$line")"
+		[[ "$line" == *'urls = ["'* ]] && url="$(sed -n 's/.*urls = \["\([^"]*\)"\].*/\1/p' <<<"$line")"
+		if [[ "$line" == *')'* ]]; then
+			[[ -n "$sha" && -n "$url" ]] && printf '%s\t%s\t%s\n' "$name" "$sha" "$url"
+			name=""
+			sha=""
+			url=""
+		fi
+	done <"$1"
+}
+
+# In BUCK $1, replace the (unique) sha256 value $2 with $3; fail if $3 is absent.
+rewrite_sha() {
+	sed -i "s/${2}/${3}/" "$1"
+	grep -q "$3" "$1"
+}
+
+main() {
+	local buck="${1:?usage: update_archive_sha.sh <buck-file> <base-buck-file>}"
+	local base="${2:-}" name sha url newsha tmp
+	declare -A base_url=()
+	while IFS=$'\t' read -r name sha url; do base_url["$name"]="$url"; done < <(archives_of "$base")
+	while IFS=$'\t' read -r name sha url; do
+		[[ "$url" == "${base_url[$name]:-}" ]] && continue
+		tmp="$(mktemp)"
+		curl -fsSL "$url" -o "$tmp"
+		newsha="$(sha256sum "$tmp" | awk '{print $1}')"
+		rm -f "$tmp"
+		rewrite_sha "$buck" "$sha" "$newsha"
+	done < <(archives_of "$buck")
+}
+
+[[ -n "${_UPDATE_ARCHIVE_SHA_SOURCED:-}" ]] || main "$@"

--- a/tools/renovate/update_archive_sha_test.sh
+++ b/tools/renovate/update_archive_sha_test.sh
@@ -1,0 +1,121 @@
+#!/usr/bin/env bash
+# Test driver for update_archive_sha.sh.
+# Sources the script (with _UPDATE_ARCHIVE_SHA_SOURCED=1 to skip main) and
+# checks archives_of (which archives, and their pins, are seen — the parse that
+# decides which shas get recomputed) and rewrite_sha (the mutation).
+set -uo pipefail
+
+if [[ -f "${RUNFILES_DIR:-/dev/null}/bazel_tools/tools/bash/runfiles/runfiles.bash" ]]; then
+	# shellcheck source=/dev/null
+	source "${RUNFILES_DIR}/bazel_tools/tools/bash/runfiles/runfiles.bash"
+elif [[ -f "${BASH_SOURCE[0]}.runfiles/bazel_tools/tools/bash/runfiles/runfiles.bash" ]]; then
+	# shellcheck source=/dev/null
+	source "${BASH_SOURCE[0]}.runfiles/bazel_tools/tools/bash/runfiles/runfiles.bash"
+elif [[ -f "${RUNFILES_MANIFEST_FILE:-/dev/null}" ]]; then
+	# shellcheck source=/dev/null
+	source "$(grep -m1 "^bazel_tools/tools/bash/runfiles/runfiles.bash " \
+		"$RUNFILES_MANIFEST_FILE" | cut -d ' ' -f2-)"
+else
+	echo >&2 "ERROR: cannot find Bazel runfiles library"
+	exit 1
+fi
+
+SCRIPT="$(rlocation _main/tools/renovate/update_archive_sha.sh)"
+if [[ ! -f "$SCRIPT" ]]; then
+	echo "ERROR: cannot locate update_archive_sha.sh via runfiles" >&2
+	exit 1
+fi
+
+# shellcheck source=/dev/null
+_UPDATE_ARCHIVE_SHA_SOURCED=1 source "$SCRIPT"
+
+PASS=0
+FAIL=0
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+
+expect() {
+	local name="$1" want="$2" got="$3"
+	if [[ "$got" == "$want" ]]; then
+		echo "PASS: $name"
+		((PASS++)) || true
+	else
+		echo "FAIL: $name — want [$want], got [$got]"
+		((FAIL++)) || true
+	fi
+}
+
+# A file with two archives and one unrelated rule between them.
+cat >"$tmp/BUCK" <<'EOF'
+cached_http_archive(
+    name = "cpython",
+    sha256 = "aaaa",
+    urls = ["https://example/py/v1/cpython.tar.gz"],
+)
+
+filegroup(
+    name = "misc",
+    srcs = ["x"],
+)
+
+cached_http_archive(
+    name = "toolchain",
+    sha256 = "bbbb",
+    urls = ["https://example/tc/v9/tc.tar.gz"],
+)
+EOF
+
+expect "archives_of finds both pins, skips the non-archive rule" \
+	$'cpython\taaaa\thttps://example/py/v1/cpython.tar.gz\ntoolchain\tbbbb\thttps://example/tc/v9/tc.tar.gz' \
+	"$(archives_of "$tmp/BUCK")"
+expect "archives_of on absent file -> empty" "" "$(archives_of "$tmp/nope")"
+
+# rewrite_sha replaces one archive's pin by value, leaving the other alone.
+new="deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef"
+rewrite_sha "$tmp/BUCK" "aaaa" "$new"
+trim() { sed 's/^[[:space:]]*//'; }
+expect "rewrite updates the target pin" "sha256 = \"${new}\"," "$(grep -m1 'sha256' "$tmp/BUCK" | trim)"
+expect "rewrite leaves the other pin" 'sha256 = "bbbb",' "$(grep 'sha256' "$tmp/BUCK" | tail -1 | trim)"
+
+# rewrite_sha fails loudly when the old value is absent and the new one isn't
+# already there — the mutation did not take.
+printf 'sha256 = "cccc",\n' >"$tmp/fresh"
+rc=0
+rewrite_sha "$tmp/fresh" "notpresent" "ffff" 2>/dev/null || rc=$?
+expect "rewrite fails when the old sha is absent" "1" "$rc"
+
+# main re-fetches (and rewrites) only archives whose URL changed vs base.
+# Stub curl to write the URL as the "content", so sha256sum of that is
+# deterministic — no network.
+stub="$tmp/stub"
+mkdir -p "$stub"
+cat >"$stub/curl" <<'SH'
+#!/bin/sh
+out=""; url=""
+while [ $# -gt 0 ]; do
+	case "$1" in
+	-o) out="$2"; shift 2 ;;
+	-*) shift ;;
+	*) url="$1"; shift ;;
+	esac
+done
+printf '%s' "$url" >"$out"
+SH
+chmod +x "$stub/curl"
+
+cat >"$tmp/base2" <<'EOF'
+cached_http_archive(name = "a", sha256 = "AAAA", urls = ["https://ex/a/v1"])
+cached_http_archive(name = "b", sha256 = "BBBB", urls = ["https://ex/b/v1"])
+EOF
+cat >"$tmp/work2" <<'EOF'
+cached_http_archive(name = "a", sha256 = "AAAA", urls = ["https://ex/a/v2"])
+cached_http_archive(name = "b", sha256 = "BBBB", urls = ["https://ex/b/v1"])
+EOF
+want_a="$(printf '%s' 'https://ex/a/v2' | sha256sum | awk '{print $1}')"
+PATH="$stub:$PATH" main "$tmp/work2" "$tmp/base2"
+expect "main recomputes the changed archive" "sha256 = \"${want_a}\"" "$(sed -n 's/.*\(sha256 = "[0-9a-f]*"\).*/\1/p' "$tmp/work2" | head -1)"
+expect "main leaves the unchanged archive" 'sha256 = "BBBB"' "$(sed -n 's/.*\(sha256 = "[^"]*"\).*/\1/p' "$tmp/work2" | tail -1)"
+
+echo ""
+echo "$PASS passed, $FAIL failed"
+[[ "$FAIL" -eq 0 ]]


### PR DESCRIPTION
Auto-track the cpython pin in `third_party/python/BUCK` (previously untracked), and recompute BUCK archive checksums generically.

**Version + date.** Two custom managers track the cpython version (`github-tags` `python/cpython`) and the python-build-standalone build date (`github-releases`). Both are encoded in the one archive URL, so they're grouped into a single PR and `separateMajorMinor` is off (the 8-digit date bumps as a major). The two datasources max independently, so if cpython tags a version before python-build-standalone ships a build with it, the grouped URL 404s until the build lands — a loud failure (the sha download fails), not a silent bad pin. No `allowedVersions` cap: Renovate surfaces every newer cpython under the repo's global cooldown + automerge policy.

**Checksum.** Renovate can't recompute the sha256 (renovatebot/renovate#22183), so `update_archive_sha.sh` does it — generically, not per-dep: `renovate-sha` runs it over every changed BUCK (`git diff … ':(glob)**/BUCK'`), and `archives_of` recomputes each `cached_http_archive` whose URL changed vs master. Diff-gated: an unchanged URL keeps its first-seen sha (so a silently re-published artifact fails the build rather than being relocked — Renovate automerges, so nothing re-reviews the pin), and a rewrite that can't find its old sha fails loudly (`grep -q`).

Validated: the grouped config produces the correct `(3.12.12, 20260610) → (3.12.13, 20260718)` update on one branch (against a throwaway GitHub repo); `bazel test //tools:update_archive_sha_test` covers multi-archive parsing, the per-archive rewrite, the loud-fail, and `main`'s diff-gate (changed archive recomputed, unchanged left alone); `archives_of` extracts the real cpython pin and the download+hash matches the pinned checksum.
