### PR TITLE
buck2: py_version_check reads the pin, checks the path

### DIFF
--- a/third_party/python/BUCK
+++ b/third_party/python/BUCK
@@ -1,5 +1,11 @@
 load("//tools:defs.bzl", "cached_http_archive")
 
+export_file(
+    name = "pin",
+    src = "BUCK",
+    visibility = ["PUBLIC"],
+)
+
 cached_http_archive(
     name = "cpython",
     sha256 = "c218f50baeb2c06a30c2f03db5986b2bad6ab7c8a52faad2d5a59bda0677b93a",

--- a/tools/BUCK
+++ b/tools/BUCK
@@ -21,9 +21,9 @@ command_alias(
 
 cached_check(
     name = "py_version_check",
-    args = [
-        "-c",
-        "import sys; assert sys.version_info[:3] == (3, 12, 13), sys.version; open(sys.argv[1], 'w').write('ok')",
-    ],
     exe = ":py",
+    srcs = [
+        "py_version_check.py",
+        "//third_party/python:pin",
+    ],
 )

--- a/tools/defs.bzl
+++ b/tools/defs.bzl
@@ -1,13 +1,13 @@
 # Check target that runs an executable and caches the result remotely.
-# The executable receives `args` plus the output path as its final argument
-# and must write the output file on success.
+# The executable receives `srcs` then `args`, then the output path as its
+# final argument, and must write the output file on success.
 # `allow_cache_upload` opts the action into action-cache writes; the
 # OSS prelude's genrule hard-codes uploads off, so genrules cannot be used
 # for cache-exercising checks.
 def _cached_check_impl(ctx: AnalysisContext) -> list[Provider]:
     out = ctx.actions.declare_output("out.txt")
     ctx.actions.run(
-        cmd_args(ctx.attrs.exe[RunInfo], ctx.attrs.args, out.as_output()),
+        cmd_args(ctx.attrs.exe[RunInfo], ctx.attrs.srcs, ctx.attrs.args, out.as_output()),
         category = "cached_check",
         allow_cache_upload = True,
     )
@@ -18,6 +18,7 @@ cached_check = rule(
     attrs = {
         "args": attrs.list(attrs.string(), default = []),
         "exe": attrs.exec_dep(providers = [RunInfo]),
+        "srcs": attrs.list(attrs.source(), default = []),
     },
 )
 

--- a/tools/py_version_check.py
+++ b/tools/py_version_check.py
@@ -1,0 +1,17 @@
+"""Assert //tools:py is the cpython pinned in third_party/python/BUCK, running
+from the hermetic tree rather than a system python.
+
+argv[1] is the pin file (read for the version, so it never drifts on a bump);
+argv[2] is the output to touch on success.
+"""
+
+import re
+import sys
+
+pin = open(sys.argv[1], encoding="utf-8").read()
+m = re.search(r"cpython-(\d+)\.(\d+)\.(\d+)\+", pin)
+assert m, "no cpython version pinned in " + sys.argv[1]
+want = tuple(int(g) for g in m.groups())
+assert sys.version_info[:3] == want, "%s != %s" % (sys.version_info[:3], want)
+assert "cpython" in sys.executable, "not the pinned interpreter: " + sys.executable
+open(sys.argv[2], "w", encoding="utf-8").write("ok")


### PR DESCRIPTION
The check hardcoded `(3, 12, 13)`; a Renovate cpython bump then fails the buck2 job on a version it was never told about (#457).

Read the pinned version from `third_party/python/BUCK` instead, so the assertion tracks the pin with no drift, and assert the interpreter runs from the hermetic cpython tree rather than a system python.

`export_file(name="pin", src="BUCK")` stages the pin line; `cached_check` gains a `srcs` list to pass it and the script to the interpreter.

Validated: `buck2 build //tools:py_version_check` passes under the pinned 3.12.13 tree.
