### PR TITLE
renovate: recompute MODULE.bazel archive shas

### DIFF
--- a/.github/workflows/renovate-sha.yml
+++ b/.github/workflows/renovate-sha.yml
@@ -18,6 +18,7 @@ on:
       - tools/crun/install.sh
       - tools/nativelink/install.sh
       - "**/BUCK"
+      - MODULE.bazel
 permissions:
   contents: write
 # Shared with renovate-lockfile: fixers on the same branch run one at a
@@ -43,15 +44,16 @@ jobs:
           bash tools/renovate/update_sha.sh tools/buckle/install.sh
           bash tools/renovate/update_sha.sh tools/crun/install.sh
           bash tools/renovate/update_sha.sh tools/nativelink/install.sh
-      # Each changed BUCK's archive pins: only a URL that changed vs master is
-      # re-fetched, so an unchanged pin keeps its first-seen checksum.
-      - name: Recompute BUCK archive sha256 pins
+      # Each changed BUCK's or MODULE.bazel's archive pins: only a URL that
+      # changed vs master is re-fetched, so an unchanged pin keeps its
+      # first-seen checksum.
+      - name: Recompute archive sha256 pins
         run: |
           git fetch -q --depth=1 origin master
-          git diff --name-only FETCH_HEAD -- ':(glob)**/BUCK' | while read -r buck; do
+          git diff --name-only FETCH_HEAD -- ':(glob)**/BUCK' MODULE.bazel | while read -r pinfile; do
             base="$(mktemp)"
-            git show "FETCH_HEAD:$buck" >"$base" 2>/dev/null || : >"$base"
-            bash tools/renovate/update_archive_sha.sh "$buck" "$base"
+            git show "FETCH_HEAD:$pinfile" >"$base" 2>/dev/null || : >"$base"
+            bash tools/renovate/update_archive_sha.sh "$pinfile" "$base"
           done
       - name: Push fix if the pins changed
         run: |

--- a/tools/renovate/update_archive_sha.sh
+++ b/tools/renovate/update_archive_sha.sh
@@ -1,23 +1,36 @@
 #!/usr/bin/env bash
-# Recompute cached_http_archive sha256 pins in a BUCK file for the archives
-# whose URL changed vs the base version, and only those.
+# Recompute pinned archive sha256s in a BUCK file or MODULE.bazel for the
+# archives whose URL changed vs the base version, and only those.
 # An unchanged URL keeps its first-seen sha, so a silently re-published upstream
 # artifact fails the build rather than being relocked to the new bytes.
 # Renovate rewrites a version in the URL but cannot compute the sha256
 # (renovatebot/renovate#22183); this closes that gap on the bump branch.
-# Usage: update_archive_sha.sh <buck-file> <base-buck-file>
+# Usage: update_archive_sha.sh <pin-file> <base-pin-file>
 set -euo pipefail
 
 # Emit "name<TAB>sha256<TAB>url" for each archive in file $1 — a rule block that
-# carries both a `sha256 = "..."` and a single-element `urls = ["..."]`.
+# carries both a `sha256 = "..."` and a single-element `urls = ["..."]`
+# (BUCK cached_http_archive) or a singular `url = "..."` (MODULE.bazel
+# http_archive/http_file).
 archives_of() {
 	[[ -f "$1" ]] || return 0
-	local line name="" sha="" url=""
+	local line name="" sha="" url="" quotes in_string=0
 	while IFS= read -r line; do
+		# Lines inside (or delimiting) a triple-quoted string are literal
+		# content, not fields or block ends.
+		quotes="${line//[^\"]/}"
+		if [[ "$line" == *'"""'* ]]; then
+			[[ "$quotes" == '"""' ]] && in_string=$((1 - in_string))
+			continue
+		fi
+		if [[ "$in_string" == 1 ]]; then
+			continue
+		fi
 		[[ "$line" == *'name = "'* ]] && name="$(sed -n 's/.*name = "\([^"]*\)".*/\1/p' <<<"$line")"
 		[[ "$line" == *'sha256 = "'* ]] && sha="$(sed -n 's/.*sha256 = "\([^"]*\)".*/\1/p' <<<"$line")"
 		[[ "$line" == *'urls = ["'* ]] && url="$(sed -n 's/.*urls = \["\([^"]*\)"\].*/\1/p' <<<"$line")"
-		if [[ "$line" == *')'* ]]; then
+		[[ "$line" == *'url = "'* ]] && url="$(sed -n 's/.*url = "\([^"]*\)".*/\1/p' <<<"$line")"
+		if [[ "$line" =~ \)[[:space:]]*$ ]]; then
 			[[ -n "$sha" && -n "$url" ]] && printf '%s\t%s\t%s\n' "$name" "$sha" "$url"
 			name=""
 			sha=""
@@ -26,14 +39,14 @@ archives_of() {
 	done <"$1"
 }
 
-# In BUCK $1, replace the (unique) sha256 value $2 with $3; fail if $3 is absent.
+# In pin file $1, replace the (unique) sha256 value $2 with $3; fail if $3 is absent.
 rewrite_sha() {
 	sed -i "s/${2}/${3}/" "$1"
 	grep -q "$3" "$1"
 }
 
 main() {
-	local buck="${1:?usage: update_archive_sha.sh <buck-file> <base-buck-file>}"
+	local pinfile="${1:?usage: update_archive_sha.sh <pin-file> <base-pin-file>}"
 	local base="${2:-}" name sha url newsha tmp
 	declare -A base_url=()
 	while IFS=$'\t' read -r name sha url; do base_url["$name"]="$url"; done < <(archives_of "$base")
@@ -43,8 +56,8 @@ main() {
 		curl -fsSL "$url" -o "$tmp"
 		newsha="$(sha256sum "$tmp" | awk '{print $1}')"
 		rm -f "$tmp"
-		rewrite_sha "$buck" "$sha" "$newsha"
-	done < <(archives_of "$buck")
+		rewrite_sha "$pinfile" "$sha" "$newsha"
+	done < <(archives_of "$pinfile")
 }
 
 [[ -n "${_UPDATE_ARCHIVE_SHA_SOURCED:-}" ]] || main "$@"

--- a/tools/renovate/update_archive_sha_test.sh
+++ b/tools/renovate/update_archive_sha_test.sh
@@ -70,6 +70,40 @@ expect "archives_of finds both pins, skips the non-archive rule" \
 	"$(archives_of "$tmp/BUCK")"
 expect "archives_of on absent file -> empty" "" "$(archives_of "$tmp/nope")"
 
+# MODULE.bazel http_archive blocks use a singular `url = "..."`.
+cat >"$tmp/MODULE.bazel" <<'EOF'
+http_archive(
+    name = "crane_linux_amd64",
+    build_file_content = """exports_files(["crane"])""",
+    sha256 = "cccc",
+    url = "https://example/cr/v2/crane.tar.gz",
+)
+EOF
+
+expect "archives_of reads MODULE.bazel singular url" \
+	$'crane_linux_amd64\tcccc\thttps://example/cr/v2/crane.tar.gz' \
+	"$(archives_of "$tmp/MODULE.bazel")"
+
+# A multiline build_file_content closes a nested call on its own line; that
+# bare ")" must not end the block.
+cat >"$tmp/MODULE2.bazel" <<'EOF'
+http_archive(
+    name = "jre",
+    build_file_content = """
+filegroup(
+    name = "files",
+    srcs = glob(["**"]),
+)
+""",
+    sha256 = "dddd",
+    url = "https://example/jre/v3/jre.tar.gz",
+)
+EOF
+
+expect "archives_of survives multiline build_file_content" \
+	$'jre\tdddd\thttps://example/jre/v3/jre.tar.gz' \
+	"$(archives_of "$tmp/MODULE2.bazel")"
+
 # rewrite_sha replaces one archive's pin by value, leaving the other alone.
 new="deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef"
 rewrite_sha "$tmp/BUCK" "aaaa" "$new"


### PR DESCRIPTION
MODULE.bazel github-release pins are about to be renovate-matched, and the sha recompute only parsed BUCK cached_http_archive blocks — a bump there would arrive with a stale sha.

archives_of learns the singular `url =` form and skips triple-quoted `build_file_content` (whose nested closers otherwise end the block early); the workflow feeds MODULE.bazel through the same diff-gated recompute.

Verified against the real MODULE.bazel: all eight pins parse with correct names.
