### PR TITLE
nativelink: worker OCI image tar

### DIFF
--- a/tools/nativelink/BUCK
+++ b/tools/nativelink/BUCK
@@ -1,5 +1,6 @@
 load("//tools:defs.bzl", "cached_check")
 load("//tools/nativelink:busybox.bzl", "busybox")
+load("//tools/nativelink:image.bzl", "worker_image")
 load("//tools/nativelink:layer.bzl", "worker_layer")
 load("//tools/nativelink:rootfs.bzl", "busybox_rootfs")
 
@@ -47,5 +48,25 @@ cached_check(
         ":layer",
         ":rootfs",
         "make_layer.py",
+    ],
+)
+
+worker_image(
+    name = "worker_image",
+    crane = "//third_party/crane:crane[crane]",
+    layer = ":layer",
+    py = "//tools:py",
+    script = "make_image.py",
+)
+
+cached_check(
+    name = "image_test",
+    exe = "//tools:py",
+    srcs = [
+        "image_test.py",
+        ":worker_image",
+        ":layer",
+        "//third_party/crane:crane[crane]",
+        "make_image.py",
     ],
 )

--- a/tools/nativelink/image.bzl
+++ b/tools/nativelink/image.bzl
@@ -1,0 +1,27 @@
+# The worker OCI image tar: crane wraps the deterministic layer from an
+# empty base, so the image digest is a pure function of the layer bytes.
+def _worker_image_impl(ctx: AnalysisContext) -> list[Provider]:
+    crane = ctx.attrs.crane[DefaultInfo].default_outputs[0]
+    layer = ctx.attrs.layer[DefaultInfo].default_outputs[0]
+    out = ctx.actions.declare_output("worker.tar")
+    ctx.actions.run(
+        cmd_args(
+            ctx.attrs.py[RunInfo],
+            ctx.attrs.script,
+            crane,
+            layer,
+            out.as_output(),
+        ),
+        category = "worker_image",
+    )
+    return [DefaultInfo(default_output = out)]
+
+worker_image = rule(
+    impl = _worker_image_impl,
+    attrs = {
+        "crane": attrs.dep(providers = [DefaultInfo]),
+        "layer": attrs.dep(providers = [DefaultInfo]),
+        "py": attrs.exec_dep(providers = [RunInfo]),
+        "script": attrs.source(),
+    },
+)

--- a/tools/nativelink/image_test.py
+++ b/tools/nativelink/image_test.py
@@ -1,0 +1,46 @@
+"""Property checks for the worker OCI image tar.
+
+argv[1] is the image tar, argv[2] the layer tar, argv[3] the crane
+binary, argv[4] make_image.py, argv[5] the output to touch on success.
+"""
+
+import gzip
+import hashlib
+import importlib.util
+import json
+import os
+import sys
+import tarfile
+import tempfile
+
+image, layer, crane, make_image_path = sys.argv[1], sys.argv[2], sys.argv[3], sys.argv[4]
+
+spec = importlib.util.spec_from_file_location("make_image", make_image_path)
+make_image = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(make_image)
+
+with open(layer, "rb") as f:
+    layer_bytes = f.read()
+
+with tarfile.open(image) as t:
+    names = t.getnames()
+    manifest = json.load(t.extractfile("manifest.json"))
+    assert len(manifest) == 1, manifest
+    entry = manifest[0]
+    assert entry["Config"] in names, entry
+    layers = entry["Layers"]
+    assert len(layers) == 1, layers
+    embedded = t.extractfile(layers[0]).read()
+    tag = "causes-worker:" + hashlib.sha256(layer_bytes).hexdigest()[:12]
+    assert entry["RepoTags"] == [tag], entry
+
+assert gzip.decompress(embedded) == layer_bytes, "embedded layer differs from :layer"
+
+# Reproducibility: rebuilding from the same layer yields identical bytes.
+with tempfile.TemporaryDirectory() as td:
+    again = os.path.join(td, "again.tar")
+    make_image.make_image(crane, layer, again)
+    with open(image, "rb") as a, open(again, "rb") as b:
+        assert a.read() == b.read(), "image bytes are not reproducible"
+
+open(sys.argv[5], "w", encoding="utf-8").write("ok")

--- a/tools/nativelink/make_image.py
+++ b/tools/nativelink/make_image.py
@@ -1,0 +1,32 @@
+"""Wrap the layer tar argv[2] in an OCI image tar argv[3] using crane argv[1].
+
+The tag embeds the layer digest so a loaded image is self-identifying;
+the bytes stay a pure function of the layer.
+"""
+
+import hashlib
+import subprocess
+import sys
+
+
+def make_image(crane, layer, out):
+    with open(layer, "rb") as f:
+        digest = hashlib.sha256(f.read()).hexdigest()
+    subprocess.run(
+        [
+            crane,
+            "append",
+            "--oci-empty-base",
+            "-f",
+            layer,
+            "-o",
+            out,
+            "-t",
+            "causes-worker:" + digest[:12],
+        ],
+        check=True,
+    )
+
+
+if __name__ == "__main__":
+    make_image(sys.argv[1], sys.argv[2], sys.argv[3])


### PR DESCRIPTION
crane append wraps the deterministic layer in an OCI image tar from an empty base.
The image digest is a pure function of the layer bytes.
The tag embeds the layer digest so a loaded image is self-identifying.
The test asserts single-layer manifest structure, the digest tag, that the embedded layer gunzips to `:layer` exactly, and byte-identical rebuild via `make_image.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)