### PR TITLE
tools/nativelink: add README

### DIFF
--- a/tools/BUILD.bazel
+++ b/tools/BUILD.bazel
@@ -3,6 +3,7 @@ load("@rules_shell//shell:sh_binary.bzl", "sh_binary")
 load("@rules_shell//shell:sh_test.bzl", "sh_test")
 load("//build:rust.bzl", "rust_binary")
 load("//tools/lint:format_check.bzl", "format_srcs")
+load("//tools/lint:linters.bzl", "markdown_lint_test")
 
 exports_files([
     "proto_gen_impl.sh",
@@ -212,6 +213,11 @@ py_test(
     ],
     main = "agent_action_guard_test.py",
     deps = [":agent_action_guard"],
+)
+
+markdown_lint_test(
+    name = "pymarkdown_nativelink",
+    srcs = ["nativelink/README.md"],
 )
 
 format_srcs()

--- a/tools/nativelink/README.md
+++ b/tools/nativelink/README.md
@@ -1,0 +1,13 @@
+# NativeLink
+
+The local remote-execution executor for buck2.
+NativeLink runs one process combining CAS, action cache, scheduler, and a sandboxed worker, and serves the remote-execution API on `127.0.0.1:50051`.
+buck2's launcher (`tools/buckle/buck2.sh`) starts it on demand.
+
+This directory holds the pinned installer, the two server configs, and the buck2 targets that build the worker-image pieces (busybox and a minimal rootfs) used inside the sandbox.
+
+The worker sandbox is achieved via crun + a custom busybox root image with NativeLink bind mounted in.
+The bind mount permits NativeLink to be updated without changing the rootfs, which reduces cache churn - the worker container image digest is a CAS input.
+
+`config.json5` is used to configure NativeLink.
+When BuildBuddy is in use, `config-bb.json5.template` is used to generate `.nativelink.json5` (gitignored) with the BuildBuddy API key.


### PR DESCRIPTION
Documents the what and why of `tools/nativelink`: local remote-execution executor for buck2, the committed-vs-gitignored config split, the pinned installer, and the busybox/rootfs worker-image targets.

Wires it into the markdown lint gate the same way other subdirectory READMEs without their own `BUILD.bazel` package are covered (see `infra/BUILD.bazel`): a `markdown_lint_test` in the parent package's `BUILD.bazel`.

