### PR TITLE
buck2: run NativeLink under crun

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -65,6 +65,16 @@ jobs:
         run: sudo bash tools/buck2/install.sh /usr/local/bin
       - name: Install NativeLink
         run: sudo bash tools/nativelink/install.sh /usr/local/bin
+      # The buck2 launcher runs NativeLink inside a crun container built
+      # from the pinned worker layer.
+      - name: Install crun
+        run: sudo bash tools/crun/install.sh /usr/local/bin
+      # ubuntu-latest restricts unprivileged user-namespace creation by
+      # default; rootless crun needs one to build its container. The
+      # devcontainer instead grants this via --cap-add SYS_ADMIN + seccomp,
+      # which isn't available on a hosted runner.
+      - name: Allow unprivileged user namespaces
+        run: sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0
       # The buck2 launcher auto-starts NativeLink with this overlay, whose
       # stores write through to BuildBuddy (NativeLink holds the key).
       - name: Configure NativeLink BuildBuddy overlay

--- a/tools/buck2/buck2.sh
+++ b/tools/buck2/buck2.sh
@@ -4,6 +4,10 @@
 # Config selection: the gitignored `.nativelink.json5` at the repo root
 # (the BuildBuddy overlay, see tools/nativelink/config-bb.json5.template)
 # when present, else the committed local-only tools/nativelink/config.json5.
+#
+# tools/nativelink/crun-bundle-config.json.template is `crun spec --rootless`'s
+# output with NativeLink's overrides baked in — the omitted network namespace
+# is why buck2 can still reach NativeLink on 127.0.0.1:50051.
 set -euo pipefail
 
 # Outside a repo there is nothing to execute on; hand over directly.
@@ -29,7 +33,10 @@ if [[ -e "$root/.buckroot" ]] && no_daemon; then
 			>"$root/.buckconfig.prelaunch"
 	fi
 	bootstrap_rc=0
-	buck2-bin build --local-only //tools/nativelink:layer ||
+	# Output is sorted by target label, not listed order; the sed -n below relies on it.
+	outputs="$(buck2-bin build --local-only --show-full-simple-output \
+		//tools/nativelink:busybox //tools/nativelink:layer \
+		'//tools/nativelink:layer[layer][digest]')" ||
 		bootstrap_rc=$?
 	rm -f "$root/.buckconfig.prelaunch"
 	# The daemon that ran the bootstrap build is still bound to the
@@ -41,15 +48,44 @@ if [[ -e "$root/.buckroot" ]] && no_daemon; then
 			"failed; refusing to start NativeLink over unverified bytes" >&2
 		exit 1
 	fi
+	busybox="$(sed -n '1p' <<<"$outputs")"
+	layer_tar="$(sed -n '2p' <<<"$outputs")"
+	digest="$(cat "$(sed -n '3p' <<<"$outputs")")"
 
 	cfg="$root/.nativelink.json5"
 	[[ -f "$cfg" ]] || cfg="$root/tools/nativelink/config.json5"
-	mkdir -p "$HOME/.cache/causes-nativelink"
+	nl_cache="$HOME/.cache/causes-nativelink"
+	mkdir -p "$nl_cache/bin" "$nl_cache/xdg"
+	cp -f "$(command -v nativelink)" "$nl_cache/bin/nativelink"
+	cp -f "$cfg" "$nl_cache/config.json5"
+
+	rootfs="$nl_cache/rootfs-$digest"
+	if [[ ! -d "$rootfs" ]]; then
+		tmp_rootfs="$(mktemp -d "$nl_cache/rootfs-$digest.XXXXXX")"
+		"$busybox" tar x -f "$layer_tar" -C "$tmp_rootfs"
+		mv -T "$tmp_rootfs" "$rootfs"
+	fi
+
+	bundle="$nl_cache/crun-bundle"
+	rm -rf "$bundle"
+	mkdir -p "$bundle"
+	sed \
+		-e "s|@ROOTFS@|$rootfs|g" \
+		-e "s|@HOME@|$HOME|g" \
+		-e "s|@NL_CACHE@|$nl_cache|g" \
+		-e "s|@HOST_UID@|$(id -u)|g" \
+		-e "s|@HOST_GID@|$(id -g)|g" \
+		"$root/tools/nativelink/crun-bundle-config.json.template" \
+		>"$bundle/config.json"
+
+	container="causes-nativelink-$digest"
+	export XDG_RUNTIME_DIR="$nl_cache/xdg"
+	crun delete -f "$container" >/dev/null 2>&1 || true
 	(
 		flock -n 9 || exit 0
-		nohup nativelink "$cfg" \
-			>>"$HOME/.cache/causes-nativelink/nativelink.log" 2>&1 &
-	) 9>"$HOME/.cache/causes-nativelink/launch.lock"
+		crun run --bundle "$bundle" --detach --no-new-keyring "$container" \
+			>>"$nl_cache/nativelink.log" 2>&1
+	) 9>"$nl_cache/launch.lock"
 	for _ in $(seq 100); do
 		(exec 3<>/dev/tcp/127.0.0.1/50051) 2>/dev/null && break
 		sleep 0.1

--- a/tools/nativelink/crun-bundle-config.json.template
+++ b/tools/nativelink/crun-bundle-config.json.template
@@ -1,0 +1,210 @@
+{
+  "ociVersion": "1.0.0",
+  "process": {
+    "terminal": false,
+    "user": {
+      "uid": 12021,
+      "gid": 0
+    },
+    "args": [
+      "@NL_CACHE@/bin/nativelink",
+      "@NL_CACHE@/config.json5"
+    ],
+    "env": [
+      "PATH=/bin",
+      "HOME=@HOME@",
+      "XDG_RUNTIME_DIR=@NL_CACHE@/xdg"
+    ],
+    "cwd": "/",
+    "capabilities": {
+      "bounding": [
+        "CAP_AUDIT_WRITE",
+        "CAP_KILL",
+        "CAP_NET_BIND_SERVICE"
+      ],
+      "effective": [
+        "CAP_AUDIT_WRITE",
+        "CAP_KILL",
+        "CAP_NET_BIND_SERVICE"
+      ],
+      "inheritable": [],
+      "permitted": [
+        "CAP_AUDIT_WRITE",
+        "CAP_KILL",
+        "CAP_NET_BIND_SERVICE"
+      ],
+      "ambient": [
+        "CAP_AUDIT_WRITE",
+        "CAP_KILL",
+        "CAP_NET_BIND_SERVICE"
+      ]
+    },
+    "rlimits": [
+      {
+        "type": "RLIMIT_NOFILE",
+        "hard": 1024,
+        "soft": 1024
+      }
+    ],
+    "noNewPrivileges": true
+  },
+  "root": {
+    "path": "@ROOTFS@",
+    "readonly": true
+  },
+  "hostname": "crun",
+  "mounts": [
+    {
+      "destination": "/tmp",
+      "type": "tmpfs",
+      "source": "tmpfs",
+      "options": ["nosuid", "strictatime", "mode=1777"]
+    },
+    {
+      "destination": "/etc/resolv.conf",
+      "type": "bind",
+      "source": "/etc/resolv.conf",
+      "options": ["bind", "ro"]
+    },
+    {
+      "destination": "@NL_CACHE@",
+      "type": "bind",
+      "source": "@NL_CACHE@",
+      "options": ["bind", "rw"]
+    },
+    {
+      "destination": "/etc/ssl/certs/ca-certificates.crt",
+      "type": "bind",
+      "source": "/etc/ssl/certs/ca-certificates.crt",
+      "options": ["bind", "ro"]
+    },
+    {
+      "destination": "/proc",
+      "type": "proc",
+      "source": "proc"
+    },
+    {
+      "destination": "/dev",
+      "type": "tmpfs",
+      "source": "tmpfs",
+      "options": [
+        "nosuid",
+        "strictatime",
+        "mode=755",
+        "size=65536k"
+      ]
+    },
+    {
+      "destination": "/dev/pts",
+      "type": "devpts",
+      "source": "devpts",
+      "options": [
+        "nosuid",
+        "noexec",
+        "newinstance",
+        "ptmxmode=0666",
+        "mode=0620"
+      ]
+    },
+    {
+      "destination": "/dev/shm",
+      "type": "tmpfs",
+      "source": "shm",
+      "options": [
+        "nosuid",
+        "noexec",
+        "nodev",
+        "mode=1777",
+        "size=65536k"
+      ]
+    },
+    {
+      "destination": "/dev/mqueue",
+      "type": "mqueue",
+      "source": "mqueue",
+      "options": [
+        "nosuid",
+        "noexec",
+        "nodev"
+      ]
+    },
+    {
+      "destination": "/sys",
+      "type": "sysfs",
+      "source": "sysfs",
+      "options": [
+        "nosuid",
+        "noexec",
+        "nodev",
+        "ro"
+      ]
+    },
+    {
+      "destination": "/sys/fs/cgroup",
+      "type": "cgroup",
+      "source": "cgroup",
+      "options": [
+        "nosuid",
+        "noexec",
+        "nodev",
+        "relatime",
+        "ro"
+      ]
+    }
+  ],
+  "linux": {
+    "resources": {
+      "devices": [
+        {
+          "allow": false,
+          "access": "rwm"
+        }
+      ]
+    },
+    "namespaces": [
+      {
+        "type": "pid"
+      },
+      {
+        "type": "ipc"
+      },
+      {
+        "type": "uts"
+      },
+      {
+        "type": "user"
+      },
+      {
+        "type": "cgroup"
+      },
+      {
+        "type": "mount"
+      }
+    ],
+    "uidMappings": [
+      { "containerID": 12021, "hostID": @HOST_UID@, "size": 1 }
+    ],
+    "gidMappings": [
+      { "containerID": 0, "hostID": @HOST_GID@, "size": 1 }
+    ],
+    "maskedPaths": [
+      "/proc/acpi",
+      "/proc/asound",
+      "/proc/kcore",
+      "/proc/keys",
+      "/proc/latency_stats",
+      "/proc/timer_list",
+      "/proc/timer_stats",
+      "/proc/sched_debug",
+      "/sys/firmware",
+      "/proc/scsi"
+    ],
+    "readonlyPaths": [
+      "/proc/bus",
+      "/proc/fs",
+      "/proc/irq",
+      "/proc/sys",
+      "/proc/sysrq-trigger"
+    ]
+  }
+}


### PR DESCRIPTION
The launcher builds `//tools/nativelink:layer` for the bootstrap verification, extracts its tar into a plain rootfs directory (content-addressed by the tar's own sha256, reused across launches), assembles a rootless crun bundle (uid mapped to 12021, gid to 0, no network namespace removed so host networking is preserved, resolv.conf and the CA bundle bind-mounted for outbound fetches, the NativeLink binary/config/work dir bind-mounted in), and starts NativeLink via `crun run --detach` in place of a bare host process.
CI installs crun and relaxes ubuntu-latest's unprivileged user-namespace restriction, which the devcontainer instead grants via `--cap-add SYS_ADMIN` and a seccomp allowance.

Stacked on #506.

🤖 Generated with [Claude Code](https://claude.com/claude-code)