### PR TITLE
nativelink: raise the crun worker's fd limit, add an upload timeout

### DIFF
--- a/tools/nativelink/config-bb.json5.template
+++ b/tools/nativelink/config-bb.json5.template
@@ -97,6 +97,9 @@
         cas_fast_slow_store: "WORKER_FAST_SLOW_STORE",
         upload_action_result: { ac_store: "AC_MAIN_STORE" },
         work_directory: "${HOME}/.cache/causes-nativelink/work",
+        // Default is 10 minutes; a stuck upload silently hangs a build for
+        // that long instead of failing loud with DeadlineExceeded.
+        max_upload_timeout_s: 60,
         platform_properties: {
           cpu_count: { query_cmd: "nproc" },
           OSFamily: { query_cmd: "uname -s" },

--- a/tools/nativelink/config.json5
+++ b/tools/nativelink/config.json5
@@ -61,6 +61,9 @@
         cas_fast_slow_store: "WORKER_FAST_SLOW_STORE",
         upload_action_result: { ac_store: "AC_MAIN_STORE" },
         work_directory: "${HOME}/.cache/causes-nativelink/work",
+        // Default is 10 minutes; a stuck upload silently hangs a build for
+        // that long instead of failing loud with DeadlineExceeded.
+        max_upload_timeout_s: 60,
         platform_properties: {
           cpu_count: { query_cmd: "nproc" },
           OSFamily: { query_cmd: "uname -s" },

--- a/tools/nativelink/crun-bundle-config.json.template
+++ b/tools/nativelink/crun-bundle-config.json.template
@@ -42,8 +42,8 @@
     "rlimits": [
       {
         "type": "RLIMIT_NOFILE",
-        "hard": 1024,
-        "soft": 1024
+        "hard": 24576,
+        "soft": 24576
       }
     ],
     "noNewPrivileges": true


### PR DESCRIPTION
## Summary
- Raises the crun worker bundle's `RLIMIT_NOFILE` from 1024 to 24576 (matched to NativeLink's own recommended value). At 1024, NativeLink deadlocks uploading any action output with enough concurrent files (~5,200+) to exhaust its `OPEN_FILE_SEMAPHORE` — filed upstream: [TraceMachina/nativelink#2636](https://github.com/TraceMachina/nativelink/issues/2636). 1024 was inherited unmodified from `crun spec --rootless`'s boilerplate, never tuned for NativeLink's workload.
- Adds `max_upload_timeout_s: 60` (default is 10 minutes) so a stuck upload fails loud and fast instead of silently hanging a build for up to 10 minutes.

## Test plan
- [x] `bash tools/check.sh` passes.
- [x] Verified via real buck2 build through the crun-hosted NativeLink worker: `cpython` (real ~5,200-file, ~180MB unpack) now builds cleanly and fast with no stall.
- [x] Confirmed the underlying bug in isolation (bare host + minimal crun bundle bisection, no BUCK rule involved) — see linked upstream issue for full repro.
