### PR TITLE
devcontainer: pin features via lockfile

### DIFF
--- a/.devcontainer/devcontainer-lock.json
+++ b/.devcontainer/devcontainer-lock.json
@@ -1,0 +1,19 @@
+{
+  "features": {
+    "ghcr.io/devcontainers/features/docker-outside-of-docker:1": {
+      "version": "1.10.0",
+      "resolved": "ghcr.io/devcontainers/features/docker-outside-of-docker@sha256:c2c2cf829505ead8e4892c88c31b6594ae94a2bbb209e16e1fac456c1a3a624e",
+      "integrity": "sha256:c2c2cf829505ead8e4892c88c31b6594ae94a2bbb209e16e1fac456c1a3a624e"
+    },
+    "ghcr.io/devcontainers/features/github-cli:1": {
+      "version": "1.1.0",
+      "resolved": "ghcr.io/devcontainers/features/github-cli@sha256:d22f50b70ed75339b4eed1ba9ecde3a1791f90e88d37936517e3bace0bbad671",
+      "integrity": "sha256:d22f50b70ed75339b4eed1ba9ecde3a1791f90e88d37936517e3bace0bbad671"
+    },
+    "ghcr.io/devcontainers/features/node:1": {
+      "version": "1.7.1",
+      "resolved": "ghcr.io/devcontainers/features/node@sha256:8c0de46939b61958041700ee89e3493f3b2e4131a06dc46b4d9423427d06e5f6",
+      "integrity": "sha256:8c0de46939b61958041700ee89e3493f3b2e4131a06dc46b4d9423427d06e5f6"
+    }
+  }
+}

--- a/renovate.json
+++ b/renovate.json
@@ -158,6 +158,17 @@
         "\"(?<depName>[^\":@]+):(?<currentValue>[^\"@]+)@(?<currentDigest>sha256:[0-9a-f]+)\""
       ],
       "datasourceTemplate": "docker"
+    },
+    {
+      "description": "devcontainer features are OCI artifacts on ghcr.io; version and digest come from the lockfile together.",
+      "customType": "regex",
+      "managerFilePatterns": [
+        "/^\\.devcontainer/devcontainer-lock\\.json$/"
+      ],
+      "matchStrings": [
+        "\"(?<depName>ghcr\\.io/devcontainers/features/[^\"]+):\\d+\":\\s*\\{\\s*\"version\":\\s*\"(?<currentValue>[^\"]+)\",\\s*\"resolved\":\\s*\"[^\"]+@(?<currentDigest>sha256:[0-9a-f]+)\",\\s*\"integrity\":\\s*\"sha256:[0-9a-f]+\""
+      ],
+      "datasourceTemplate": "docker"
     }
   ]
 }


### PR DESCRIPTION
devcontainer.json references features by floating :1 tags, so the exact bits installed depend on when the image is built.
The lockfile pins each feature to a version and sha256 digest.
A renovate customManagers regex over the lockfile proposes version and digest together straight from the registry, so the reviewed diff is exactly what gets installed — no post-proposal resolution step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)