### PR TITLE
nativelink: busybox from the docker image by digest

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -109,6 +109,17 @@
       "extractVersionTemplate": "^v(?<version>.*)$"
     },
     {
+      "description": "busybox worker rootfs pinned as a digest-pinned Docker image in a BUCK file; the digest is content-addressed, so no sha-recompute is needed.",
+      "customType": "regex",
+      "managerFilePatterns": [
+        "/(^|/)BUCK$/"
+      ],
+      "matchStrings": [
+        "busybox_image = \"(?<depName>busybox):(?<currentValue>[^\"@]+)@(?<currentDigest>sha256:[0-9a-f]+)\""
+      ],
+      "datasourceTemplate": "docker"
+    },
+    {
       "description": "crane release pinned in a BUCK file. Renovate cannot recompute the sha256 (renovatebot/renovate#22183); the renovate-sha workflow recomputes it on the bump PR.",
       "customType": "regex",
       "managerFilePatterns": [

--- a/tools/nativelink/BUCK
+++ b/tools/nativelink/BUCK
@@ -3,8 +3,7 @@ load("//tools/nativelink:image.bzl", "worker_image")
 worker_image(
     name = "worker_image",
     assemble = "assemble_image.sh",
-    busybox_sha256 = "6e123e7f3202a8c1e9b1f94d8941580a25135382b99e8d3e34fb858bba311348",
-    busybox_url = "https://busybox.net/downloads/binaries/1.35.0-x86_64-linux-musl/busybox",
+    busybox_image = "busybox:1.37.0-musl@sha256:222ad6d973c0d198014546a65cd02c5fdedcc172123c5b4c2bf0af636550bd94",
     crane = "//third_party/crane:crane[crane]",
     visibility = ["PUBLIC"],
 )

--- a/tools/nativelink/image.bzl
+++ b/tools/nativelink/image.bzl
@@ -1,15 +1,15 @@
 # Build the NativeLink worker's from-scratch OCI image as a cacheable action.
-# busybox is downloaded by pinned sha256; crane is a pinned cached_http_archive.
-# The image is a pure function of them, so its output digest is stable.
+# crane is a pinned cached_http_archive; busybox is extracted from the Docker
+# busybox image pinned by digest. The image is a pure function of them, so its
+# output digest is stable.
 def _worker_image_impl(ctx: AnalysisContext) -> list[Provider]:
-    busybox = ctx.actions.declare_output("busybox")
-    ctx.actions.download_file(
-        busybox.as_output(),
-        ctx.attrs.busybox_url,
-        sha256 = ctx.attrs.busybox_sha256,
-        is_executable = True,
-    )
     crane = ctx.attrs.crane[DefaultInfo].default_outputs[0]
+    busybox = ctx.actions.declare_output("busybox")
+    extract = 'set -eu; d="$(mktemp -d)"; "$1" export "$3" - | tar -x -C "$d"; cp "$d/bin/busybox" "$2"; chmod 0755 "$2"'
+    ctx.actions.run(
+        cmd_args("/bin/sh", "-c", extract, "extract", crane, busybox.as_output(), ctx.attrs.busybox_image),
+        category = "busybox_extract",
+    )
     out = ctx.actions.declare_output("worker.tar")
     ctx.actions.run(
         cmd_args("/bin/sh", ctx.attrs.assemble, busybox, crane, out.as_output()),
@@ -22,8 +22,7 @@ worker_image = rule(
     impl = _worker_image_impl,
     attrs = {
         "assemble": attrs.source(),
-        "busybox_sha256": attrs.string(),
-        "busybox_url": attrs.string(),
+        "busybox_image": attrs.string(),
         "crane": attrs.dep(providers = [DefaultInfo]),
     },
 )


### PR DESCRIPTION
Source busybox by crane-exporting the Docker official `busybox` image pinned by tag+digest, replacing the `busybox.net` binary that has no Renovate datasource.

The digest-pinned ref is content-addressed, so the Renovate `docker` datasource tracks it and no sha-recompute is needed. Extraction runs on the worker (network egress confirmed).

Image digest moves `d72f78e6` → `0c68dae0` (busybox 1.35.0 → 1.37.0); `crane validate` passes.
