### PR TITLE
tools: add install_release.shlib

### DIFF
--- a/tools/BUILD.bazel
+++ b/tools/BUILD.bazel
@@ -168,6 +168,17 @@ sh_test(
     ],
 )
 
+# Stubs curl to check install_release.shlib installs a payload only on a
+# matching sha256 and lands the tar member as the named executable.
+sh_test(
+    name = "install_release_test",
+    srcs = ["install_release_test.sh"],
+    data = [
+        "install_release.shlib",
+        "@bazel_tools//tools/bash/runfiles",
+    ],
+)
+
 # PreToolUse action guard, wired into .claude/settings.json.  Denies forbidden
 # agent actions at the moment of action: native tooling instead of the Bazel
 # wrappers, lockfile destruction, and mod.rs creation.  Decision logic lives in

--- a/tools/install_release.shlib
+++ b/tools/install_release.shlib
@@ -1,0 +1,35 @@
+# install_release.shlib — download and install a pinned github-release binary.
+# Sourced by each tool's install.sh, not executed.
+# tar formats hold the binary at <member> inside the archive (default: <name>
+# at the archive root); raw is a single-file binary payload.
+# Args: repo sha256 tag asset format name bindir [member]
+install_release() {
+	local repo="$1" sha256="$2" tag="$3" asset="$4" format="$5" name="$6" bindir="$7"
+	local member="${8:-$name}"
+	local tmp
+	tmp="$(mktemp -d)"
+	if ! curl -fsSL "https://github.com/${repo}/releases/download/${tag}/${asset}" -o "$tmp/dl"; then
+		echo "install_release: download failed for ${asset}" >&2
+		rm -rf "$tmp"
+		return 1
+	fi
+	if ! echo "${sha256}  $tmp/dl" | sha256sum -c - >/dev/null 2>&1; then
+		echo "install_release: sha256 mismatch for ${asset}" >&2
+		rm -rf "$tmp"
+		return 1
+	fi
+	case "$format" in
+	tgz) tar xzf "$tmp/dl" -C "$tmp" ;;
+	txz) tar xJf "$tmp/dl" -C "$tmp" ;;
+	raw) cp "$tmp/dl" "$tmp/$name" ;;
+	*)
+		echo "install_release: unknown format $format" >&2
+		rm -rf "$tmp"
+		return 1
+		;;
+	esac
+	local rc=0
+	install -m 0755 "$tmp/$member" "$bindir/$name" || rc=$?
+	rm -rf "$tmp"
+	return "$rc"
+}

--- a/tools/install_release_test.sh
+++ b/tools/install_release_test.sh
@@ -1,0 +1,146 @@
+#!/usr/bin/env bash
+# Tests install_release.shlib: a stubbed download installs only when its sha256
+# matches, and a tgz payload lands as the named executable.
+set -uo pipefail
+
+if [[ -f "${RUNFILES_DIR:-/dev/null}/bazel_tools/tools/bash/runfiles/runfiles.bash" ]]; then
+	# shellcheck source=/dev/null
+	source "${RUNFILES_DIR}/bazel_tools/tools/bash/runfiles/runfiles.bash"
+elif [[ -f "${BASH_SOURCE[0]}.runfiles/bazel_tools/tools/bash/runfiles/runfiles.bash" ]]; then
+	# shellcheck source=/dev/null
+	source "${BASH_SOURCE[0]}.runfiles/bazel_tools/tools/bash/runfiles/runfiles.bash"
+elif [[ -f "${RUNFILES_MANIFEST_FILE:-/dev/null}" ]]; then
+	# shellcheck source=/dev/null
+	source "$(grep -m1 "^bazel_tools/tools/bash/runfiles/runfiles.bash " \
+		"$RUNFILES_MANIFEST_FILE" | cut -d ' ' -f2-)"
+else
+	echo >&2 "ERROR: cannot find Bazel runfiles library"
+	exit 1
+fi
+
+set -e
+shlib="$(rlocation _main/tools/install_release.shlib)"
+
+work="$(mktemp -d)"
+bindir="$(mktemp -d)"
+stub="$(mktemp -d)"
+trap 'rm -rf "$work" "$bindir" "$stub"' EXIT
+
+printf '#!/bin/sh\necho tool-ran\n' >"$work/tool"
+chmod +x "$work/tool"
+tar czf "$work/pkg.tgz" -C "$work" tool
+sha="$(sha256sum "$work/pkg.tgz" | cut -d' ' -f1)"
+
+# curl stub: ignore the URL, copy the fixture to the -o target.
+cat >"$stub/curl" <<EOF
+#!/bin/sh
+out=""
+while [ \$# -gt 0 ]; do [ "\$1" = "-o" ] && out="\$2"; shift; done
+cp "$work/pkg.tgz" "\$out"
+EOF
+chmod +x "$stub/curl"
+export PATH="$stub:$PATH"
+
+# shellcheck source=/dev/null
+. "$shlib"
+
+install_release me/tool "$sha" v1 tool-1.tgz tgz tool "$bindir"
+[[ -x "$bindir/tool" ]] || {
+	echo "not installed"
+	exit 1
+}
+[[ "$("$bindir/tool")" == "tool-ran" ]] || {
+	echo "wrong content"
+	exit 1
+}
+
+if install_release me/tool deadbeef v1 tool-1.tgz tgz tool2 "$bindir" 2>/dev/null; then
+	echo "expected sha mismatch to fail"
+	exit 1
+fi
+[[ -e "$bindir/tool2" ]] && {
+	echo "installed despite bad sha"
+	exit 1
+}
+
+# txz payload, with the binary at a subdirectory path that differs from the
+# installed name (buckle's shape: archive holds pkg-dir/buckle, installed as
+# buckle).
+printf '#!/bin/sh\necho subdir-tool-ran\n' >"$work/subtool"
+chmod +x "$work/subtool"
+mkdir -p "$work/pkg-dir"
+cp "$work/subtool" "$work/pkg-dir/subtool"
+tar cJf "$work/pkg.txz" -C "$work" pkg-dir
+txz_sha="$(sha256sum "$work/pkg.txz" | cut -d' ' -f1)"
+
+cat >"$stub/curl" <<EOF
+#!/bin/sh
+out=""
+while [ \$# -gt 0 ]; do [ "\$1" = "-o" ] && out="\$2"; shift; done
+cp "$work/pkg.txz" "\$out"
+EOF
+chmod +x "$stub/curl"
+
+install_release me/tool "$txz_sha" v1 tool-1.txz txz renamed-tool "$bindir" \
+	pkg-dir/subtool
+[[ -x "$bindir/renamed-tool" ]] || {
+	echo "txz: not installed"
+	exit 1
+}
+[[ "$("$bindir/renamed-tool")" == "subdir-tool-ran" ]] || {
+	echo "txz: wrong content"
+	exit 1
+}
+
+# A member path absent from the archive must fail the call, not report
+# success with nothing installed.
+if install_release me/tool "$txz_sha" v1 tool-1.txz txz ghost "$bindir" \
+	pkg-dir/no-such-file 2>/dev/null; then
+	echo "expected missing member to fail"
+	exit 1
+fi
+[[ -e "$bindir/ghost" ]] && {
+	echo "installed despite missing member"
+	exit 1
+}
+
+# raw payload: the download is the binary itself.
+raw_sha="$(sha256sum "$work/tool" | cut -d' ' -f1)"
+cat >"$stub/curl" <<EOF
+#!/bin/sh
+out=""
+while [ \$# -gt 0 ]; do [ "\$1" = "-o" ] && out="\$2"; shift; done
+cp "$work/tool" "\$out"
+EOF
+chmod +x "$stub/curl"
+install_release me/tool "$raw_sha" v1 tool-1 raw raw-tool "$bindir"
+[[ -x "$bindir/raw-tool" && "$("$bindir/raw-tool")" == "tool-ran" ]] || {
+	echo "raw: not installed or wrong content"
+	exit 1
+}
+
+if install_release me/tool "$raw_sha" v1 tool-1 zip zip-tool "$bindir" 2>/dev/null; then
+	echo "expected unknown format to fail"
+	exit 1
+fi
+[[ -e "$bindir/zip-tool" ]] && {
+	echo "installed despite unknown format"
+	exit 1
+}
+
+# curl failure must fail the call before the checksum comparison.
+cat >"$stub/curl" <<'EOF'
+#!/bin/sh
+exit 22
+EOF
+chmod +x "$stub/curl"
+if install_release me/tool "$raw_sha" v1 tool-1 raw dl-tool "$bindir" 2>/dev/null; then
+	echo "expected download failure to fail"
+	exit 1
+fi
+[[ -e "$bindir/dl-tool" ]] && {
+	echo "installed despite download failure"
+	exit 1
+}
+
+echo "ok"


### PR DESCRIPTION
Adds `tools/install_release.shlib`, a sourced shell library for installer scripts.

It downloads a pinned github release asset, verifies its sha256, extracts it (tgz/txz/raw, with an optional member path), and installs the resulting binary.
Installers become one-line callers.

This lands the library before its callers.
Landing it also puts `.shlib` in master's extension set, since the agent-mode new-language scan derives its allowlist from master.
