### PR TITLE
nativelink: pull busybox from the docker image

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -136,6 +136,17 @@
         "https://github\\.com/(?<depName>[^/\"]+/[^/\"]+)/releases/download/(?<currentValue>[^/\"]+)/[^\"]*"
       ],
       "datasourceTemplate": "github-releases"
+    },
+    {
+      "description": "A digest-pinned docker image in a BUCK file; the digest is content-addressed, so no sha-recompute is needed.",
+      "customType": "regex",
+      "managerFilePatterns": [
+        "/(^|/)BUCK$/"
+      ],
+      "matchStrings": [
+        "\"(?<depName>[^\":@]+):(?<currentValue>[^\"@]+)@(?<currentDigest>sha256:[0-9a-f]+)\""
+      ],
+      "datasourceTemplate": "docker"
     }
   ]
 }

--- a/third_party/crane/BUCK
+++ b/third_party/crane/BUCK
@@ -1,0 +1,9 @@
+load("//tools:defs.bzl", "cached_http_archive")
+
+cached_http_archive(
+    name = "crane",
+    sha256 = "c14340087103ba9dadf61d45acd20675490fd0ccbd56ac7901fc1b502137f44b",
+    sub_targets = ["crane"],
+    urls = ["https://github.com/google/go-containerregistry/releases/download/v0.20.2/go-containerregistry_Linux_x86_64.tar.gz"],
+    visibility = ["//tools/nativelink:"],
+)

--- a/tools/nativelink/BUCK
+++ b/tools/nativelink/BUCK
@@ -1,0 +1,17 @@
+load("//tools:defs.bzl", "cached_check")
+load("//tools/nativelink:busybox.bzl", "busybox")
+
+busybox(
+    name = "busybox",
+    crane = "//third_party/crane:crane[crane]",
+    image = "busybox:1.37.0-musl@sha256:222ad6d973c0d198014546a65cd02c5fdedcc172123c5b4c2bf0af636550bd94",
+)
+
+cached_check(
+    name = "busybox_test",
+    exe = "//tools:py",
+    srcs = [
+        "busybox_test.py",
+        ":busybox",
+    ],
+)

--- a/tools/nativelink/busybox.bzl
+++ b/tools/nativelink/busybox.bzl
@@ -1,0 +1,20 @@
+# Provide /bin/busybox from the pinned docker busybox image as an output.
+# crane exports the image rootfs; the applets are hardlinks to the one binary,
+# so a plain copy of bin/busybox yields the whole multi-call binary.
+def _busybox_impl(ctx: AnalysisContext) -> list[Provider]:
+    crane = ctx.attrs.crane[DefaultInfo].default_outputs[0]
+    out = ctx.actions.declare_output("busybox")
+    script = 'set -eu; d="$(mktemp -d)"; "$1" export "$3" "$d/rootfs.tar"; tar -x -C "$d" -f "$d/rootfs.tar"; cp "$d/bin/busybox" "$2"; chmod 0755 "$2"'
+    ctx.actions.run(
+        cmd_args("/bin/sh", "-c", script, "extract", crane, out.as_output(), ctx.attrs.image),
+        category = "busybox",
+    )
+    return [DefaultInfo(default_output = out)]
+
+busybox = rule(
+    impl = _busybox_impl,
+    attrs = {
+        "crane": attrs.dep(providers = [DefaultInfo]),
+        "image": attrs.string(),
+    },
+)

--- a/tools/nativelink/busybox_test.py
+++ b/tools/nativelink/busybox_test.py
@@ -1,0 +1,21 @@
+"""Assert the pulled artifact is a working busybox multi-call binary.
+
+argv[1] is the busybox binary, argv[2] the output to touch on success.
+"""
+
+import subprocess
+import sys
+
+busybox = sys.argv[1]
+
+applets = set(
+    subprocess.run([busybox, "--list"], capture_output=True, text=True, check=True).stdout.split()
+)
+assert {"sh", "tar", "ls", "ln"} <= applets, applets
+
+echoed = subprocess.run(
+    [busybox, "echo", "ok"], capture_output=True, text=True, check=True
+).stdout.strip()
+assert echoed == "ok", echoed
+
+open(sys.argv[2], "w", encoding="utf-8").write("ok")


### PR DESCRIPTION
Pull `/bin/busybox` from the pinned docker busybox image via crane and expose it as a buck2 output.

crane is a `cached_http_archive` tracked by the github Renovate manager; busybox is pinned `busybox:tag@digest` and tracked by a new `docker` manager.

Extraction writes crane's export to a file before untarring so a crane failure fails the action instead of being masked by the pipe.

`busybox_test` runs the extracted binary against `--list` and `busybox echo ok`.

Step 1 of the worker image; the rootfs tree, layer tar, and OCI image follow in separate PRs.
