### PR TITLE
nativelink: busybox rootfs tree

### DIFF
--- a/tools/nativelink/BUCK
+++ b/tools/nativelink/BUCK
@@ -1,5 +1,6 @@
 load("//tools:defs.bzl", "cached_check")
 load("//tools/nativelink:busybox.bzl", "busybox")
+load("//tools/nativelink:rootfs.bzl", "busybox_rootfs")
 
 busybox(
     name = "busybox",
@@ -13,5 +14,19 @@ cached_check(
     srcs = [
         "busybox_test.py",
         ":busybox",
+    ],
+)
+
+busybox_rootfs(
+    name = "rootfs",
+    busybox = ":busybox",
+)
+
+cached_check(
+    name = "rootfs_test",
+    exe = "//tools:py",
+    srcs = [
+        "busybox_rootfs_test.py",
+        ":rootfs",
     ],
 )

--- a/tools/nativelink/busybox_rootfs_test.py
+++ b/tools/nativelink/busybox_rootfs_test.py
@@ -1,0 +1,32 @@
+"""Assert the rootfs tree is a runnable busybox layout.
+
+argv[1] is the rootfs directory, argv[2] the output to touch on success.
+"""
+
+import os
+import subprocess
+import sys
+
+root = sys.argv[1]
+
+bb = os.path.join(root, "bin", "busybox")
+assert os.path.isfile(bb) and os.access(bb, os.X_OK), bb
+
+applets = set(
+    subprocess.run([bb, "--list"], capture_output=True, text=True, check=True).stdout.split()
+)
+for applet in ("sh", "tar", "ls", "ln"):
+    link = os.path.join(root, "bin", applet)
+    assert os.path.islink(link) and os.readlink(link) == "busybox", link
+links = {n for n in os.listdir(os.path.join(root, "bin")) if n != "busybox"}
+assert links == applets - {"busybox"}, sorted(applets - {"busybox"} ^ links)
+
+echoed = subprocess.run(
+    [os.path.join(root, "bin", "echo"), "ok"], capture_output=True, text=True, check=True
+).stdout.strip()
+assert echoed == "ok", echoed
+
+for d in ("tmp", "proc", "dev", "etc"):
+    assert os.path.isdir(os.path.join(root, d)), d
+
+open(sys.argv[2], "w", encoding="utf-8").write("ok")

--- a/tools/nativelink/rootfs.bzl
+++ b/tools/nativelink/rootfs.bzl
@@ -1,0 +1,29 @@
+# The worker rootfs tree: bin/busybox, one symlink per applet, and the
+# mount-point directories the runtime expects.
+def _busybox_rootfs_impl(ctx: AnalysisContext) -> list[Provider]:
+    busybox = ctx.attrs.busybox[DefaultInfo].default_outputs[0]
+    out = ctx.actions.declare_output("rootfs", dir = True)
+    script = """
+set -eu
+bb="$1"
+root="$2"
+mkdir -p "$root/bin" "$root/tmp" "$root/proc" "$root/dev" "$root/etc"
+cp "$bb" "$root/bin/busybox"
+chmod 0755 "$root/bin/busybox"
+"$bb" --list | while read -r applet; do
+  [ "$applet" = busybox ] && continue
+  ln -s busybox "$root/bin/$applet"
+done
+"""
+    ctx.actions.run(
+        cmd_args("/bin/sh", "-c", script, "rootfs", busybox, out.as_output()),
+        category = "busybox_rootfs",
+    )
+    return [DefaultInfo(default_output = out)]
+
+busybox_rootfs = rule(
+    impl = _busybox_rootfs_impl,
+    attrs = {
+        "busybox": attrs.dep(providers = [DefaultInfo]),
+    },
+)


### PR DESCRIPTION
The worker rootfs as a directory artifact: bin/busybox, one symlink per applet from the binary's own --list, and the mount-point directories the runtime expects.

Step 2 of the worker image; the deterministic layer tar and the OCI image follow separately.
