### PR TITLE
sqlx_prepare: run the staleness test unsandboxed

### DIFF
--- a/tools/sqlx_prepare.bzl
+++ b/tools/sqlx_prepare.bzl
@@ -68,4 +68,9 @@ def sqlx_prepare(name, migrations, srcs, path_deps = None, visibility = None):
             "//:Cargo.lock",
             ":Cargo.toml",
         ],
+        # This test keeps a persistent cargo cache in the real home directory
+        # (outside the tree) so cargo's path-embedded fingerprints survive
+        # across runs; it is inherently non-hermetic and cannot run under
+        # mount isolation.
+        tags = ["no-sandbox"],
     )


### PR DESCRIPTION
`sqlx_prepare_impl.sh` keeps a persistent cargo cache under `~/.cache/causes` so cargo's fingerprints survive between runs. Under full linux-sandbox isolation that path is read-only, so `mkdir` of the target dir fails and the staleness test errors before it can run.

The test is inherently non-hermetic (persistent external cache by design), so it runs unsandboxed via `tags = ["no-sandbox"]`.

Surfaced when the devcontainer rebuild enabled unprivileged user namespaces: bazel switched from processwrapper-sandbox (no mount isolation) to full linux-sandbox, which exposed the read-only path.
