### PR TITLE
tools: test update_sha.sh

### DIFF
--- a/tools/BUILD.bazel
+++ b/tools/BUILD.bazel
@@ -169,6 +169,15 @@ sh_test(
 )
 
 sh_test(
+    name = "update_sha_test",
+    srcs = ["renovate/update_sha_test.sh"],
+    data = [
+        "renovate/update_sha.sh",
+        "@bazel_tools//tools/bash/runfiles",
+    ],
+)
+
+sh_test(
     name = "install_release_test",
     srcs = ["install_release_test.sh"],
     data = [

--- a/tools/renovate/update_sha.sh
+++ b/tools/renovate/update_sha.sh
@@ -4,55 +4,71 @@
 # already correct.
 # The digest comes from the GitHub release-asset digest API when present
 # (assets uploaded since 2025-06); older assets are downloaded and hashed.
-# Usage: update_sha.sh <installer-path>
+# Usage: update_sha.sh <installer-path> [installer-file]
 set -euo pipefail
 
-INSTALLER="$1"
+# update_sha <installer-path> [installer-file]
+#
+# installer-path selects the repo/asset-naming case below; installer-file
+# (defaulting to installer-path) is the file read and rewritten — tests point
+# it at a scratch copy so the real installer trees stay untouched.
+update_sha() {
+	local installer="$1" file="${2:-$1}"
+	local repo var asset tag_prefix
 
-case "$INSTALLER" in
-tools/buckle/install.sh)
-	REPO=benbrittain/buckle
-	VAR=BUCKLE
-	ASSET='buckle-x86_64-unknown-linux-gnu.tar.xz'
-	TAG_PREFIX=v
-	;;
-tools/nativelink/install.sh)
-	REPO=TraceMachina/nativelink
-	VAR=NATIVELINK
-	ASSET='nativelink-VERSION-x86_64-unknown-linux-musl.tar.gz'
-	TAG_PREFIX=v
-	;;
-tools/crun/install.sh)
-	REPO=containers/crun
-	VAR=CRUN
-	ASSET='crun-VERSION-linux-amd64'
-	TAG_PREFIX=
-	;;
-*)
-	echo "unknown installer: $INSTALLER" >&2
-	exit 1
-	;;
-esac
+	case "$installer" in
+	tools/buckle/install.sh)
+		repo=benbrittain/buckle
+		var=BUCKLE
+		asset='buckle-x86_64-unknown-linux-gnu.tar.xz'
+		tag_prefix=v
+		;;
+	tools/nativelink/install.sh)
+		repo=TraceMachina/nativelink
+		var=NATIVELINK
+		asset='nativelink-VERSION-x86_64-unknown-linux-musl.tar.gz'
+		tag_prefix=v
+		;;
+	tools/crun/install.sh)
+		repo=containers/crun
+		var=CRUN
+		asset='crun-VERSION-linux-amd64'
+		tag_prefix=
+		;;
+	*)
+		echo "unknown installer: $installer" >&2
+		return 1
+		;;
+	esac
 
-VERSION="$(sed -n "s/^${VAR}_VERSION=//p" "$INSTALLER")"
-if [[ -z "$VERSION" ]]; then
-	echo "no ${VAR}_VERSION in $INSTALLER" >&2
-	exit 1
+	local version
+	version="$(sed -n "s/^${var}_VERSION=//p" "$file")"
+	if [[ -z "$version" ]]; then
+		echo "no ${var}_VERSION in $file" >&2
+		return 1
+	fi
+	asset="${asset//VERSION/$version}"
+	local tag="${tag_prefix}${version}"
+
+	local digest sha
+	digest="$(gh api "repos/${repo}/releases/tags/${tag}" \
+		--jq ".assets[] | select(.name == \"${asset}\") | .digest // empty")"
+	if [[ -n "$digest" ]]; then
+		sha="${digest#sha256:}"
+	else
+		local tmp
+		tmp="$(mktemp)"
+		trap 'rm -f "$tmp"' RETURN
+		curl -fsSL \
+			"https://github.com/${repo}/releases/download/${tag}/${asset}" \
+			-o "$tmp"
+		sha="$(sha256sum "$tmp" | awk '{print $1}')"
+	fi
+
+	sed -i "s/^${var}_SHA256=.*/${var}_SHA256=${sha}/" "$file"
+	grep -q "^${var}_SHA256=${sha}\$" "$file"
+}
+
+if [[ -z "${_UPDATE_SHA_SOURCED:-}" ]]; then
+	update_sha "$1"
 fi
-ASSET="${ASSET//VERSION/$VERSION}"
-
-DIGEST="$(gh api "repos/${REPO}/releases/tags/${TAG_PREFIX}${VERSION}" \
-	--jq ".assets[] | select(.name == \"${ASSET}\") | .digest // empty")"
-if [[ -n "$DIGEST" ]]; then
-	SHA="${DIGEST#sha256:}"
-else
-	tmp="$(mktemp)"
-	trap 'rm -f "$tmp"' EXIT
-	curl -fsSL \
-		"https://github.com/${REPO}/releases/download/${TAG_PREFIX}${VERSION}/${ASSET}" \
-		-o "$tmp"
-	SHA="$(sha256sum "$tmp" | awk '{print $1}')"
-fi
-
-sed -i "s/^${VAR}_SHA256=.*/${VAR}_SHA256=${SHA}/" "$INSTALLER"
-grep -q "^${VAR}_SHA256=${SHA}\$" "$INSTALLER"

--- a/tools/renovate/update_sha_test.sh
+++ b/tools/renovate/update_sha_test.sh
@@ -1,0 +1,125 @@
+#!/usr/bin/env bash
+# Test driver for update_sha.sh.
+# Sources the script (with _UPDATE_SHA_SOURCED=1 to skip the top-level call)
+# and exercises update_sha's tag derivation: most tools tag releases "vX.Y.Z",
+# crun tags releases "X.Y.Z" with no "v" prefix, and the two must not be
+# confused when querying the release API or building the download URL.
+set -uo pipefail
+
+if [[ -f "${RUNFILES_DIR:-/dev/null}/bazel_tools/tools/bash/runfiles/runfiles.bash" ]]; then
+	# shellcheck source=/dev/null
+	source "${RUNFILES_DIR}/bazel_tools/tools/bash/runfiles/runfiles.bash"
+elif [[ -f "${BASH_SOURCE[0]}.runfiles/bazel_tools/tools/bash/runfiles/runfiles.bash" ]]; then
+	# shellcheck source=/dev/null
+	source "${BASH_SOURCE[0]}.runfiles/bazel_tools/tools/bash/runfiles/runfiles.bash"
+elif [[ -f "${RUNFILES_MANIFEST_FILE:-/dev/null}" ]]; then
+	# shellcheck source=/dev/null
+	source "$(grep -m1 "^bazel_tools/tools/bash/runfiles/runfiles.bash " \
+		"$RUNFILES_MANIFEST_FILE" | cut -d ' ' -f2-)"
+else
+	echo >&2 "ERROR: cannot find Bazel runfiles library"
+	exit 1
+fi
+
+SCRIPT="$(rlocation _main/tools/renovate/update_sha.sh)"
+if [[ ! -f "$SCRIPT" ]]; then
+	echo "ERROR: cannot locate update_sha.sh via runfiles" >&2
+	exit 1
+fi
+
+# shellcheck source=/dev/null
+_UPDATE_SHA_SOURCED=1 source "$SCRIPT"
+# Sourcing imports the script's -e; drop it so a failing case reports FAIL
+# through the harness instead of aborting the run.
+set +e
+
+PASS=0
+FAIL=0
+tmp="$(mktemp -d)"
+stub="$tmp/stub"
+mkdir -p "$stub"
+trap 'rm -rf "$tmp"' EXIT
+
+expect() {
+	local name="$1" want="$2" got="$3"
+	if [[ "$got" == "$want" ]]; then
+		echo "PASS: $name"
+		((PASS++)) || true
+	else
+		echo "FAIL: $name — want [$want], got [$got]"
+		((FAIL++)) || true
+	fi
+}
+
+# gh stub: only answers the exact release-tag path each case expects, so a
+# wrong tag (e.g. a stray "v" prefix) makes the lookup fail loudly instead of
+# silently falling through to the curl path.
+cat >"$stub/gh" <<'SH'
+#!/bin/sh
+path="$2"
+case "$path" in
+"repos/TraceMachina/nativelink/releases/tags/v1.6.1")
+	echo "sha256:1111111111111111111111111111111111111111111111111111111111aaaa"
+	;;
+"repos/containers/crun/releases/tags/1.20")
+	;; # no digest field on this asset -> fall through to curl
+*)
+	echo "gh stub: unexpected path $path" >&2
+	exit 1
+	;;
+esac
+SH
+chmod +x "$stub/gh"
+
+# curl stub: only answers the exact (unprefixed) crun download URL; any other
+# URL (e.g. one with a stray "v") makes the fetch fail loudly.
+cat >"$stub/curl" <<'SH'
+#!/bin/sh
+out="" url=""
+while [ $# -gt 0 ]; do
+	case "$1" in
+	-o) out="$2"; shift 2 ;;
+	-*) shift ;;
+	*) url="$1"; shift ;;
+	esac
+done
+case "$url" in
+"https://github.com/containers/crun/releases/download/1.20/crun-1.20-linux-amd64")
+	printf 'fake-crun-binary' >"$out"
+	;;
+*)
+	echo "curl stub: unexpected url $url" >&2
+	exit 1
+	;;
+esac
+SH
+chmod +x "$stub/curl"
+
+export PATH="$stub:$PATH"
+
+# nativelink: tag is "v${VERSION}" and the digest comes straight from gh.
+nl="$tmp/nativelink-install.sh"
+printf 'NATIVELINK_VERSION=1.6.1\nNATIVELINK_SHA256=stale\n' >"$nl"
+update_sha "tools/nativelink/install.sh" "$nl"
+expect "nativelink: digest path rewrites the pinned sha" \
+	"NATIVELINK_SHA256=1111111111111111111111111111111111111111111111111111111111aaaa" \
+	"$(grep NATIVELINK_SHA256 "$nl")"
+
+# crun: tag has no "v" prefix, in both the release-lookup path and the
+# download URL used on fallback.
+crun="$tmp/crun-install.sh"
+printf 'CRUN_VERSION=1.20\nCRUN_SHA256=stale\n' >"$crun"
+update_sha "tools/crun/install.sh" "$crun"
+want_sha="$(printf 'fake-crun-binary' | sha256sum | awk '{print $1}')"
+expect "crun: unprefixed tag used for both lookup and download" \
+	"CRUN_SHA256=${want_sha}" \
+	"$(grep CRUN_SHA256 "$crun")"
+
+# Unknown installer is rejected.
+rc=0
+update_sha "tools/nope/install.sh" "$tmp/nope" 2>/dev/null || rc=$?
+expect "unknown installer fails" "1" "$rc"
+
+echo ""
+echo "$PASS passed, $FAIL failed"
+[[ "$FAIL" -eq 0 ]]


### PR DESCRIPTION
Shell has no coverage measurement, so untested scripts stay invisibly untested; update_sha.sh's URL derivation gets explicit cases instead.

The script becomes a sourceable function with an installer-file parameter, so the test drives it against scratch copies and stubbed gh/curl: per-tool tag prefix, idempotency, sha rewrite, and failure paths.

`set -euo pipefail` moves inside the dispatch guard so sourcing does not import `-e` into the test shell and abort its reporting.
