### PR TITLE
tools: cached_http_archive zstd support, fix directory-pattern extraction bug

### DIFF
--- a/third_party/python/BUCK
+++ b/third_party/python/BUCK
@@ -17,6 +17,7 @@ cached_http_archive(
     strip_components = 2,
     urls = ["https://github.com/astral-sh/python-build-standalone/releases/download/20260718/cpython-3.14.6+20260718-x86_64-unknown-linux-musl-noopt+static-full.tar.zst"],
     visibility = ["PUBLIC"],
+    zstd = "//third_party/zstd:zstd",
 )
 
 cached_check(

--- a/third_party/zstd/BUCK
+++ b/third_party/zstd/BUCK
@@ -1,0 +1,12 @@
+load("//tools:defs.bzl", "downloaded_tool")
+
+# Static Linux binary; no compiler is available to build zstd from source,
+# and upstream facebook/zstd only publishes source tarballs for Linux.
+downloaded_tool(
+    name = "zstd",
+    exec_compatible_with = ["//platforms:image_build_enabled"],
+    out = "zstd",
+    sha256 = "190c196b46883a234238d9c52a211c1494df79bb170fbe30c6fc22639d5d4731",
+    url = "https://github.com/aspect-build/zstd-prebuilt/releases/download/v1.5.6-bcr2/zstd_linux_amd64",
+    visibility = ["PUBLIC"],
+)

--- a/tools/defs.bzl
+++ b/tools/defs.bzl
@@ -40,6 +40,21 @@ tree_tool = rule(
     },
 )
 
+# A single sha256-pinned executable, runnable as an exec_dep.
+def _downloaded_tool_impl(ctx: AnalysisContext) -> list[Provider]:
+    out = ctx.actions.declare_output(ctx.attrs.out)
+    ctx.actions.download_file(out.as_output(), ctx.attrs.url, sha256 = ctx.attrs.sha256, is_executable = True)
+    return [DefaultInfo(default_output = out), RunInfo(args = cmd_args(out))]
+
+downloaded_tool = rule(
+    impl = _downloaded_tool_impl,
+    attrs = {
+        "out": attrs.string(),
+        "sha256": attrs.string(),
+        "url": attrs.string(),
+    },
+)
+
 # http_archive whose unpacked tree is remotely cached.
 # The prelude's http_archive never sets `allow_cache_upload` on its unpack
 # action, so its output can be read from the cache but never repopulates it.
@@ -53,12 +68,37 @@ def _cached_http_archive_impl(ctx: AnalysisContext) -> list[Provider]:
         sha256 = ctx.attrs.sha256,
     )
     out = ctx.actions.declare_output("out", dir = True)
-    script = 'archive="$1"; out="$2"; shift 2; mkdir -p "$out" && ' + \
-             'tar -x -f "$archive" --strip-components={} -C "$out" "$@"'.format(
-                 ctx.attrs.strip_components,
-             )
+    if ctx.attrs.zstd:
+        # tar has no zstd support on the platforms this runs on; decompress
+        # through the pinned zstd tool first and hand tar a plain stream.
+        extract = '"$zstd" -dc "$archive" | tar -x -f - -C "{dest}"'
+        tool_args = [ctx.attrs.zstd[RunInfo]]
+        arg_prefix = 'zstd="$1"; archive="$2"; out="$3"; shift 3'
+    else:
+        extract = 'tar -x -f "$archive" -C "{dest}"'
+        tool_args = []
+        arg_prefix = 'archive="$1"; out="$2"; shift 2'
+
+    if ctx.attrs.paths:
+        # tar's own path-selection argument is broken for directory
+        # entries on the platforms this runs on: it extracts them fine but
+        # still reports "not found" and exits nonzero. Extract everything
+        # to a scratch dir and move the wanted (already
+        # `strip_components`-deep) subtrees' entries out by hand instead.
+        # paths must be disjoint (no path nested under another), since
+        # entries from each land directly in the shared "$out".
+        script = arg_prefix + '; tmp="$(mktemp -d)"; mkdir -p "$out" && ' + \
+                 extract.format(dest = "$tmp") + " && " + \
+                 'for p in "$@"; do for e in "$tmp/$p"/* "$tmp/$p"/.[!.]* "$tmp/$p"/..?*; do ' + \
+                 '[ -e "$e" ] && mv "$e" "$out/"; done; done; true'
+    else:
+        script = arg_prefix + '; mkdir -p "$out" && ' + \
+                 extract.format(dest = "$out") + \
+                 ' --strip-components={} "$@"'.format(ctx.attrs.strip_components)
+
+    cmd = cmd_args(*(["/bin/sh", "-c", script, "unpack"] + tool_args + [archive, out.as_output()] + ctx.attrs.paths))
     ctx.actions.run(
-        cmd_args("/bin/sh", "-c", script, "unpack", archive, out.as_output(), ctx.attrs.paths),
+        cmd,
         category = "cached_http_archive",
         allow_cache_upload = True,
     )
@@ -77,5 +117,7 @@ cached_http_archive = rule(
         "strip_components": attrs.int(default = 0),
         "sub_targets": attrs.list(attrs.string(), default = []),
         "urls": attrs.list(attrs.string()),
+        # Set when the archive needs zstd decompression tar can't do itself.
+        "zstd": attrs.option(attrs.exec_dep(providers = [RunInfo]), default = None),
     },
 )


### PR DESCRIPTION
## Summary
- Adds an optional `zstd` exec_dep to `cached_http_archive` for archives busybox's tar can't decompress (e.g. cpython's pinned `.tar.zst`).
- Fixes a separate, pre-existing bug in the same rule: tar's own path-selection pattern (`paths` attr) doesn't work for directory entries on the platforms this runs on — it extracts the entries fine but still reports "not found" and exits nonzero. Now extracts everything to a scratch dir and moves the wanted subtrees' entries out by hand.
- Adds `third_party/zstd:zstd`, a pinned static zstd binary (aspect-build/zstd-prebuilt — no compiler is available to build zstd from source, and upstream facebook/zstd only publishes source tarballs for Linux).
- Wires `cpython`'s `cached_http_archive` to use it.

## Test plan
- [x] `bash tools/check.sh` passes.
- [x] Verified via real buck2 build through the crun-hosted NativeLink worker: `cpython` unpacks correctly, `python3 --version` reports `Python 3.14.6`.
