### PR TITLE
cargo: move console version to workspace deps

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,6 +49,7 @@ reqwest = { version = "0.13", features = [
   "query",
 ], default-features = false }
 clap = { version = "4", features = ["env", "derive"] }
+console = "0.16"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 anyhow = "1"

--- a/tools/sqlx-cli/Cargo.toml
+++ b/tools/sqlx-cli/Cargo.toml
@@ -14,7 +14,7 @@ path = "src/main.rs"
 
 [dependencies]
 clap = { workspace = true }
-console = "0.16"
+console = { workspace = true }
 sqlx = { workspace = true }
 sqlx-cli = { workspace = true }
 tokio = { workspace = true }


### PR DESCRIPTION
tools/sqlx-cli was the only workspace member pinning a registry dependency inline.
Declare console once under [workspace.dependencies] and reference it with workspace = true, like every other registry dependency.
Cargo.lock is unchanged; verified with cargo metadata --locked and by running the sqlx binary.
First of a two-PR stack; the follow-up adds a lint enforcing this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)