### PR TITLE
rules: block raw git, note worktree jj limit

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -64,7 +64,8 @@
       "Bash(bash tools/check.sh ci //...)"
     ],
     "deny": [
-      "Read(~/.aws/credentials)"
+      "Read(~/.aws/credentials)",
+      "Bash(git:*)"
     ]
   }
 }

--- a/.claude/skills/jj/SKILL.md
+++ b/.claude/skills/jj/SKILL.md
@@ -36,6 +36,8 @@ Skip this checklist only for routine pushes with no rebase/reorder.
 
 1. **No raw git.** Never run `git commit`, `git push`, `git checkout`, etc.
    Use `jj describe`, `jj git push`, `jj new`, etc.
+   A harness git worktree (`EnterWorktree`, under `.claude/worktrees/`) cannot host jj: it has no `.jj`, so jj commands there operate on the main workspace instead.
+   Isolate background work in a jj workspace outside the repo (see `.claude/rules/project/project_buck2_bazel_isolation.md`), and if the harness forces edits inside its own worktree stop and ask rather than falling back to raw git.
 
 2. **No staging area.** `@` (the working copy) IS the commit.
    Edits are tracked automatically.


### PR DESCRIPTION
The no-raw-git ban was prose-only, so a background job rationalized past it (#487/#488) and authored commits with git in a harness worktree.

- Deny `Bash(git:*)` in `.claude/settings.json` — enforced, not advisory.
- Document in the jj skill why a harness worktree looks like it forces git (no `.jj`, so jj hits the main workspace), and the fix: a jj workspace outside the repo, or stop and ask.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
