### PR TITLE
renovate: add functional check

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -63,11 +63,14 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7
         with:
           fetch-depth: 10
-      # See tools/nativelink/README.md, "Changing the rootfs digest".
-      - name: Check whether the rootfs digest pin changed
-        id: pin_check
+      # Shared by every change-detection step below (pin, renovate.json, …):
+      # base/head only exist on pull_request/merge_group, and fetch-depth:
+      # 10 must actually reach both — fail loud here rather than have a
+      # shallow-history "unknown revision" surface later as a confusing
+      # git-diff failure in whichever step happens to run first.
+      - name: Determine base/head commits for change checks
+        id: base_head
         run: |
-          pin_changed=false
           base=""
           head=""
           if [ "${{ github.event_name }}" = "pull_request" ]; then
@@ -78,17 +81,22 @@ jobs:
             head="${{ github.event.merge_group.head_sha }}"
           fi
           if [ -n "$base" ]; then
-            # fetch-depth: 10 must reach both commits; fail loud rather
-            # than have a shallow-history "unknown revision" error get
-            # swallowed by the `!` below and misread as pin_changed=true.
             git cat-file -e "$base^{commit}"
             git cat-file -e "$head^{commit}"
-            if ! git diff --quiet "$base" "$head" -- tools/nativelink/pin.bzl; then
-              pin_changed=true
-            fi
           fi
           echo "orig_head=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
           echo "base=$base" >> "$GITHUB_OUTPUT"
+          echo "head=$head" >> "$GITHUB_OUTPUT"
+      # See tools/nativelink/README.md, "Changing the rootfs digest".
+      - name: Check whether the rootfs digest pin changed
+        id: pin_check
+        run: |
+          pin_changed=false
+          base="${{ steps.base_head.outputs.base }}"
+          head="${{ steps.base_head.outputs.head }}"
+          if [ -n "$base" ] && ! git diff --quiet "$base" "$head" -- tools/nativelink/pin.bzl; then
+            pin_changed=true
+          fi
           echo "pin_changed=$pin_changed" >> "$GITHUB_OUTPUT"
       - name: Install buck2
         run: sudo bash tools/buck2/install.sh /usr/local/bin
@@ -124,7 +132,7 @@ jobs:
       - name: "Rootfs digest change: trigger executor start with the previous pin"
         if: steps.pin_check.outputs.pin_changed == 'true'
         run: |
-          git checkout "${{ steps.pin_check.outputs.base }}"
+          git checkout "${{ steps.base_head.outputs.base }}"
           # pin.bzl may not exist yet at base (e.g. the PR that introduces
           # it): fall back to the digest's previous location, the literal
           # worker_layer(digest = "...") in tools/nativelink/BUCK.
@@ -141,7 +149,7 @@ jobs:
       # what every other run tests, not the unmerged branch tip.
       - name: "Rootfs digest change: switch to the build head"
         if: steps.pin_check.outputs.pin_changed == 'true'
-        run: git checkout "${{ steps.pin_check.outputs.orig_head }}"
+        run: git checkout "${{ steps.base_head.outputs.orig_head }}"
       - name: "Rootfs digest change: validate new pin builds hermetically on the old worker"
         if: steps.pin_check.outputs.pin_changed == 'true'
         run: |
@@ -152,11 +160,35 @@ jobs:
         if: steps.pin_check.outputs.pin_changed == 'true'
         run: |
           buck2 kill
+      - name: Check whether renovate.json changed
+        id: renovate_check
+        run: |
+          changed=false
+          base="${{ steps.base_head.outputs.base }}"
+          head="${{ steps.base_head.outputs.head }}"
+          if [ -n "$base" ] && ! git diff --quiet "$base" "$head" -- renovate.json; then
+            changed=true
+          fi
+          echo "changed=$changed" >> "$GITHUB_OUTPUT"
+      # See tools/renovate/README.md, "functional_check (buck2)".
+      - name: "renovate.json change: run functional check"
+        if: steps.renovate_check.outputs.changed == 'true'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          printf '[renovate]\n  gh_token = %s\n' "$GITHUB_TOKEN" >> .buckconfig.local
+          buck2 build //tools/renovate:functional_check
+      # functional_check can't satisfy --remote-only (see tools/renovate/
+      # README.md); every sweep below excludes it.
+      - name: Compute --remote-only target set
+        run: |
+          targets="$(buck2 uquery '//... - //tools/renovate:functional_check' | tr '\n' ' ')"
+          echo "REMOTE_ONLY_TARGETS=$targets" >> "$GITHUB_ENV"
       # --remote-only: CI is the trusted executor environment, so every
       # action — including the hybrid image-build platform's — runs on
       # NativeLink and warms the shared cache; nothing here executes local.
       - name: Build buck2 targets
-        run: buck2 build --remote-only //...
+        run: buck2 build --remote-only $REMOTE_ONLY_TARGETS
       # A green cached build cannot distinguish "cache works" from
       # "permanently missing"; only a demonstrated hit proves the read path.
       # buck2 clean + kill destroys buck2's local state, so the required
@@ -166,7 +198,7 @@ jobs:
         run: |
           buck2 clean
           buck2 kill
-          buck2 build --remote-only //... 2>&1 | tee rebuild.log
+          buck2 build --remote-only $REMOTE_ONLY_TARGETS 2>&1 | tee rebuild.log
           grep -q 'Cache hits: 100%' rebuild.log
       # An action reading an undeclared repo file must fail under input
       # staging. Validates that the reference configuration exercised in

--- a/BUCK
+++ b/BUCK
@@ -1,0 +1,5 @@
+export_file(
+    name = "renovate_json",
+    src = "renovate.json",
+    visibility = ["//tools/renovate:"],
+)

--- a/platforms/BUCK
+++ b/platforms/BUCK
@@ -1,5 +1,5 @@
 load("//tools/nativelink:pin.bzl", "WORKER_LAYER_DIGEST")
-load(":defs.bzl", "image_build_platform", "platform_group", "remote_cache_platform")
+load(":defs.bzl", "image_build_platform", "local_only_platform", "platform_group", "remote_cache_platform")
 
 remote_cache_platform(
     name = "default",
@@ -27,7 +27,27 @@ image_build_platform(
     os_configuration = "prelude//os:linux",
 )
 
+# Requesting this constraint value via `exec_compatible_with` routes a
+# target's actions to :local_only instead of :default — remote dispatch is
+# structurally unavailable there, not just discouraged.
+constraint_setting(
+    name = "local_only_setting",
+)
+
+constraint_value(
+    name = "local_only_enabled",
+    constraint_setting = ":local_only_setting",
+    visibility = ["PUBLIC"],
+)
+
+local_only_platform(
+    name = "local_only",
+    cpu_configuration = "prelude//cpu:x86_64",
+    local_only_marker = ":local_only_enabled",
+    os_configuration = "prelude//os:linux",
+)
+
 platform_group(
     name = "all",
-    platforms = [":default", ":image_build"],
+    platforms = [":default", ":image_build", ":local_only"],
 )

--- a/platforms/defs.bzl
+++ b/platforms/defs.bzl
@@ -116,6 +116,55 @@ image_build_platform = rule(
     },
 )
 
+# For actions that must never reach a remote executor at all (e.g. a
+# credential baked into the command — remote dispatch requires uploading
+# the Action/Command proto to CAS as a precondition of execution, which
+# `allow_cache_uploads = False` does not prevent, since that only gates the
+# *result* write, not the *request* upload needed just to dispatch it).
+# remote_enabled = False removes the capability outright, the same shape as
+# `image_build`'s allow_cache_uploads = False: a target opting in this way
+# gets a real guarantee, not a scheduling preference like local_only on an
+# individual action would.
+def _local_only_impl(ctx: AnalysisContext) -> list[Provider]:
+    constraints = dict()
+    constraints.update(ctx.attrs.cpu_configuration[ConfigurationInfo].constraints)
+    constraints.update(ctx.attrs.os_configuration[ConfigurationInfo].constraints)
+    marker = ctx.attrs.local_only_marker[ConstraintValueInfo]
+    constraints[marker.setting.label] = marker
+    cfg = ConfigurationInfo(constraints = constraints, values = {})
+
+    name = ctx.label.raw_target()
+    platform = ExecutionPlatformInfo(
+        label = name,
+        configuration = cfg,
+        executor_config = CommandExecutorConfig(
+            local_enabled = True,
+            remote_enabled = False,
+            remote_cache_enabled = False,
+            allow_cache_uploads = False,
+            remote_execution_use_case = "buck2-default",
+            use_windows_path_separators = False,
+        ),
+    )
+
+    return [
+        DefaultInfo(),
+        platform,
+        PlatformInfo(label = str(name), configuration = cfg),
+        ExecutionPlatformRegistrationInfo(
+            platforms = [platform],
+        ),
+    ]
+
+local_only_platform = rule(
+    impl = _local_only_impl,
+    attrs = {
+        "cpu_configuration": attrs.dep(providers = [ConfigurationInfo]),
+        "local_only_marker": attrs.dep(providers = [ConstraintValueInfo]),
+        "os_configuration": attrs.dep(providers = [ConfigurationInfo]),
+    },
+)
+
 # `[build] execution_platforms` in .buckconfig names exactly one target, so
 # the registered platforms are combined here.
 # Order matters: a target with no exec_compatible_with matches the first

--- a/renovate.json
+++ b/renovate.json
@@ -48,6 +48,12 @@
       "description": "Releases tagged with 8-digit dates, not semver.",
       "matchDepNames": ["astral-sh/python-build-standalone", "facebook/buck2"],
       "versioning": "loose"
+    },
+    {
+      "description": "The renovate/renovate image pinned in tools/renovate/BUCK (the functional-check fixture) bumps at most once a month as they have very good backwards compat.",
+      "matchDatasources": ["docker"],
+      "matchDepNames": ["renovate/renovate"],
+      "schedule": ["on the first day of the month"]
     }
   ],
   "customManagers": [
@@ -138,10 +144,11 @@
       "extractVersionTemplate": "^v(?<version>.*)$"
     },
     {
-      "description": "Any github release download pinned in a BUCK file; owner/repo is the dep, so a new pinned github tool is tracked with no per-tool config. The renovate-sha workflow recomputes the sha256 on the bump PR (renovatebot/renovate#22183). The match runs to the closing quote so the whole URL is the replace target, and autoReplaceGlobalMatch (on by default) rewrites every occurrence of the version within it — needed when a version or date repeats in the asset filename.",
+      "description": "Any github release download pinned in a BUCK file or MODULE.bazel; owner/repo is the dep, so a new pinned github tool is tracked with no per-tool config. The renovate-sha workflow recomputes the sha256 on the bump PR (renovatebot/renovate#22183). The match runs to the closing quote so the whole URL is the replace target, and autoReplaceGlobalMatch (on by default) rewrites every occurrence of the version within it — needed when a version or date repeats in the asset filename.",
       "customType": "regex",
       "managerFilePatterns": [
-        "/(^|/)BUCK$/"
+        "/(^|/)BUCK$/",
+        "/^MODULE\\.bazel$/"
       ],
       "matchStrings": [
         "https://github\\.com/(?<depName>[^/\"]+/[^/\"]+)/releases/download/(?<currentValue>[^/\"]+)/[^\"]*"

--- a/third_party/crane/BUCK
+++ b/third_party/crane/BUCK
@@ -3,10 +3,16 @@ load("//tools:defs.bzl", "cached_http_archive")
 cached_http_archive(
     name = "crane",
     sha256 = "1a57bc98207fa1c0d04bf760699099e26f8383499bfd55b99c1b919a928a7230",
-    # Only //tools/nativelink: consumes crane, feeding the worker-image
-    # subgraph, so its unpack action routes there too.
+    # //tools/nativelink feeds the worker-image subgraph, so its unpack
+    # action routes there too.
     exec_compatible_with = ["//platforms:image_build_enabled"],
     sub_targets = ["crane"],
     urls = ["https://github.com/google/go-containerregistry/releases/download/v0.21.7/go-containerregistry_Linux_x86_64.tar.gz"],
-    visibility = ["//tools/nativelink:"],
+    visibility = ["//tools/nativelink:", "//tools/renovate:"],
+)
+
+export_file(
+    name = "buck_file",
+    src = "BUCK",
+    visibility = ["//tools/renovate:"],
 )

--- a/tools/crun/BUCK
+++ b/tools/crun/BUCK
@@ -1,0 +1,7 @@
+# Fixture text for tools/renovate:functional_check to regex-scan, never
+# executed — the crun binary itself is used off PATH, not built from this.
+export_file(
+    name = "install_sh",
+    src = "install.sh",
+    visibility = ["//tools/renovate:"],
+)

--- a/tools/nativelink/BUCK
+++ b/tools/nativelink/BUCK
@@ -4,6 +4,18 @@ load("//tools/nativelink:layer.bzl", "worker_layer")
 load("//tools/nativelink:pin.bzl", "WORKER_LAYER_DIGEST")
 load("//tools/nativelink:rootfs.bzl", "busybox_rootfs")
 
+export_file(
+    name = "install_sh",
+    src = "install.sh",
+    visibility = ["//tools/renovate:"],
+)
+
+export_file(
+    name = "buck_file",
+    src = "BUCK",
+    visibility = ["//tools/renovate:"],
+)
+
 # exec_compatible_with routes the whole worker-image subgraph (this target
 # down through rootfs and layer) to the hybrid platform, so a --local-only
 # build of layer can execute every action it depends on.

--- a/tools/renovate/BUCK
+++ b/tools/renovate/BUCK
@@ -1,0 +1,17 @@
+load(":functional_check.bzl", "renovate_functional_check")
+
+# Tracked by the docker-digest custom manager in renovate.json, so Renovate
+# proposes the bump automatically (rate-limited to once a month, see
+# renovate.json) — no manual re-pin step.
+renovate_functional_check(
+    name = "functional_check",
+    script = "functional_check.sh",
+    crane = "//third_party/crane:crane[crane]",
+    crane_buck = "//third_party/crane:buck_file",
+    crun_install = "//tools/crun:install_sh",
+    nativelink_buck = "//tools/nativelink:buck_file",
+    nativelink_install = "//tools/nativelink:install_sh",
+    renovate_image = "renovate/renovate:43.285.2@sha256:ffe523c05ffca0143d855624a43edb1a75642b6d38390d542ca6da9e1ba72df7",
+    renovate_json = "//:renovate_json",
+    exec_compatible_with = ["//platforms:local_only_enabled"],
+)

--- a/tools/renovate/README.md
+++ b/tools/renovate/README.md
@@ -7,3 +7,14 @@ Scripts the `renovate-sha` CI workflow runs against a Renovate bump branch to fi
 
 Invoked directly with `bash` from CI, not through a Bazel target: a partway-applied Renovate bump has a version/sha256 mismatch, which fails a Bazel build before these scripts could run to fix it.
 The `sh_test` targets here only cover the scripts themselves under `bazel test //...`.
+
+## `functional_check` (buck2)
+
+Runs the real Renovate image against a fixture repo of this repo's pins, as a build action.
+
+`GH_TOKEN` comes from `.buckconfig.local`'s `[renovate] gh_token` (gitignored), not a declared attr, so it never lands in a `BUCK` file:
+
+```sh
+printf '[renovate]\n  gh_token = %s\n' "$(gh auth token)" >> .buckconfig.local
+buck2 build //tools/renovate:functional_check
+```

--- a/tools/renovate/functional_check.bzl
+++ b/tools/renovate/functional_check.bzl
@@ -1,0 +1,52 @@
+# Runs functional_check.sh as a cacheable build action (see that script for
+# why it's a `build` target, not a `test`).
+#
+# GH_TOKEN is read from .buckconfig.local's [renovate] gh_token (gitignored,
+# same pattern as [buck2_re_client] http_headers) rather than a declared
+# attr, so the secret never lands in a BUCK file. When it's absent, no
+# action is created at all — `buck2 build //...` produces a trivial no-op
+# output for this target instead of failing, so an unconfigured checkout
+# (a fresh clone, CI without the secret wired up) doesn't break the sweep.
+def _renovate_functional_check_impl(ctx: AnalysisContext) -> list[Provider]:
+    out = ctx.actions.declare_output("functional_check.stamp")
+    token = read_config("renovate", "gh_token")
+    if token == None:
+        ctx.actions.write(out, "skipped: [renovate] gh_token not set in .buckconfig.local\n")
+        return [DefaultInfo(default_output = out)]
+
+    # exec_compatible_with routes this to //platforms:local_only, whose
+    # remote_enabled = False makes this a real guarantee: GH_TOKEN's
+    # effects (this action's log carries them) never reach a remote
+    # executor, because there's no remote executor this platform can
+    # dispatch to at all — not because the action asked not to.
+    ctx.actions.run(
+        cmd_args(
+            "/bin/bash",
+            ctx.attrs.script,
+            ctx.attrs.crane[DefaultInfo].default_outputs[0],
+            ctx.attrs.crun_install,
+            ctx.attrs.nativelink_install,
+            ctx.attrs.nativelink_buck,
+            ctx.attrs.crane_buck,
+            ctx.attrs.renovate_json,
+            ctx.attrs.renovate_image,
+            out.as_output(),
+        ),
+        env = {"GH_TOKEN": token},
+        category = "renovate_functional_check",
+    )
+    return [DefaultInfo(default_output = out)]
+
+renovate_functional_check = rule(
+    impl = _renovate_functional_check_impl,
+    attrs = {
+        "crane": attrs.dep(providers = [DefaultInfo]),
+        "crane_buck": attrs.source(),
+        "crun_install": attrs.source(doc = "Fixture text only, regex-scanned by Renovate — never executed."),
+        "nativelink_buck": attrs.source(),
+        "nativelink_install": attrs.source(),
+        "renovate_image": attrs.string(doc = "renovate/renovate pinned by digest"),
+        "renovate_json": attrs.source(),
+        "script": attrs.source(),
+    },
+)

--- a/tools/renovate/functional_check.sh
+++ b/tools/renovate/functional_check.sh
@@ -1,0 +1,185 @@
+#!/usr/bin/env bash
+# Runs the real Renovate image (via crun) against a fixture repo of this
+# repo's pins and asserts its managers extract them.
+# A buck2 build action, not a test, so it's cacheable: re-runs only when a
+# declared input (this script, renovate.json, the pinned image digest,
+# crane/nativelink) changes — whether upstream has published something new
+# is not tracked, by design (that's what the pin freezes).
+# GH_TOKEN comes from the environment, never from a declared input — see
+# functional_check.bzl for how it's threaded through and why this can never
+# reach a remote executor.
+#
+# NOT YET HERMETIC: crun, git, and jq are all called off PATH, none staged
+# as declared buck2 inputs.
+#
+# Args: crane crun_install nativelink_install nativelink_buck crane_buck \
+#       renovate_json renovate_image out_stamp
+set -euo pipefail
+
+crane="$1"
+crun_install="$2"
+nativelink_install="$3"
+nativelink_buck="$4"
+crane_buck="$5"
+renovate_json="$6"
+renovate_image="$7"
+out="$8"
+
+token="${GH_TOKEN:-}"
+if [[ -z "$token" ]]; then
+	echo "ERROR: GH_TOKEN is not set. Configure it in .buckconfig.local:" \
+		"[renovate]\\n  gh_token = <token>" >&2
+	exit 1
+fi
+
+work="$(mktemp -d)"
+xdg="$(mktemp -d)"
+trap 'rm -rf "$work" "$xdg"' EXIT
+
+bindir="$work/bin"
+mkdir -p "$bindir"
+install -m 0755 "$crane" "$bindir/crane"
+export PATH="$bindir:$PATH"
+
+# ---- fixture repo: the real renovate.json, backdated pins ----
+repo="$work/repo"
+mkdir -p "$repo/tools/nativelink" "$repo/tools/crun" \
+	"$repo/third_party/crane" "$repo/third_party/python"
+cp "$renovate_json" "$repo/renovate.json"
+sed 's/^NATIVELINK_VERSION=.*/NATIVELINK_VERSION=1.5.0/' \
+	"$nativelink_install" >"$repo/tools/nativelink/install.sh"
+sed 's/^CRUN_VERSION=.*/CRUN_VERSION=1.20/' \
+	"$crun_install" >"$repo/tools/crun/install.sh"
+sed -E 's/busybox:[0-9.]+-musl@sha256:[0-9a-f]+/busybox:1.36.0-musl@sha256:0000000000000000000000000000000000000000000000000000000000000000/' \
+	"$nativelink_buck" >"$repo/tools/nativelink/BUCK"
+sed 's|download/v[0-9.]*/|download/v0.19.0/|' \
+	"$crane_buck" >"$repo/third_party/crane/BUCK"
+# The multi-axis pin: cpython version and python-build-standalone date share
+# one URL; the grouped update must move both axes together.
+cat >"$repo/third_party/python/BUCK" <<'EOF'
+cached_http_archive(
+    name = "cpython",
+    sha256 = "0000000000000000000000000000000000000000000000000000000000000000",
+    strip_components = 1,
+    urls = ["https://github.com/astral-sh/python-build-standalone/releases/download/20240814/cpython-3.12.0+20240814-x86_64-unknown-linux-gnu-install_only.tar.gz"],
+    visibility = ["PUBLIC"],
+)
+EOF
+# A MODULE.bazel pin absent from every BUCK file, so the MODULE.bazel
+# manager pattern is load-bearing for its assertion.
+cat >"$repo/MODULE.bazel" <<'EOF'
+http_archive(
+    name = "uv_linux_amd64",
+    sha256 = "8c88519b0ef0af9801fcdee419bbb12116bd9e6b18e162ae093c932d8b264050",
+    url = "https://github.com/astral-sh/uv/releases/download/0.11.0/uv-x86_64-unknown-linux-gnu.tar.gz",
+)
+EOF
+git -C "$repo" -c init.defaultBranch=master init -q
+git -C "$repo" -c user.email=test@test -c user.name=test add -A
+git -C "$repo" -c user.email=test@test -c user.name=test \
+	commit -q -m "fixture: renovate pins"
+
+# ---- OCI bundle: export the real (digest-pinned) renovate image, no Docker daemon ----
+bundle="$work/bundle"
+mkdir -p "$bundle/rootfs"
+crane export --platform linux/amd64 "$renovate_image" - |
+	tar -x -C "$bundle/rootfs"
+
+(cd "$bundle" && crun spec --rootless)
+
+uid="$(id -u)"
+gid="$(id -g)"
+config="$bundle/config.json"
+jq \
+	--argjson uid "$uid" \
+	--argjson gid "$gid" \
+	--arg repo "$repo" \
+	--arg token "$token" \
+	'.process.terminal = false
+	 | .process.user.uid = 12021
+	 | .process.user.gid = 0
+	 | .process.args = ["renovate"]
+	 | .process.cwd = "/repo"
+	 | .process.env += [
+	     "RENOVATE_PLATFORM=local",
+	     "LOG_LEVEL=debug",
+	     "GITHUB_COM_TOKEN=" + $token,
+	     "RENOVATE_TOKEN=" + $token
+	   ]
+	 | .linux.uidMappings = [{"containerID": 12021, "hostID": $uid, "size": 1}]
+	 | .linux.gidMappings = [{"containerID": 0, "hostID": $gid, "size": 1}]
+	 | .linux.namespaces = [.linux.namespaces[] | select(.type != "network")]
+	 | .mounts += [
+	     {"destination": "/repo", "type": "bind", "source": $repo,
+	      "options": ["rbind", "rw"]},
+	     {"destination": "/etc/resolv.conf", "type": "bind",
+	      "source": "/etc/resolv.conf", "options": ["rbind", "ro"]},
+	     {"destination": "/tmp", "type": "tmpfs", "source": "tmpfs",
+	      "options": ["nosuid", "nodev", "mode=1777"]}
+	   ]' \
+	"$config" >"$config.new"
+mv "$config.new" "$config"
+
+log="$work/renovate.log"
+XDG_RUNTIME_DIR="$xdg" crun run --no-new-keyring -b "$bundle" \
+	"renovate-functional-check-$$" >"$log" 2>&1
+rc=$?
+
+fail=0
+if [[ "$rc" -ne 0 ]]; then
+	echo "FAIL: renovate exited $rc"
+	fail=1
+fi
+
+# A dep's update window runs from its depName line to the next depName line,
+# so a neighbouring dep's newValue cannot satisfy the wrong assertion.
+update_proposed() {
+	awk -v dep="\"depName\": \"$1\"" '
+		/"depName": "/ { cur = (index($0, dep) > 0) }
+		cur && /"newValue"/ { found = 1 }
+		END { exit !found }
+	' "$log"
+}
+
+# Every backdated pin must yield an update decision, not just extract.
+for dep in TraceMachina/nativelink containers/crun astral-sh/uv \
+	google/go-containerregistry busybox \
+	python/cpython astral-sh/python-build-standalone; do
+	if grep -qF "\"depName\": \"${dep}\"" "$log"; then
+		echo "PASS: extracted depName ${dep}"
+	else
+		echo "FAIL: depName ${dep} not found in renovate output"
+		fail=1
+	fi
+	if update_proposed "$dep"; then
+		echo "PASS: update proposed for ${dep}"
+	else
+		echo "FAIL: no update proposed for ${dep}"
+		fail=1
+	fi
+done
+
+# The multi-axis pair moves together: one grouped branch carries both the
+# cpython version and the python-build-standalone date.
+if grep -qF '"branchName": "renovate/cpython"' "$log"; then
+	echo "PASS: cpython and python-build-standalone group into renovate/cpython"
+else
+	echo "FAIL: no grouped renovate/cpython branch in renovate output"
+	fail=1
+fi
+
+if grep -q "external-host-error" "$log"; then
+	echo "FAIL: renovate reported external-host-error"
+	grep -n "external-host-error" "$log"
+	fail=1
+else
+	echo "PASS: zero external-host-error"
+fi
+
+if [[ "$fail" -ne 0 ]]; then
+	echo "---- renovate log tail ----" >&2
+	tail -200 "$log" >&2
+	exit 1
+fi
+
+echo "ok" >"$out"


### PR DESCRIPTION
## Summary
- Adds `tools/renovate:functional_check`: runs the real Renovate image against a fixture repo of this repo's pins via crun, asserting its managers extract and propose updates. A cacheable buck2 build action, not a test.
- Routes it through a new `local_only` execution platform (`platforms/defs.bzl`): `remote_enabled = False`, so `GH_TOKEN` structurally never reaches a remote executor.
- `GH_TOKEN` comes from `.buckconfig.local`'s `[renovate] gh_token`, gitignored, never a declared attr. Unset → no action, trivial skip stamp.
- Already tracked by the existing digest-pin custom manager; new `packageRules` entry rate-limits its bumps to once a month.
- Extends the github-releases regex manager to also scan `MODULE.bazel` — `astral-sh/uv`'s pin lives there, uncovered by any manager until now, caught by this check's own fixture.
- Not hermetic yet: `crun`, `git`, `jq` run off PATH. `tools/crun/install.sh` is fixture text only, never executed.
- CI runs the check only on `renovate.json` changes, with its own ephemeral `GITHUB_TOKEN`, excluded from the `--remote-only //...` sweep.

## Test plan
- [x] `bash tools/check.sh agent //...`
- [x] `buck2 build //tools/renovate:functional_check` with no token → skip stamp
- [x] Same, with a real `GH_TOKEN` → passes end-to-end, including the `astral-sh/uv` MODULE.bazel case
- [x] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)
