### PR TITLE
lint: Cargo deps must be workspace references

### DIFF
--- a/tools/lint/BUILD.bazel
+++ b/tools/lint/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@rules_python//python:defs.bzl", "py_test")
+load("@rules_python//python:defs.bzl", "py_library", "py_test")
 load(
     "@rules_python//python/entry_points:py_console_script_binary.bzl",
     "py_console_script_binary",
@@ -98,6 +98,54 @@ _RUST_CRATE_PACKAGES = [
     "//services/causes_api",
     "//services/causes_cli",
 ]
+
+# ── cargo workspace-dependency check ──────────────────────────────────────────
+# Members may not pin dependency versions; every registry dep is declared in
+# the root [workspace.dependencies] and referenced with `workspace = true`.
+# The script cross-checks the root's [workspace.members] against the manifests
+# supplied, so a new crate cannot silently escape the check.
+_CARGO_WORKSPACE_TOMLS = ["//:toml_format_srcs"] + [
+    "%s:toml_format_srcs" % pkg
+    for pkg in [
+        "//lib/rust/api_db",
+        "//lib/rust/causes_crypto",
+        "//lib/rust/causes_mcp",
+        "//lib/rust/causes_proto",
+        "//lib/rust/causes_session",
+        "//lib/rust/db_aws",
+        "//lib/rust/db_connect",
+        "//lib/rust/db_pool",
+        "//lib/rust/proto_ext",
+        "//services/causes_api",
+        "//services/causes_cli",
+        "//tools/ci_health",
+        "//tools/proto-gen",
+        "//tools/sqlx-cli",
+    ]
+]
+
+py_library(
+    name = "check_cargo_workspace_deps",
+    srcs = ["check_cargo_workspace_deps.py"],
+    imports = ["."],
+)
+
+py_test(
+    name = "check_cargo_workspace_deps_test",
+    size = "small",
+    srcs = ["check_cargo_workspace_deps_test.py"],
+    main = "check_cargo_workspace_deps_test.py",
+    deps = [":check_cargo_workspace_deps"],
+)
+
+py_test(
+    name = "cargo_workspace_deps_check",
+    size = "small",
+    srcs = ["check_cargo_workspace_deps.py"],
+    args = ["$(rootpaths %s)" % t for t in _CARGO_WORKSPACE_TOMLS],
+    data = _CARGO_WORKSPACE_TOMLS,
+    main = "check_cargo_workspace_deps.py",
+)
 
 py_test(
     name = "cargo_bazel_deps_check",

--- a/tools/lint/check_cargo_workspace_deps.py
+++ b/tools/lint/check_cargo_workspace_deps.py
@@ -1,0 +1,109 @@
+"""Guardrail: workspace members take every dependency from the workspace.
+
+A member Cargo.toml may not pin a dependency version.
+Registry dependencies are declared once in the root [workspace.dependencies]
+and referenced with `workspace = true`; intra-workspace `path` dependencies
+carry no version and are allowed.
+
+Invocation: pass the root Cargo.toml and every member Cargo.toml as
+positional arguments (files not named Cargo.toml are ignored).
+The root is recognised by its [workspace] table, and every entry in its
+[workspace.members] must have its manifest among the arguments, so a new
+crate cannot silently escape the check.
+"""
+
+from pathlib import Path
+import sys
+import tomllib
+
+_DEP_TABLES = ("dependencies", "dev-dependencies", "build-dependencies")
+
+
+def dep_violation(spec):
+    """The reason this dependency spec is not a workspace reference, or None."""
+    if isinstance(spec, str):
+        return f'inline version "{spec}"'
+    if spec.get("workspace") is True:
+        return None
+    if "version" in spec:
+        return f'inline version "{spec["version"]}"'
+    if "path" in spec:
+        return None
+    return "not a workspace reference"
+
+
+def _table_violations(table_name, table):
+    return [
+        f"{table_name}: {name} — {reason}"
+        for name, spec in sorted(table.items())
+        if (reason := dep_violation(spec)) is not None
+    ]
+
+
+def check_manifest(manifest):
+    """All dependency violations in one parsed member manifest."""
+    violations = []
+    for table_name in _DEP_TABLES:
+        violations += _table_violations(table_name, manifest.get(table_name, {}))
+    for cfg, tables in manifest.get("target", {}).items():
+        for table_name in _DEP_TABLES:
+            violations += _table_violations(
+                f"target.'{cfg}'.{table_name}", tables.get(table_name, {})
+            )
+    return violations
+
+
+def main(argv):
+    manifests = {}
+    for arg in argv:
+        path = Path(arg)
+        if path.name == "Cargo.toml":
+            manifests[path] = tomllib.loads(path.read_text())
+
+    roots = [(p, m) for p, m in manifests.items() if "workspace" in m]
+    if len(roots) != 1:
+        sys.stderr.write(
+            "expected exactly one Cargo.toml with a [workspace] table among the "
+            f"arguments, got {len(roots)} — wiring bug\n"
+        )
+        return 1
+    root_path, root = roots[0]
+
+    members = root["workspace"]["members"]
+    missing = [m for m in members if root_path.parent / m / "Cargo.toml" not in manifests]
+    if missing:
+        sys.stderr.write(
+            "workspace member manifests missing from the arguments — wiring bug; "
+            "add each member's toml_format_srcs (or its exported Cargo.toml) to "
+            "cargo_workspace_deps_check in tools/lint/BUILD.bazel:\n"
+        )
+        for m in missing:
+            sys.stderr.write(f"  - {m}\n")
+        return 1
+
+    failures = []
+    for member in sorted(members):
+        path = root_path.parent / member / "Cargo.toml"
+        violations = check_manifest(manifests[path])
+        if violations:
+            failures.append((path, violations))
+
+    if failures:
+        sys.stderr.write("Cargo.toml dependencies must be workspace references:\n\n")
+        for path, violations in failures:
+            sys.stderr.write(f"  {path}\n")
+            for violation in violations:
+                sys.stderr.write(f"    - {violation}\n")
+        sys.stderr.write(
+            "\nDeclare each version once under [workspace.dependencies] in the "
+            "root Cargo.toml and reference it from the member, e.g.:\n"
+            "    console = { workspace = true }\n"
+        )
+        return 1
+
+    print(f"checked {len(members)} member manifest(s); all deps are workspace refs")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/tools/lint/check_cargo_workspace_deps_test.py
+++ b/tools/lint/check_cargo_workspace_deps_test.py
@@ -1,0 +1,115 @@
+"""Tests for the workspace-dependency lint (check_cargo_workspace_deps.py)."""
+
+import contextlib
+import io
+from pathlib import Path
+import tempfile
+import tomllib
+import unittest
+
+from check_cargo_workspace_deps import check_manifest, dep_violation, main
+
+
+class DepViolationTest(unittest.TestCase):
+    def test_workspace_reference_is_allowed(self):
+        self.assertIsNone(dep_violation({"workspace": True}))
+
+    def test_workspace_reference_with_features_is_allowed(self):
+        self.assertIsNone(dep_violation({"workspace": True, "features": ["json"]}))
+
+    def test_path_dependency_is_allowed(self):
+        self.assertIsNone(dep_violation({"path": "../db_pool"}))
+
+    def test_string_shorthand_is_flagged(self):
+        self.assertIsNotNone(dep_violation("0.16"))
+
+    def test_version_key_is_flagged(self):
+        self.assertIsNotNone(dep_violation({"version": "1", "features": ["full"]}))
+
+    def test_path_with_version_is_flagged(self):
+        self.assertIsNotNone(dep_violation({"path": "../db_pool", "version": "0.1"}))
+
+    def test_git_dependency_is_flagged(self):
+        self.assertIsNotNone(dep_violation({"git": "https://example.com/x.git"}))
+
+
+class CheckManifestTest(unittest.TestCase):
+    def test_clean_manifest_has_no_violations(self):
+        manifest = tomllib.loads(
+            '[dependencies]\ntokio = { workspace = true }\ndb_pool = { path = "../db_pool" }\n'
+        )
+        self.assertEqual(check_manifest(manifest), [])
+
+    def test_every_dependency_table_is_scanned(self):
+        manifest = tomllib.loads(
+            '[dependencies]\na = "1"\n'
+            '[dev-dependencies]\nb = "1"\n'
+            '[build-dependencies]\nc = "1"\n'
+            "[target.'cfg(unix)'.dependencies]\n"
+            'd = "1"\n'
+        )
+        joined = "\n".join(check_manifest(manifest))
+        self.assertEqual(len(check_manifest(manifest)), 4)
+        self.assertIn("dependencies: a", joined)
+        self.assertIn("dev-dependencies: b", joined)
+        self.assertIn("build-dependencies: c", joined)
+        self.assertIn("target.'cfg(unix)'.dependencies: d", joined)
+
+
+ROOT_MANIFEST = '[workspace]\nmembers = ["crates/a"]\n[workspace.dependencies]\nserde = "1"\n'
+CLEAN_MEMBER = '[package]\nname = "a"\n[dependencies]\nserde = { workspace = true }\n'
+DIRTY_MEMBER = '[package]\nname = "a"\n[dependencies]\nserde = "1"\n'
+
+
+class MainTest(unittest.TestCase):
+    def setUp(self):
+        tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(tmp.cleanup)
+        self.root = Path(tmp.name)
+        self.stderr = io.StringIO()
+
+    def write(self, rel, text):
+        path = self.root / rel
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(text)
+        return str(path)
+
+    def run_main(self, args):
+        with (
+            contextlib.redirect_stderr(self.stderr),
+            contextlib.redirect_stdout(io.StringIO()),
+        ):
+            return main(args)
+
+    def test_clean_workspace_passes(self):
+        args = [
+            self.write("Cargo.toml", ROOT_MANIFEST),
+            self.write("crates/a/Cargo.toml", CLEAN_MEMBER),
+            self.write("rustfmt.toml", "edition = '2024'\n"),
+        ]
+        self.assertEqual(self.run_main(args), 0)
+
+    def test_member_violation_fails_and_is_named(self):
+        args = [
+            self.write("Cargo.toml", ROOT_MANIFEST),
+            self.write("crates/a/Cargo.toml", DIRTY_MEMBER),
+        ]
+        self.assertEqual(self.run_main(args), 1)
+        self.assertIn("crates/a/Cargo.toml", self.stderr.getvalue())
+        self.assertIn("serde", self.stderr.getvalue())
+
+    def test_missing_member_manifest_is_a_wiring_error(self):
+        self.write("crates/a/Cargo.toml", CLEAN_MEMBER)
+        args = [self.write("Cargo.toml", ROOT_MANIFEST)]
+        self.assertEqual(self.run_main(args), 1)
+        self.assertIn("crates/a", self.stderr.getvalue())
+        self.assertIn("wiring", self.stderr.getvalue())
+
+    def test_missing_root_manifest_is_a_wiring_error(self):
+        args = [self.write("crates/a/Cargo.toml", CLEAN_MEMBER)]
+        self.assertEqual(self.run_main(args), 1)
+        self.assertIn("wiring", self.stderr.getvalue())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
lint: Cargo deps must be workspace references
Member Cargo.toml files may not pin dependency versions.
Registry deps are declared once in the root [workspace.dependencies]
and referenced with workspace = true; intra-workspace path deps carry
no version and stay allowed.
The check cross-checks the root's [workspace.members] against the
manifests it received, so a new crate cannot silently escape coverage.
