### PR TITLE
infra/postgres: race-free port selection in helper

### DIFF
--- a/infra/postgres/BUILD.bazel
+++ b/infra/postgres/BUILD.bazel
@@ -38,6 +38,33 @@ sh_test(
     ],
 )
 
+# Unit test: exercises pg_start_in's port-retry loop against fake
+# initdb/pg_ctl doubles, deterministically and without a real server.
+# Run with: bazel test //infra/postgres:port_retry_test
+sh_test(
+    name = "port_retry_test",
+    srcs = ["port_retry_test.sh"],
+    data = [
+        "testfixture.sh",
+        "@bazel_tools//tools/bash/runfiles",
+    ] + glob(["testdata/fake_pg/**"]),
+)
+
+# Integration smoke test: starts several real postgres instances concurrently
+# and checks each lands on a distinct port; see port_retry_test.sh for the
+# test that actually proves the retry-on-collision guarantee.
+# Run with: bazel test //infra/postgres:concurrent_start_test
+sh_test(
+    name = "concurrent_start_test",
+    size = "medium",
+    srcs = ["concurrent_start_test.sh"],
+    data = [
+        "testfixture.sh",
+        ":postgres_extracted",
+        "@bazel_tools//tools/bash/runfiles",
+    ],
+)
+
 # Verify the bundled psql binary runs (shared libs must be present alongside it).
 sh_test(
     name = "psql_test",

--- a/infra/postgres/concurrent_start_test.sh
+++ b/infra/postgres/concurrent_start_test.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+# Integration smoke test: starts several real postgres instances concurrently
+# and checks every one comes up on a distinct port with no failures.
+# port_retry_test.sh is what proves the retry-on-collision guarantee itself;
+# this test guards against a regression that only shows up against a real
+# server (e.g. a shared PGDATA path or a startup race under real timing).
+# Run with: bazel test //infra/postgres:concurrent_start_test
+set -euo pipefail
+
+# Standard Bazel 3-way runfiles init.
+if [[ -f "${RUNFILES_DIR:-/dev/null}/bazel_tools/tools/bash/runfiles/runfiles.bash" ]]; then
+	# shellcheck source=/dev/null
+	source "${RUNFILES_DIR}/bazel_tools/tools/bash/runfiles/runfiles.bash"
+elif [[ -f "${BASH_SOURCE[0]}.runfiles/bazel_tools/tools/bash/runfiles/runfiles.bash" ]]; then
+	# shellcheck source=/dev/null
+	source "${BASH_SOURCE[0]}.runfiles/bazel_tools/tools/bash/runfiles/runfiles.bash"
+elif [[ -f "${RUNFILES_MANIFEST_FILE:-/dev/null}" ]]; then
+	# shellcheck source=/dev/null
+	source "$(grep -m1 "^bazel_tools/tools/bash/runfiles/runfiles.bash " \
+		"$RUNFILES_MANIFEST_FILE" | cut -d ' ' -f2-)"
+else
+	echo >&2 "ERROR: cannot find Bazel runfiles library"
+	exit 1
+fi
+
+testfixture="$(rlocation _main/infra/postgres/testfixture.sh)"
+pg_bin="$(rlocation _main/infra/postgres/postgres_extracted)/bin"
+
+instances=6
+
+# Starts one instance in its own scratch dir, records the assigned port (or
+# FAIL) to $2, then stops it. Runs in a subshell so each instance's exported
+# PGBIN/PGDATA/PGPORT never leak into siblings running concurrently.
+run_instance() {
+	local work="$1" outfile="$2"
+	(
+		# shellcheck source=/dev/null
+		source "$testfixture"
+		if pg_start_in "$pg_bin" "$work"; then
+			echo "$PGPORT" >"$outfile"
+			"$PGBIN/pg_ctl" stop -D "$PGDATA" -m immediate -q 2>/dev/null || true
+		else
+			echo "FAIL" >"$outfile"
+		fi
+	)
+}
+
+root="$(mktemp -d)"
+trap 'rm -rf "$root"' EXIT
+pids=()
+for i in $(seq 1 "$instances"); do
+	mkdir -p "$root/$i"
+	run_instance "$root/$i" "$root/$i.port" &
+	pids+=($!)
+done
+
+failed=0
+for pid in "${pids[@]}"; do
+	wait "$pid" || failed=1
+done
+
+ports=()
+for i in $(seq 1 "$instances"); do
+	port="$(cat "$root/$i.port")"
+	if [[ "$port" == "FAIL" ]]; then
+		echo >&2 "ERROR: instance $i failed to start"
+		failed=1
+		continue
+	fi
+	ports+=("$port")
+done
+
+if [[ "$failed" -ne 0 ]]; then
+	exit 1
+fi
+
+unique_count="$(printf '%s\n' "${ports[@]}" | sort -u | wc -l)"
+if [[ "$unique_count" -ne "$instances" ]]; then
+	echo >&2 "ERROR: expected $instances distinct ports, got: ${ports[*]}"
+	exit 1
+fi
+
+echo "OK: $instances concurrent instances started on distinct ports: ${ports[*]}"

--- a/infra/postgres/port_retry_test.sh
+++ b/infra/postgres/port_retry_test.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+# Unit test for pg_start_in's port-retry loop, using fake initdb/pg_ctl
+# doubles (testdata/fake_pg/) so the retry/bail-out logic is verified
+# deterministically, without a real postgres server or real network ports.
+# Run with: bazel test //infra/postgres:port_retry_test
+set -euo pipefail
+
+# Standard Bazel 3-way runfiles init.
+if [[ -f "${RUNFILES_DIR:-/dev/null}/bazel_tools/tools/bash/runfiles/runfiles.bash" ]]; then
+	# shellcheck source=/dev/null
+	source "${RUNFILES_DIR}/bazel_tools/tools/bash/runfiles/runfiles.bash"
+elif [[ -f "${BASH_SOURCE[0]}.runfiles/bazel_tools/tools/bash/runfiles/runfiles.bash" ]]; then
+	# shellcheck source=/dev/null
+	source "${BASH_SOURCE[0]}.runfiles/bazel_tools/tools/bash/runfiles/runfiles.bash"
+elif [[ -f "${RUNFILES_MANIFEST_FILE:-/dev/null}" ]]; then
+	# shellcheck source=/dev/null
+	source "$(grep -m1 "^bazel_tools/tools/bash/runfiles/runfiles.bash " \
+		"$RUNFILES_MANIFEST_FILE" | cut -d ' ' -f2-)"
+else
+	echo >&2 "ERROR: cannot find Bazel runfiles library"
+	exit 1
+fi
+
+# shellcheck source=/dev/null
+source "$(rlocation _main/infra/postgres/testfixture.sh)"
+
+fake_pg_bin="$(dirname "$(rlocation _main/infra/postgres/testdata/fake_pg/pg_ctl)")"
+
+# Runs pg_start_in against the fake bin with $1 as the newline-separated
+# outcome script, in a fresh scratch dir. Sets $rc and $attempts.
+run_scenario() {
+	local outcomes="$1"
+	local work
+	work="$(mktemp -d)"
+	export FAKE_PG_CTL_OUTCOMES="$work/outcomes"
+	export FAKE_PG_CTL_COUNTER="$work/counter"
+	printf '%s\n' "$outcomes" >"$FAKE_PG_CTL_OUTCOMES"
+
+	rc=0
+	pg_start_in "$fake_pg_bin" "$work/instance" >"$work/stdout" 2>"$work/stderr" || rc=$?
+	attempts="$(cat "$FAKE_PG_CTL_COUNTER" 2>/dev/null || echo 0)"
+}
+
+# Scenario 1: first candidate binds — succeeds in one attempt.
+run_scenario "ok"
+if [[ "$rc" -ne 0 || "$attempts" -ne 1 ]]; then
+	echo >&2 "FAIL: expected success in 1 attempt, got rc=$rc attempts=$attempts"
+	exit 1
+fi
+echo "OK: succeeds on first available port"
+
+# Scenario 2: one port collision, then success — proves the retry loop
+# treats a bind collision as retryable and recovers.
+run_scenario $'collision\nok'
+if [[ "$rc" -ne 0 || "$attempts" -ne 2 ]]; then
+	echo >&2 "FAIL: expected success after 1 retry, got rc=$rc attempts=$attempts"
+	exit 1
+fi
+echo "OK: retries past a port collision and succeeds"
+
+# Scenario 3: a non-collision startup failure must not be retried — it is a
+# real error, and masking it behind port-retry logic would hide misconfigured
+# postgres flags as flaky port exhaustion.
+run_scenario "other"
+if [[ "$rc" -eq 0 || "$attempts" -ne 1 ]]; then
+	echo >&2 "FAIL: expected immediate failure on non-port error, got rc=$rc attempts=$attempts"
+	exit 1
+fi
+echo "OK: fails fast on a non-port startup error, without retrying"
+
+# Scenario 4: only port collisions, forever — bounded by max_attempts (10)
+# rather than looping indefinitely.
+run_scenario "$(for _ in $(seq 1 20); do echo collision; done)"
+if [[ "$rc" -eq 0 || "$attempts" -ne 10 ]]; then
+	echo >&2 "FAIL: expected bail-out after 10 attempts, got rc=$rc attempts=$attempts"
+	exit 1
+fi
+echo "OK: bounds retries to 10 attempts when every port collides"
+
+# Scenario 5: a collision, then a genuine error — the collision message from
+# attempt 1 must not leak into attempt 2's check (pg_ctl -l appends to the
+# same log), so this must fail on attempt 2 rather than being misread as
+# another collision and retried.
+run_scenario $'collision\nother'
+if [[ "$rc" -eq 0 || "$attempts" -ne 2 ]]; then
+	echo >&2 "FAIL: expected failure on attempt 2, got rc=$rc attempts=$attempts"
+	exit 1
+fi
+echo "OK: a real error after a collision is not masked by the stale log entry"
+
+echo "OK: all port-retry scenarios passed"

--- a/infra/postgres/testdata/fake_pg/initdb
+++ b/infra/postgres/testdata/fake_pg/initdb
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+# Test double for postgres's initdb, used by port_retry_test.sh.
+# Only implements what pg_start_in depends on: creating the -D directory.
+set -euo pipefail
+
+while [[ $# -gt 0 ]]; do
+	case "$1" in
+	-D)
+		shift
+		mkdir -p "$1"
+		;;
+	esac
+	shift
+done

--- a/infra/postgres/testdata/fake_pg/pg_ctl
+++ b/infra/postgres/testdata/fake_pg/pg_ctl
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# Test double for postgres's pg_ctl, used by port_retry_test.sh to drive
+# pg_start_in's port-retry loop deterministically without a real server.
+#
+# Each invocation consumes the next line of $FAKE_PG_CTL_OUTCOMES ("ok",
+# "collision", or anything else) and counts itself into
+# $FAKE_PG_CTL_COUNTER, so a test can assert exactly how many attempts a
+# scenario took.
+set -euo pipefail
+
+logfile=""
+args=("$@")
+for ((i = 0; i < ${#args[@]}; i++)); do
+	if [[ "${args[$i]}" == "-l" ]]; then
+		logfile="${args[$((i + 1))]}"
+	fi
+done
+
+count=$(($(cat "$FAKE_PG_CTL_COUNTER" 2>/dev/null || echo 0) + 1))
+echo "$count" >"$FAKE_PG_CTL_COUNTER"
+outcome=$(sed -n "${count}p" "$FAKE_PG_CTL_OUTCOMES" 2>/dev/null || true)
+
+case "$outcome" in
+ok)
+	exit 0
+	;;
+collision)
+	echo "FATAL: could not bind IPv4 socket: Address already in use" >>"$logfile"
+	exit 1
+	;;
+*)
+	echo "FATAL: unrelated startup failure" >>"$logfile"
+	exit 1
+	;;
+esac

--- a/infra/postgres/testfixture.sh
+++ b/infra/postgres/testfixture.sh
@@ -1,39 +1,69 @@
 #!/usr/bin/env bash
 # Bazel test fixture: starts a throwaway PostgreSQL instance.
-# Source this file and call pg_start.
-# Caller must source the Bazel runfiles library before calling pg_start.
-# After pg_start exports: PGBIN, PGDATA, PGHOST, PGPORT,
-#                         PGUSER, PGDATABASE, TEST_POSTGRES_URL.
+#
+# sh_test/sh_binary consumers (runfiles + TEST_TMPDIR available): source this
+# file and call pg_start.  Caller must source the Bazel runfiles library
+# first.  After pg_start exports: PGBIN, PGDATA, PGHOST, PGPORT,
+#                                 PGUSER, PGDATABASE, TEST_POSTGRES_URL.
+#
+# Build-action consumers (no runfiles, no TEST_TMPDIR): source this file by
+# its plain input path and call pg_start_in "$pg_bin_dir" "$writable_dir"
+# directly; it exports the same variables without touching rlocation or
+# TEST_TMPDIR.
 
-pg_start() {
-	export PGBIN="$(rlocation _main/infra/postgres/postgres_extracted)/bin"
-	export PGDATA="${TEST_TMPDIR}/pgdata"
+# Starts postgres rooted at $2 (a writable directory) using the install at
+# $1 (a PGBIN dir). Tries candidate ports until one binds: a bind collision
+# is the only failure treated as retryable, so a genuine startup error still
+# fails on the first attempt with the postgres log attached.
+pg_start_in() {
+	PGBIN="$1"
+	PGDATA="$2/pgdata"
+	export PGBIN PGDATA
 	export PGUSER="postgres"
 	export PGDATABASE="postgres"
-
-	# Ask the OS for a free port by binding to 0, then release it.
-	local port
-	port=$(python3 -c \
-		"import socket; s=socket.socket(); s.bind(('127.0.0.1',0)); \
-     p=s.getsockname()[1]; s.close(); print(p)")
-	export PGPORT="$port"
-	export PGHOST="127.0.0.1"
-	export TEST_POSTGRES_URL="postgresql://postgres@127.0.0.1:${PGPORT}/postgres"
 
 	# Initialise the data directory (trust auth so no passwords needed).
 	"$PGBIN/initdb" -D "$PGDATA" --no-locale --encoding=UTF8 \
 		-U postgres --auth=trust >/dev/null
 
-	# Start the server listening on TCP only (no Unix socket needed in tests).
+	# Start the server listening on TCP only (no Unix socket needed in tests,
+	# which also sidesteps sandbox tmpdir path-length limits on socket paths).
 	# Use mmap for dynamic shared memory so nothing lands in /dev/shm.
 	# Ephemeral test instances that crash leave POSIX segments behind in
-	# /dev/shm; with mmap the segments live inside PGDATA and vanish when
-	# TEST_TMPDIR is cleaned up.
-	local pglog="${TEST_TMPDIR}/pg.log"
-	"$PGBIN/pg_ctl" start -D "$PGDATA" -l "$pglog" \
-		-o "-p ${PGPORT} -h 127.0.0.1 -k '' -c dynamic_shared_memory_type=mmap" \
-		--wait
+	# /dev/shm; with mmap the segments live inside PGDATA and vanish when the
+	# caller's directory is cleaned up.
+	local pglog="$2/pg.log"
+	local candidate attempt max_attempts=10
+	for attempt in $(seq 1 "$max_attempts"); do
+		# RANDOM only ranges 0-32767, so candidates cover 20000-52767.
+		candidate=$((20000 + RANDOM))
+		# Truncated per attempt: pg_ctl -l appends, and a stale collision
+		# message from an earlier attempt must not shadow this attempt's
+		# real outcome in the check below.
+		: >"$pglog"
+		# LC_ALL=C pins postgres's log wording to English so the collision
+		# check below matches regardless of the invoking environment's locale.
+		if LC_ALL=C "$PGBIN/pg_ctl" start -D "$PGDATA" -l "$pglog" \
+			-o "-p ${candidate} -h 127.0.0.1 -k '' -c dynamic_shared_memory_type=mmap" \
+			--wait 2>/dev/null; then
+			export PGPORT="$candidate"
+			export PGHOST="127.0.0.1"
+			export TEST_POSTGRES_URL="postgresql://postgres@127.0.0.1:${PGPORT}/postgres"
+			return 0
+		fi
+		if ! grep -q "Address already in use" "$pglog" 2>/dev/null; then
+			echo >&2 "ERROR: postgres failed to start (not a port collision):"
+			cat "$pglog" >&2
+			return 1
+		fi
+	done
+	echo >&2 "ERROR: no free port found in ${max_attempts} attempts"
+	cat "$pglog" >&2
+	return 1
+}
 
+pg_start() {
+	pg_start_in "$(rlocation _main/infra/postgres/postgres_extracted)/bin" "${TEST_TMPDIR}"
 	trap 'pg_stop' EXIT INT TERM
 }
 


### PR DESCRIPTION
## Why

`pg_start`'s port choice used bind(0)-then-release-then-start-later — a TOCTOU race.
Port assignment belongs centralized in the postgres helper, not duplicated per consumer.
A separate in-progress PR needs a build-action-safe entry point (no runfiles, no `TEST_TMPDIR`) instead of inlining its own retry loop; this PR makes that possible.

## What

- New `pg_start_in(pg_bin_dir, writable_dir)`: retries `pg_ctl start` on random candidate ports until one binds.
  A bind collision (detected via the postgres log, locale-pinned with `LC_ALL=C`) is the only retryable failure; any other startup error fails immediately with the log attached.
  Bounded to 10 attempts.
- `pg_start` becomes a thin `TEST_TMPDIR`/rlocation-based wrapper around `pg_start_in`.
- No unix socket needed (`-k ''`), so sandbox tmpdir socket-path-length limits don't apply.

## Tests

- `port_retry_test.sh`: deterministic unit test against fake `initdb`/`pg_ctl` doubles — first-port success, retry-past-collision, fail-fast on a genuine error, bail-out after 10 collisions, and a real error immediately after a collision (regression test for a stale-log bug caught in review).
- `concurrent_start_test.sh`: starts 6 real postgres instances concurrently, asserts distinct ports and no failures.
- `testfixture_test.sh` (existing): unchanged, still passes.

## Scope

Touches only `infra/postgres/`. Does not touch `tools/sqlx_prepare.bzl` / `tools/sqlx_prepare_impl.sh`.
