### PR TITLE
renovate: track every github-release BUCK pin generically

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -43,6 +43,11 @@
       "matchDepNames": ["python/cpython", "astral-sh/python-build-standalone"],
       "groupName": "cpython",
       "separateMajorMinor": false
+    },
+    {
+      "description": "python-build-standalone releases are 8-digit dates, not semver.",
+      "matchDepNames": ["astral-sh/python-build-standalone"],
+      "versioning": "loose"
     }
   ],
   "customManagers": [
@@ -122,18 +127,15 @@
       "extractVersionTemplate": "^v(?<version>.*)$"
     },
     {
-      "description": "python-build-standalone build date pinned in a BUCK file; the date is in both the release tag and the asset filename, so both are captured.",
+      "description": "Any github release download pinned in a BUCK file; owner/repo is the dep, so a new pinned github tool is tracked with no per-tool config. The renovate-sha workflow recomputes the sha256 on the bump PR (renovatebot/renovate#22183). The match runs to the closing quote so the whole URL is the replace target, and autoReplaceGlobalMatch (on by default) rewrites every occurrence of the version within it — needed when a version or date repeats in the asset filename.",
       "customType": "regex",
       "managerFilePatterns": [
         "/(^|/)BUCK$/"
       ],
       "matchStrings": [
-        "releases/download/(?<currentValue>\\d{8})/",
-        "\\+(?<currentValue>\\d{8})-"
+        "https://github\\.com/(?<depName>[^/\"]+/[^/\"]+)/releases/download/(?<currentValue>[^/\"]+)/[^\"]*"
       ],
-      "depNameTemplate": "astral-sh/python-build-standalone",
-      "datasourceTemplate": "github-releases",
-      "versioningTemplate": "loose"
+      "datasourceTemplate": "github-releases"
     }
   ]
 }


### PR DESCRIPTION
Resurrects #452. One customManager matches any github release download URL in a BUCK file, capturing `owner/repo` as depName, so a new pinned github tool is tracked with no per-tool entry. The `update_archive_sha.sh` recompute (#453) already handles the sha256 generically; this is the manager half.

The match runs to the closing quote so the whole URL is the replace target; autoReplaceGlobalMatch (default on) then rewrites a version or date that repeats in the asset filename.

Folds the python-build-standalone manager in: the generic manager captures the date, a packageRule carries the loose versioning the 8-digit date needs, and the existing cpython group rule keeps cpython+pbs in one PR.

Verified against a live Renovate run over a scratch tree (old crane, pbs, cpython pins): crane `v0.19.0` → `v0.21.7`, pbs `20240814` → `20241219` (both URL and filename dates), cpython `3.12.0` → `3.14.6`; two branches — `renovate/cpython` (grouped) and crane's own. Config passes `renovate-config-validator --strict`.

Once merged, the crane-specific manager in #433 is redundant and drops out.
