### PR TITLE
nativelink: digest-pin the worker image

### DIFF
--- a/tools/nativelink/BUCK
+++ b/tools/nativelink/BUCK
@@ -55,8 +55,8 @@ worker_image(
     name = "worker_image",
     crane = "//third_party/crane:crane[crane]",
     layer = ":layer",
+    digest = "af18e99e3ecc14f51f78e8d5def7391d02dcdaea5d762d7cf179c5def7831a89",
     py = "//tools:py",
-    script = "make_image.py",
 )
 
 cached_check(

--- a/tools/nativelink/image.bzl
+++ b/tools/nativelink/image.bzl
@@ -1,27 +1,105 @@
-# The worker OCI image tar: crane wraps the deterministic layer from an
-# empty base, so the image digest is a pure function of the layer bytes.
+"""The worker OCI image tar.
+
+crane wraps the deterministic layer from an empty base, so the image digest is a
+pure function of the layer bytes.
+"""
+
 def _worker_image_impl(ctx: AnalysisContext) -> list[Provider]:
     crane = ctx.attrs.crane[DefaultInfo].default_outputs[0]
     layer = ctx.attrs.layer[DefaultInfo].default_outputs[0]
     out = ctx.actions.declare_output("worker.tar")
+    digest_out = ctx.actions.declare_output("worker.digest")
+    script = ctx.attrs._script
+
     ctx.actions.run(
         cmd_args(
             ctx.attrs.py[RunInfo],
-            ctx.attrs.script,
+            script,
+            "build",
             crane,
             layer,
             out.as_output(),
+            digest_out.as_output(),
         ),
         category = "worker_image",
+        identifier = "build",
     )
-    return [DefaultInfo(default_output = out)]
+    return [DefaultInfo(default_output = out, sub_targets = {
+        "digest": [DefaultInfo(default_output = digest_out)],
+    })]
 
-worker_image = rule(
+_worker_image = rule(
     impl = _worker_image_impl,
     attrs = {
         "crane": attrs.dep(providers = [DefaultInfo]),
         "layer": attrs.dep(providers = [DefaultInfo]),
         "py": attrs.exec_dep(providers = [RunInfo]),
-        "script": attrs.source(),
+        "_script": attrs.source(doc = "Path to the script that builds the image"),
     },
 )
+
+def _validate_image_impl(ctx: AnalysisContext) -> list[Provider]:
+    valid_stamp = ctx.actions.declare_output("image.stamp")
+
+    script = ctx.attrs._script
+    image_provider = ctx.attrs.image[DefaultInfo]
+
+    validation_spec = ctx.actions.run(
+        cmd_args(
+            ctx.attrs.py[RunInfo],
+            script,
+            "check",
+            image_provider.sub_targets["digest"][DefaultInfo].default_outputs,
+            "--digest",
+            ctx.attrs.digest,
+            valid_stamp.as_output(),
+        ),
+        category = "worker_image",
+        identifier = "validate",
+    )
+
+    validation_spec = ValidationSpec(
+        name = "image_digest_validation",
+        validation_result = valid_stamp,
+    )
+
+    return [
+        DefaultInfo(
+            default_output = image_provider.default_outputs[0],
+            # other_outputs = [valid_stamp],
+            sub_targets = {
+                "image": [image_provider],
+            },
+        ),
+        ValidationInfo(validations = [validation_spec]),
+    ]
+
+_validate_image = rule(
+    impl = _validate_image_impl,
+    attrs = {
+        "digest": attrs.string(doc = "Reference output digest to support validation without a hermetic builder"),
+        "py": attrs.exec_dep(providers = [RunInfo]),
+        "_script": attrs.source(doc = "Path to the script that implements the image validation"),
+        "image": attrs.dep(),
+    },
+)
+
+# macro to keep the target lean
+def worker_image(name, **kwargs):
+    _worker_image(
+        name = name + "_build",
+        _script = "make_image.py",
+        crane = kwargs.get("crane"),
+        layer = kwargs.get("layer"),
+        py = kwargs.get("py"),
+        visibility = [],
+    )
+
+    # build the image without validation to enable upgrading without special casing
+    _validate_image(
+        name = name,
+        _script = "make_image.py",
+        image = ":" + name + "_build",
+        digest = kwargs.get("digest"),
+        py = kwargs.get("py"),
+    )

--- a/tools/nativelink/image_test.py
+++ b/tools/nativelink/image_test.py
@@ -36,11 +36,17 @@ with tarfile.open(image) as t:
 
 assert gzip.decompress(embedded) == layer_bytes, "embedded layer differs from :layer"
 
-# Reproducibility: rebuilding from the same layer yields identical bytes.
+# Reproducibility: rebuilding from the same layer yields identical bytes,
+# and the digest output matches them.
 with tempfile.TemporaryDirectory() as td:
     again = os.path.join(td, "again.tar")
-    make_image.make_image(crane, layer, again)
-    with open(image, "rb") as a, open(again, "rb") as b:
-        assert a.read() == b.read(), "image bytes are not reproducible"
+    digest = os.path.join(td, "again.digest")
+    make_image.build_image(crane, layer, again, digest)
+    with open(again, "rb") as f:
+        again_bytes = f.read()
+    with open(image, "rb") as f:
+        assert f.read() == again_bytes, "image bytes are not reproducible"
+    with open(digest, encoding="utf-8") as f:
+        assert f.read().strip() == hashlib.sha256(again_bytes).hexdigest(), "digest output wrong"
 
 open(sys.argv[5], "w", encoding="utf-8").write("ok")

--- a/tools/nativelink/make_image.py
+++ b/tools/nativelink/make_image.py
@@ -1,17 +1,18 @@
-"""Wrap the layer tar argv[2] in an OCI image tar argv[3] using crane argv[1].
+"""Wrap the layer tar in an OCI image tar using crane and validates the digest.
 
 The tag embeds the layer digest so a loaded image is self-identifying;
 the bytes stay a pure function of the layer.
 """
 
 import hashlib
+import json
 import subprocess
 import sys
 
 
-def make_image(crane, layer, out):
+def build_image(crane, layer, out, digest_out):
     with open(layer, "rb") as f:
-        digest = hashlib.sha256(f.read()).hexdigest()
+        layer_digest = hashlib.sha256(f.read()).hexdigest()
     subprocess.run(
         [
             crane,
@@ -22,11 +23,45 @@ def make_image(crane, layer, out):
             "-o",
             out,
             "-t",
-            "causes-worker:" + digest[:12],
+            "causes-worker:" + layer_digest[:12],
         ],
         check=True,
     )
+    with open(out, "rb") as f:
+        image_digest = hashlib.sha256(f.read()).hexdigest()
+    with open(digest_out, "wt") as f:
+        f.write(image_digest + "\n")
+
+
+def check_digest(digest_out, digest, stamp_path):
+    with open(digest_out, "rt") as f:
+        actual_digest = f.read().strip()
+    if actual_digest != digest:
+        valid = {
+            "version": 1,
+            "data": {
+                "status": "failure",
+                "message": f"Image digest {actual_digest} does not match expected {digest}",
+            },
+        }
+    else:
+        valid = {
+            "version": 1,
+            "data": {
+                "status": "success",
+                "message": f"Image digest {actual_digest} validated",
+            },
+        }
+    with open(stamp_path, "wt") as f:
+        json.dump(valid, f)
 
 
 if __name__ == "__main__":
-    make_image(sys.argv[1], sys.argv[2], sys.argv[3])
+    match sys.argv[1]:
+        case "build":
+            build_image(sys.argv[2], sys.argv[3], sys.argv[4], sys.argv[5])
+        case "check":
+            assert sys.argv[3] == "--digest", "Expected --digest argument but got: " + sys.argv[3]
+            check_digest(sys.argv[2], sys.argv[4], sys.argv[5])
+        case _:
+            raise RuntimeError("Expected 'build' or 'check' but got: " + sys.argv[1])


### PR DESCRIPTION
The checked-in digest enables building the image outside of a hermetic executor - needed to bootstrap the hermetic builder.