### PR TITLE
nativelink: tie action cache to image digest

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -61,6 +61,35 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7
+        with:
+          fetch-depth: 10
+      # See tools/nativelink/README.md, "Changing the rootfs digest".
+      - name: Check whether the rootfs digest pin changed
+        id: pin_check
+        run: |
+          pin_changed=false
+          base=""
+          head=""
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            base="${{ github.event.pull_request.base.sha }}"
+            head="${{ github.event.pull_request.head.sha }}"
+          elif [ "${{ github.event_name }}" = "merge_group" ]; then
+            base="${{ github.event.merge_group.base_sha }}"
+            head="${{ github.event.merge_group.head_sha }}"
+          fi
+          if [ -n "$base" ]; then
+            # fetch-depth: 10 must reach both commits; fail loud rather
+            # than have a shallow-history "unknown revision" error get
+            # swallowed by the `!` below and misread as pin_changed=true.
+            git cat-file -e "$base^{commit}"
+            git cat-file -e "$head^{commit}"
+            if ! git diff --quiet "$base" "$head" -- tools/nativelink/pin.bzl; then
+              pin_changed=true
+            fi
+          fi
+          echo "orig_head=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+          echo "base=$base" >> "$GITHUB_OUTPUT"
+          echo "pin_changed=$pin_changed" >> "$GITHUB_OUTPUT"
       - name: Install buck2
         run: sudo bash tools/buck2/install.sh /usr/local/bin
       - name: Install NativeLink
@@ -92,6 +121,37 @@ jobs:
         run: |
           sed "s/YOUR_KEY_HERE/${BUILDBUDDY_API_KEY}/" \
             .buckconfig.local.template > .buckconfig.local
+      - name: "Rootfs digest change: trigger executor start with the previous pin"
+        if: steps.pin_check.outputs.pin_changed == 'true'
+        run: |
+          git checkout "${{ steps.pin_check.outputs.base }}"
+          # pin.bzl may not exist yet at base (e.g. the PR that introduces
+          # it): fall back to the digest's previous location, the literal
+          # worker_layer(digest = "...") in tools/nativelink/BUCK.
+          if [ -f tools/nativelink/pin.bzl ]; then
+            old_digest="$(grep -oP 'WORKER_LAYER_DIGEST = "\K[a-f0-9]+' tools/nativelink/pin.bzl)"
+          else
+            old_digest="$(grep -oP 'digest = "\K[a-f0-9]+' tools/nativelink/BUCK)"
+          fi
+          echo "OLD_LAYER_DIGEST=$old_digest" >> "$GITHUB_ENV"
+          buck2 targets //...
+      # Restores the exact commit the initial checkout put in place (the
+      # PR's merge-preview commit, or the merge-queue's combined commit),
+      # not head.sha directly — the rest of the job must keep testing
+      # what every other run tests, not the unmerged branch tip.
+      - name: "Rootfs digest change: switch to the build head"
+        if: steps.pin_check.outputs.pin_changed == 'true'
+        run: git checkout "${{ steps.pin_check.outputs.orig_head }}"
+      - name: "Rootfs digest change: validate new pin builds hermetically on the old worker"
+        if: steps.pin_check.outputs.pin_changed == 'true'
+        run: |
+          buck2 build --remote-only \
+            -c image_build.container_image="$OLD_LAYER_DIGEST" \
+            '//tools/nativelink:layer[layer][digest]'
+      - name: "Rootfs digest change: retire the old worker"
+        if: steps.pin_check.outputs.pin_changed == 'true'
+        run: |
+          buck2 kill
       # --remote-only: CI is the trusted executor environment, so every
       # action — including the hybrid image-build platform's — runs on
       # NativeLink and warms the shared cache; nothing here executes local.

--- a/platforms/BUCK
+++ b/platforms/BUCK
@@ -1,3 +1,4 @@
+load("//tools/nativelink:pin.bzl", "WORKER_LAYER_DIGEST")
 load(":defs.bzl", "image_build_platform", "platform_group", "remote_cache_platform")
 
 remote_cache_platform(
@@ -20,6 +21,7 @@ constraint_value(
 
 image_build_platform(
     name = "image_build",
+    container_image = WORKER_LAYER_DIGEST,
     cpu_configuration = "prelude//cpu:x86_64",
     image_build_marker = ":image_build_enabled",
     os_configuration = "prelude//os:linux",

--- a/platforms/defs.bzl
+++ b/platforms/defs.bzl
@@ -75,6 +75,13 @@ def _image_build_impl(ctx: AnalysisContext) -> list[Provider]:
     # .buckconfig.prelaunch (see tools/buck2/buck2.sh) when a key is present.
     has_cache_key = read_config("buck2_re_client", "http_headers") != None
 
+    # Overridable so a rootfs-digest-change validation build can target the
+    # still-running worker from the *previous* pin (see the "Changing the
+    # rootfs digest" section of tools/nativelink/README.md) while the
+    # target being built reads the new pin from source.
+    container_image_override = read_config("image_build", "container_image")
+    container_image = container_image_override if container_image_override != None else ctx.attrs.container_image
+
     platform = ExecutionPlatformInfo(
         label = name,
         configuration = cfg,
@@ -84,7 +91,7 @@ def _image_build_impl(ctx: AnalysisContext) -> list[Provider]:
             use_limited_hybrid = True,
             remote_cache_enabled = has_cache_key,
             allow_cache_uploads = False,
-            remote_execution_properties = {},
+            remote_execution_properties = {"container-image": container_image},
             remote_execution_use_case = "buck2-default",
             use_windows_path_separators = False,
         ),
@@ -102,6 +109,7 @@ def _image_build_impl(ctx: AnalysisContext) -> list[Provider]:
 image_build_platform = rule(
     impl = _image_build_impl,
     attrs = {
+        "container_image": attrs.string(doc = "Worker layer digest; bumping it invalidates the AC for image_build actions"),
         "cpu_configuration": attrs.dep(providers = [ConfigurationInfo]),
         "image_build_marker": attrs.dep(providers = [ConstraintValueInfo]),
         "os_configuration": attrs.dep(providers = [ConfigurationInfo]),

--- a/tools/buck2/buck2.sh
+++ b/tools/buck2/buck2.sh
@@ -57,7 +57,11 @@ if [[ -e "$root/.buckroot" ]] && no_daemon; then
 	nl_cache="$HOME/.cache/causes-nativelink"
 	mkdir -p "$nl_cache/bin" "$nl_cache/xdg"
 	cp -f "$(command -v nativelink)" "$nl_cache/bin/nativelink"
-	cp -f "$cfg" "$nl_cache/config.json5"
+	# Advertised as the container-image platform property (see
+	# platforms/defs.bzl) so buck2 bakes it into every image_build action's
+	# digest, and bumping the pin invalidates NativeLink's cache for
+	# actions that ran under the old image.
+	sed -e "s|@LAYER_DIGEST@|$digest|g" "$cfg" >"$nl_cache/config.json5"
 
 	rootfs="$nl_cache/rootfs-$digest"
 	if [[ ! -d "$rootfs" ]]; then

--- a/tools/nativelink/BUCK
+++ b/tools/nativelink/BUCK
@@ -1,6 +1,7 @@
 load("//tools:defs.bzl", "cached_check")
 load("//tools/nativelink:busybox.bzl", "busybox")
 load("//tools/nativelink:layer.bzl", "worker_layer")
+load("//tools/nativelink:pin.bzl", "WORKER_LAYER_DIGEST")
 load("//tools/nativelink:rootfs.bzl", "busybox_rootfs")
 
 # exec_compatible_with routes the whole worker-image subgraph (this target
@@ -39,7 +40,7 @@ cached_check(
 
 worker_layer(
     name = "layer",
-    digest = "fc1afd47c55bb3a8b26ce67c63ad58c624d184eef2f1f4982b2c7387eb415d77",
+    digest = WORKER_LAYER_DIGEST,
     exec_compatible_with = ["//platforms:image_build_enabled"],
     py = "//tools:py",
     rootfs = ":rootfs",

--- a/tools/nativelink/README.md
+++ b/tools/nativelink/README.md
@@ -11,3 +11,47 @@ The bind mount permits NativeLink to be updated without changing the rootfs, whi
 
 `config.json5` is used to configure NativeLink.
 When BuildBuddy is in use, `config-bb.json5.template` is used to generate `.nativelink.json5` (gitignored) with the BuildBuddy API key.
+
+## Changing the rootfs digest
+
+`pin.bzl`'s `WORKER_LAYER_DIGEST` is the single source of truth for the worker image.
+It feeds two independent things: `tools/nativelink/BUCK`'s `worker_layer` validates that `:layer_build`'s output hashes to this value, and `platforms/BUCK`'s `image_build` platform advertises it as the `container-image` remote-execution property on every `image_build`-platform action (see `platforms/defs.bzl`).
+
+The scheduler's `container-image` property type is `exact` (`config.json5`, `config-bb.json5.template`), not `priority`: a mismatched request simply can't schedule, rather than running anyway and filing its result under the wrong image's label.
+That's deliberate — it's what makes a cached action result trustworthy as "produced by this image."
+A looser type like `priority` would still bust the cache on a digest bump (the property is baked into the action's hash client-side, independent of the scheduler's matching mode), but wouldn't stop a mismatched worker from actually executing the request.
+
+The consequence: the worker construction actions (`:busybox`, `:rootfs`, `:layer_build`) are themselves `image_build`-platform actions, so they too request `container-image = <current pin>` and can only run on a worker already advertising that exact digest.
+That's fine for steady state (build normally, worker and pin already agree), but it means a bare `buck2 build //tools/nativelink:layer` done right after bumping the pin can't prove much: NativeLink hasn't been restarted yet, so nothing advertises the new digest, and the construction actions fall back to local execution (`image_build` has `local_enabled = True` for exactly this reason) rather than exercising the remote worker at all.
+Bare local execution also means construction never proves the new rootfs can be built using only tools present in an *already-running* (old) image — that a pin bump doesn't silently start requiring something the current worker doesn't have, i.e. that the image can always bootstrap its own successor.
+
+To actually validate a digest bump before committing to it, run the new rootfs's construction *on the still-live old worker*, with the platform's advertised digest deliberately pointed at the old value while the content being built and checked comes from the new pin already in source.
+`platforms/defs.bzl`'s `container_image` supports this via a `-c` override that takes priority over the `pin.bzl`-derived default:
+
+```sh
+# 1. On master (old pin), start a normal session — NativeLink comes up
+#    advertising the old digest.
+buck2 build //...
+
+# 2. Switch the working copy to the PR (new pin), without touching the
+#    running buck2 daemon or NativeLink.
+jj edit <pr-branch>
+
+# 3. Force the construction/validation actions onto the still-running old
+#    worker by pinning the platform property to the OLD digest, while the
+#    actions themselves build and check against whatever pin.bzl says now
+#    (the new digest). A pass here proves the new rootfs is buildable and
+#    hermetic using only the old image's tools.
+buck2 build -c image_build.container_image=<old-digest> \
+  '//tools/nativelink:layer[layer][digest]'
+
+# 4. Only now is it safe to retire the old worker.
+buck2 kill
+
+# 5. Fresh boot picks up the new pin for both the worker's advertised
+#    digest and every action's requested digest; run the full suite to
+#    catch regressions under the new image.
+buck2 build //...
+```
+
+If step 3 fails, the new rootfs isn't safely buildable from the current image — fix that before merging the pin bump, not after.

--- a/tools/nativelink/config-bb.json5.template
+++ b/tools/nativelink/config-bb.json5.template
@@ -85,7 +85,7 @@
         supported_platform_properties: {
           cpu_count: "minimum",
           OSFamily: "priority",
-          "container-image": "priority",
+          "container-image": "exact",
         },
       },
     },
@@ -103,7 +103,7 @@
         platform_properties: {
           cpu_count: { query_cmd: "nproc" },
           OSFamily: { query_cmd: "uname -s" },
-          "container-image": { values: [""] },
+          "container-image": { values: ["@LAYER_DIGEST@"] },
         },
       },
     },

--- a/tools/nativelink/config.json5
+++ b/tools/nativelink/config.json5
@@ -49,7 +49,7 @@
         supported_platform_properties: {
           cpu_count: "minimum",
           OSFamily: "priority",
-          "container-image": "priority",
+          "container-image": "exact",
         },
       },
     },
@@ -67,7 +67,7 @@
         platform_properties: {
           cpu_count: { query_cmd: "nproc" },
           OSFamily: { query_cmd: "uname -s" },
-          "container-image": { values: [""] },
+          "container-image": { values: ["@LAYER_DIGEST@"] },
         },
       },
     },

--- a/tools/nativelink/pin.bzl
+++ b/tools/nativelink/pin.bzl
@@ -1,0 +1,6 @@
+# Single source of truth for the pinned worker layer's content digest,
+# shared between tools/nativelink/BUCK (the layer's own validation pin) and
+# platforms/BUCK (so bumping this digest also changes the container-image
+# property baked into every image_build action, invalidating NativeLink's
+# action cache for actions that ran under the old image).
+WORKER_LAYER_DIGEST = "fc1afd47c55bb3a8b26ce67c63ad58c624d184eef2f1f4982b2c7387eb415d77"


### PR DESCRIPTION
## Summary

- Advertises the pinned worker-layer digest as an exact-match `container-image` remote-execution property on every `image_build` action, so action-cache entries are genuinely tied to the image they ran under.
- Adds a `-c image_build.container_image=<digest>` override so a validation build can target the still-running previous-digest worker while building the new pin from source.
- Wires the resulting transition procedure into CI: a PR or merge-queue entry that changes `tools/nativelink/pin.bzl` builds at the base commit first, forces the new rootfs's construction onto the still-old worker (proving it's buildable using only the previous image's tools), then retires that worker before the normal full build runs.
- Documents the why/how in `tools/nativelink/README.md`, "Changing the rootfs digest", for anyone doing this manually.

## Test plan

- [x] `buck2 build //...` succeeds under `exact` matching (steady state, worker and pin agree).
- [x] A mismatched `-c image_build.container_image=<wrong digest>` build hangs unschedulable, confirming `exact` is enforced (fresh daemon, no stale config-node caching).
- [x] A matching override dispatches via remote execution and hits cache on rebuild.
- [x] `buck2 targets //...` alone triggers the launcher's NativeLink bootstrap (used in the CI dance's first step, no full build needed).
- [x] `bash -n` on the extracted `pin_check` step's shell body.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
