### PR TITLE
tools: pin crun installer

### DIFF
--- a/.github/workflows/renovate-sha.yml
+++ b/.github/workflows/renovate-sha.yml
@@ -15,6 +15,7 @@ on:
     branches: ["renovate/**"]
     paths:
       - tools/buckle/install.sh
+      - tools/crun/install.sh
       - tools/nativelink/install.sh
       - "**/BUCK"
 permissions:
@@ -40,6 +41,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           bash tools/renovate/update_sha.sh tools/buckle/install.sh
+          bash tools/renovate/update_sha.sh tools/crun/install.sh
           bash tools/renovate/update_sha.sh tools/nativelink/install.sh
       # Each changed BUCK's archive pins: only a URL that changed vs master is
       # re-fetched, so an unchanged pin keeps its first-seen checksum.

--- a/renovate.json
+++ b/renovate.json
@@ -114,6 +114,18 @@
       "extractVersionTemplate": "^v(?<version>.*)$"
     },
     {
+      "description": "Renovate cannot update the sha256 (renovatebot/renovate#22183); the renovate-sha workflow recomputes it on the bump PR. crun release tags carry no v prefix.",
+      "customType": "regex",
+      "managerFilePatterns": [
+        "/^tools/crun/install\\.sh$/"
+      ],
+      "matchStrings": [
+        "CRUN_VERSION=(?<currentValue>\\S+)"
+      ],
+      "depNameTemplate": "containers/crun",
+      "datasourceTemplate": "github-releases"
+    },
+    {
       "description": "cpython version pinned in a BUCK file. Renovate cannot recompute the sha256 (renovatebot/renovate#22183), so a bump needs the checksum updated separately.",
       "customType": "regex",
       "managerFilePatterns": [

--- a/tools/crun/install.sh
+++ b/tools/crun/install.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+# Install the pinned crun binary into $1 (default /usr/local/bin).
+set -euo pipefail
+. "$(dirname "$0")/../install_release.shlib"
+
+CRUN_VERSION=1.20
+CRUN_SHA256=e19a9a35484f3c75567219a7b6a4a580b43a0baa234df413655f48db023a200e
+install_release containers/crun "$CRUN_SHA256" \
+	"$CRUN_VERSION" "crun-$CRUN_VERSION-linux-amd64" \
+	raw crun "${1:-/usr/local/bin}"

--- a/tools/renovate/update_sha.sh
+++ b/tools/renovate/update_sha.sh
@@ -14,11 +14,19 @@ tools/buckle/install.sh)
 	REPO=benbrittain/buckle
 	VAR=BUCKLE
 	ASSET='buckle-x86_64-unknown-linux-gnu.tar.xz'
+	TAG_PREFIX=v
 	;;
 tools/nativelink/install.sh)
 	REPO=TraceMachina/nativelink
 	VAR=NATIVELINK
 	ASSET='nativelink-VERSION-x86_64-unknown-linux-musl.tar.gz'
+	TAG_PREFIX=v
+	;;
+tools/crun/install.sh)
+	REPO=containers/crun
+	VAR=CRUN
+	ASSET='crun-VERSION-linux-amd64'
+	TAG_PREFIX=
 	;;
 *)
 	echo "unknown installer: $INSTALLER" >&2
@@ -33,7 +41,7 @@ if [[ -z "$VERSION" ]]; then
 fi
 ASSET="${ASSET//VERSION/$VERSION}"
 
-DIGEST="$(gh api "repos/${REPO}/releases/tags/v${VERSION}" \
+DIGEST="$(gh api "repos/${REPO}/releases/tags/${TAG_PREFIX}${VERSION}" \
 	--jq ".assets[] | select(.name == \"${ASSET}\") | .digest // empty")"
 if [[ -n "$DIGEST" ]]; then
 	SHA="${DIGEST#sha256:}"
@@ -41,7 +49,7 @@ else
 	tmp="$(mktemp)"
 	trap 'rm -f "$tmp"' EXIT
 	curl -fsSL \
-		"https://github.com/${REPO}/releases/download/v${VERSION}/${ASSET}" \
+		"https://github.com/${REPO}/releases/download/${TAG_PREFIX}${VERSION}/${ASSET}" \
 		-o "$tmp"
 	SHA="$(sha256sum "$tmp" | awk '{print $1}')"
 fi


### PR DESCRIPTION
crun runs OCI bundles without the docker socket; the worker-image and renovate-test work need it.

Renovate tracks `CRUN_VERSION` and the renovate-sha workflow recomputes the sha on bump PRs.

`update_sha.sh`'s release-tag prefix becomes per-tool because crun tags carry no v prefix.
