### PR TITLE
nativelink: enable per-action namespace isolation

### DIFF
--- a/tools/nativelink/config-bb.json5.template
+++ b/tools/nativelink/config-bb.json5.template
@@ -100,6 +100,8 @@
         // Default is 10 minutes; a stuck upload silently hangs a build for
         // that long instead of failing loud with DeadlineExceeded.
         max_upload_timeout_s: 60,
+        use_namespaces: true,
+        use_mount_namespace: true,
         platform_properties: {
           cpu_count: { query_cmd: "nproc" },
           OSFamily: { query_cmd: "uname -s" },

--- a/tools/nativelink/config.json5
+++ b/tools/nativelink/config.json5
@@ -64,6 +64,8 @@
         // Default is 10 minutes; a stuck upload silently hangs a build for
         // that long instead of failing loud with DeadlineExceeded.
         max_upload_timeout_s: 60,
+        use_namespaces: true,
+        use_mount_namespace: true,
         platform_properties: {
           cpu_count: { query_cmd: "nproc" },
           OSFamily: { query_cmd: "uname -s" },


### PR DESCRIPTION
## Summary
- Enables `use_namespaces: true` and `use_mount_namespace: true` on the local worker. NativeLink's own docs recommend both ("avoids a number of issues with zombie processes and also provides additional hermeticity"); neither was previously set, so each action ran without NativeLink's own per-action namespace isolation — only the outer crun container (which isolates NativeLink itself from the checkout) was in effect.
- This is a nested unprivileged user+mount namespace, created by NativeLink from within the already-unprivileged user namespace crun gives it. Confirmed working, not blocked by the AppArmor unprivileged-userns restriction that affected the first (outer) namespace level.

## Test plan
- [x] `bash tools/check.sh` passes.
- [x] Verified via real buck2 build through the crun-hosted NativeLink worker with both settings enabled: worker starts and registers with the scheduler with no error.
- [x] Forced a genuine fresh (non-cached) execution of the full worker-image subgraph (`busybox`, `rootfs`, `crane`, `cpython`, `layer` build + digest validation) — all 6 actions succeed.
- [x] Confirmed the outer container's own checkout isolation is unaffected (`ls /workspaces` inside the running container still fails with "No such file or directory").
