### PR TITLE
docs: require renovate wiring for third-party deps

### DIFF
--- a/designdocs/Contributing.md
+++ b/designdocs/Contributing.md
@@ -97,6 +97,10 @@ There are two root modules:
 - `infra/github` — GitHub repository settings, branch rulesets, and merge queue.
   See `infra/github/README.md`.
 
+## Third-party dependencies
+
+Every third-party dependency must be wired up for automatic updates via [Renovate](https://docs.renovatebot.com) in the same PR that introduces it.
+
 ## Commit discipline
 
 Each commit must do exactly one thing.


### PR DESCRIPTION
Every third-party dependency must be Renovate-wired for automatic updates in the same PR that introduces it.