### PR TITLE
check: allow .shlib in the new-language scan

### DIFF
--- a/tools/check.sh
+++ b/tools/check.sh
@@ -203,6 +203,8 @@ BEGIN {
 	master_ext_set["buckconfig"] = 1
 	# json5: the NativeLink config format (JSON with comments), not a language.
 	master_ext_set["json5"] = 1
+	# shlib: sourced shell libraries; shell is already an in-tree language.
+	master_ext_set["shlib"] = 1
 	n_violations = 0
 	file = ""
 	is_bazelrc = 0

--- a/tools/test_check_scan.sh
+++ b/tools/test_check_scan.sh
@@ -352,6 +352,14 @@ case_pass_with_master_exts "modify .rs file (existing extension)" 'diff --git a/
 +fn bar() {}
 '
 
+case_pass_with_master_exts "new .shlib file fine (seeded allowlist)" 'diff --git a/tools/x.shlib b/tools/x.shlib
+new file mode 100644
+--- /dev/null
++++ b/tools/x.shlib
+@@ -0,0 +1,1 @@
++foo() { :; }
+'
+
 # Without master_exts set, language detector is a no-op (default fall-back
 # for synthetic-diff tests that don't care about the language gate).
 case_pass "new .go file passes when master_exts unset" 'diff --git a/lib/x/main.go b/lib/x/main.go


### PR DESCRIPTION
Seed `shlib` in the new-language scanner's allowlist, beside the existing `buckversion`/`buckroot`/`buckconfig`/`json5` entries.

Sourced shell libraries use the `.shlib` extension; the scanner otherwise flags any diff introducing one until a `.shlib` file exists in master.
