### PR TITLE
nativelink: deterministic worker layer tar

### DIFF
--- a/tools/nativelink/BUCK
+++ b/tools/nativelink/BUCK
@@ -1,5 +1,6 @@
 load("//tools:defs.bzl", "cached_check")
 load("//tools/nativelink:busybox.bzl", "busybox")
+load("//tools/nativelink:layer.bzl", "worker_layer")
 load("//tools/nativelink:rootfs.bzl", "busybox_rootfs")
 
 busybox(
@@ -28,5 +29,23 @@ cached_check(
     srcs = [
         "busybox_rootfs_test.py",
         ":rootfs",
+    ],
+)
+
+worker_layer(
+    name = "layer",
+    py = "//tools:py",
+    rootfs = ":rootfs",
+    script = "make_layer.py",
+)
+
+cached_check(
+    name = "layer_test",
+    exe = "//tools:py",
+    srcs = [
+        "layer_test.py",
+        ":layer",
+        ":rootfs",
+        "make_layer.py",
     ],
 )

--- a/tools/nativelink/layer.bzl
+++ b/tools/nativelink/layer.bzl
@@ -1,0 +1,19 @@
+# The worker layer tar: the rootfs tree serialized by make_layer.py, whose
+# normalization makes the bytes a pure function of the tree.
+def _worker_layer_impl(ctx: AnalysisContext) -> list[Provider]:
+    rootfs = ctx.attrs.rootfs[DefaultInfo].default_outputs[0]
+    out = ctx.actions.declare_output("layer.tar")
+    ctx.actions.run(
+        cmd_args(ctx.attrs.py[RunInfo], ctx.attrs.script, rootfs, out.as_output()),
+        category = "worker_layer",
+    )
+    return [DefaultInfo(default_output = out)]
+
+worker_layer = rule(
+    impl = _worker_layer_impl,
+    attrs = {
+        "py": attrs.exec_dep(providers = [RunInfo]),
+        "rootfs": attrs.dep(providers = [DefaultInfo]),
+        "script": attrs.source(),
+    },
+)

--- a/tools/nativelink/layer_test.py
+++ b/tools/nativelink/layer_test.py
@@ -1,0 +1,107 @@
+"""Property checks for the worker layer tar.
+
+One permutation per input dimension the function must be invariant to,
+asserted at the python interface; uid/gid cannot be varied on disk
+without privileges, so normalize() is checked on fabricated TarInfos.
+
+argv[1] is the built layer tar, argv[2] the rootfs tree,
+argv[3] make_layer.py, argv[4] the output to touch on success.
+"""
+
+import importlib.util
+import os
+import sys
+import tarfile
+import tempfile
+
+layer, rootfs, make_layer_path = sys.argv[1], sys.argv[2], sys.argv[3]
+
+spec = importlib.util.spec_from_file_location("make_layer", make_layer_path)
+make_layer = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(make_layer)
+
+
+def build_tree(base, entries):
+    for kind, rel, arg in entries:
+        p = os.path.join(base, rel)
+        if kind == "dir":
+            os.mkdir(p)
+        elif kind == "file":
+            with open(p, "w", encoding="utf-8") as f:
+                f.write(arg)
+        elif kind == "symlink":
+            os.symlink(arg, p)
+
+
+def set_all_mtimes(base, stamp):
+    for dirpath, dirnames, filenames in os.walk(base):
+        for n in dirnames + filenames:
+            os.utime(os.path.join(dirpath, n), (stamp, stamp), follow_symlinks=False)
+
+
+def layer_bytes(entries, stamp=None):
+    with tempfile.TemporaryDirectory() as td:
+        tree = os.path.join(td, "tree")
+        os.mkdir(tree)
+        build_tree(tree, entries)
+        if stamp is not None:
+            set_all_mtimes(tree, stamp)
+        out = os.path.join(td, "layer.tar")
+        make_layer.write_layer(tree, out)
+        with open(out, "rb") as f:
+            return f.read()
+
+
+entries = [
+    ("dir", "bin", None),
+    ("file", "bin/tool", "content"),
+    ("symlink", "bin/alias", "tool"),
+    ("dir", "etc", None),
+]
+
+# Creation-order permutation, including sibling order within a directory.
+reordered = [entries[3], entries[0], entries[2], entries[1]]
+assert layer_bytes(entries) == layer_bytes(reordered), "creation order leaked"
+
+# mtime permutation.
+assert layer_bytes(entries, stamp=12345) == layer_bytes(entries, stamp=67890), "mtime leaked"
+
+# umask permutation: mode bits must not ride the builder's umask.
+old_umask = os.umask(0o022)
+try:
+    strict = layer_bytes(entries)
+    os.umask(0o077)
+    loose = layer_bytes(entries)
+finally:
+    os.umask(old_umask)
+assert strict == loose, "umask leaked into modes"
+
+# uid/gid/uname/gname/mtime: normalize zeroes arbitrary values.
+ti = tarfile.TarInfo("x")
+ti.uid, ti.gid, ti.uname, ti.gname, ti.mtime = 1234, 5678, "who", "grp", 99
+ti = make_layer.normalize(ti)
+assert (ti.uid, ti.gid, ti.uname, ti.gname, ti.mtime) == (0, 0, "", "", 0)
+
+# Type fidelity and sorted members.
+with tempfile.TemporaryDirectory() as td:
+    tree = os.path.join(td, "tree")
+    os.mkdir(tree)
+    build_tree(tree, entries)
+    out = os.path.join(td, "layer.tar")
+    make_layer.write_layer(tree, out)
+    with tarfile.open(out) as t:
+        by_name = {m.name: m for m in t.getmembers()}
+    assert by_name["bin/tool"].isfile()
+    assert by_name["bin/alias"].issym() and by_name["bin/alias"].linkname == "tool"
+    assert by_name["etc"].isdir()
+    names = list(by_name)
+    assert names == sorted(names), "members not sorted"
+
+# Wiring: the built artifact equals a recomputation from the same rootfs.
+with tempfile.TemporaryDirectory() as td:
+    again = os.path.join(td, "again.tar")
+    make_layer.write_layer(rootfs, again)
+    with open(layer, "rb") as a, open(again, "rb") as b:
+        assert a.read() == b.read(), "built layer differs from recomputation"
+
+open(sys.argv[4], "w", encoding="utf-8").write("ok")

--- a/tools/nativelink/make_layer.py
+++ b/tools/nativelink/make_layer.py
@@ -1,0 +1,37 @@
+"""Write a normalized tar of the tree argv[1] to argv[2].
+
+uid, gid, uname, gname, and mtime are zeroed, modes are pinned to 0755/0644,
+and entries are added in sorted order, so the bytes depend only on the
+tree's content.
+"""
+
+import os
+import sys
+import tarfile
+
+
+def normalize(ti):
+    ti.uid = ti.gid = 0
+    ti.uname = ti.gname = ""
+    ti.mtime = 0
+    # Modes otherwise ride the builder's umask; only executability is content.
+    if ti.isdir() or ti.mode & 0o100:
+        ti.mode = 0o755
+    else:
+        ti.mode = 0o644
+    return ti
+
+
+def write_layer(root, out):
+    paths = []
+    for dirpath, dirnames, filenames in os.walk(root):
+        for n in dirnames + filenames:
+            p = os.path.join(dirpath, n)
+            paths.append((os.path.relpath(p, root), p))
+    with tarfile.open(out, "w", format=tarfile.GNU_FORMAT) as tar:
+        for arcname, p in sorted(paths):
+            tar.add(p, arcname=arcname, filter=normalize, recursive=False)
+
+
+if __name__ == "__main__":
+    write_layer(sys.argv[1], sys.argv[2])


### PR DESCRIPTION
The layer must be byte-identical wherever it is built or the image digest cannot key the shared cache.

make_layer.py zeroes uid/gid/uname/gname/mtime, pins modes to 0755/0644 so the builder's umask cannot leak, and writes entries in sorted order.

The test permutes one input dimension at a time — creation order, mtime, umask — with uid and gid asserted at the python seam where privilege is not needed, and the built artifact byte-compared against a recomputation.
