### PR TITLE
third_party: cpython static musl build

### DIFF
--- a/third_party/python/BUCK
+++ b/third_party/python/BUCK
@@ -1,4 +1,4 @@
-load("//tools:defs.bzl", "cached_http_archive")
+load("//tools:defs.bzl", "cached_check", "cached_http_archive")
 
 export_file(
     name = "pin",
@@ -8,12 +8,23 @@ export_file(
 
 cached_http_archive(
     name = "cpython",
-    sha256 = "b442fb93903c6f3392b2430961d4725354ae0da7558c785a908d714264309b28",
-    # //tools/nativelink:worker_image depends on this through //tools:py, so
-    # a --local-only image build needs this unpack action on the hybrid
-    # platform too; every other consumer of //tools:py picks it up as well.
+    # python/install is the full interpreter tree (stdlib, headers, every
+    # C extension statically linked in — lib-dynload is empty); the sibling
+    # python/build is unrelated build-artifact output that paths excludes.
+    paths = ["python/install"],
+    sha256 = "3b3c3b571761e76497de602dec0c8a7c7046790b8ecc54b44862c8a6ecb27df5",
     exec_compatible_with = ["//platforms:image_build_enabled"],
-    strip_components = 1,
-    urls = ["https://github.com/astral-sh/python-build-standalone/releases/download/20260718/cpython-3.14.6+20260718-x86_64-unknown-linux-gnu-install_only.tar.gz"],
+    strip_components = 2,
+    urls = ["https://github.com/astral-sh/python-build-standalone/releases/download/20260623/cpython-3.14.6+20260623-x86_64-unknown-linux-musl-noopt+static-full.tar.zst"],
     visibility = ["PUBLIC"],
+)
+
+cached_check(
+    name = "cpython_layout_test",
+    exe = "//tools:py",
+    srcs = [
+        "cpython_layout_test.py",
+        ":cpython",
+        ":pin",
+    ],
 )

--- a/third_party/python/cpython_layout_test.py
+++ b/third_party/python/cpython_layout_test.py
@@ -1,0 +1,24 @@
+"""Property checks for the pinned cpython tree.
+
+argv[1] is the :cpython output directory, argv[2] the pin file (read for
+the version, so a renovate bump never makes this fail spuriously), argv[3]
+the output to touch on success.
+"""
+
+import os
+import re
+import sys
+
+root, pin_path = sys.argv[1], sys.argv[2]
+
+pin = open(pin_path, encoding="utf-8").read()
+m = re.search(r"cpython-(\d+)\.(\d+)\.\d+\+", pin)
+assert m, "no cpython version pinned in " + pin_path
+binary = "python" + m.group(1) + "." + m.group(2)
+
+assert os.path.isfile(os.path.join(root, "bin", binary)), "no interpreter at bin/" + binary
+assert not os.path.exists(os.path.join(root, "Modules")), (
+    "build-tree artifacts leaked into the pinned interpreter tree"
+)
+
+open(sys.argv[3], "w", encoding="utf-8").write("ok")

--- a/tools/defs.bzl
+++ b/tools/defs.bzl
@@ -53,11 +53,12 @@ def _cached_http_archive_impl(ctx: AnalysisContext) -> list[Provider]:
         sha256 = ctx.attrs.sha256,
     )
     out = ctx.actions.declare_output("out", dir = True)
-    script = 'mkdir -p "$2" && tar -x -f "$1" --strip-components={} -C "$2"'.format(
-        ctx.attrs.strip_components,
-    )
+    script = 'archive="$1"; out="$2"; shift 2; mkdir -p "$out" && ' + \
+             'tar -x -f "$archive" --strip-components={} -C "$out" "$@"'.format(
+                 ctx.attrs.strip_components,
+             )
     ctx.actions.run(
-        cmd_args("/bin/sh", "-c", script, "unpack", archive, out.as_output()),
+        cmd_args("/bin/sh", "-c", script, "unpack", archive, out.as_output(), ctx.attrs.paths),
         category = "cached_http_archive",
         allow_cache_upload = True,
     )
@@ -70,6 +71,8 @@ def _cached_http_archive_impl(ctx: AnalysisContext) -> list[Provider]:
 cached_http_archive = rule(
     impl = _cached_http_archive_impl,
     attrs = {
+        # Top-level archive paths to extract; empty extracts everything.
+        "paths": attrs.list(attrs.string(), default = []),
         "sha256": attrs.string(),
         "strip_components": attrs.int(default = 0),
         "sub_targets": attrs.list(attrs.string(), default = []),


### PR DESCRIPTION
The busybox-musl worker image has no dynamic linker, so a dynamically linked cpython — glibc or musl — cannot execute inside it; verified empirically inside a crun bundle built from the worker rootfs.
python-build-standalone publishes a statically linked musl build, but only inside its full build-artifact archive alongside an unrelated build tree; `cached_http_archive` gains a `paths` filter so only the install tree lands in the output.
Every buck2 consumer references the target, not the build variant, so nothing downstream changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)