### PR TITLE
tools, infra: decompose top-level packages into per-directory ones

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -156,7 +156,9 @@ _FORMAT_PACKAGES = [
     "//build/patches:",
     "//docs:",
     "//infra:",
+    "//infra/github:",
     "//infra/postgres:",
+    "//infra/terraform:",
     "//lib/rust/api_db:",
     "//lib/rust/causes_mcp:",
     "//lib/rust/causes_proto:",
@@ -168,6 +170,8 @@ _FORMAT_PACKAGES = [
     "//tools:",
     "//tools/lint:",
     "//tools/proto-gen:",
+    "//tools/renovate:",
+    "//tools/sqlx-cli:",
 ]
 
 # Aggregate each language's per-package filegroups into one non-empty filegroup.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,7 +29,7 @@ bazel run //:format                   # format all source files in-place
 bazel run //:format.check             # check formatting without changes (what CI runs)
 bazel run //infra/postgres:psql -- …  # hermetic psql
 bazel run //infra:tofu -- <module> …  # hermetic OpenTofu (e.g. infra/terraform, infra/github)
-bazel run //tools:sqlx -- …           # hermetic sqlx-cli
+bazel run //tools/sqlx-cli:sqlx -- …  # hermetic sqlx-cli
 bazel run //tools:cargo -- …          # hermetic cargo (metadata only, not compilation)
 ```
 

--- a/infra/BUILD.bazel
+++ b/infra/BUILD.bazel
@@ -1,6 +1,5 @@
 load("@rules_shell//shell:sh_binary.bzl", "sh_binary")
 load("//tools/lint:format_check.bzl", "format_srcs")
-load("//tools/lint:linters.bzl", "markdown_lint_test")
 
 # Run the AWS CLI.
 # Usage: bazel run //infra:aws -- sts get-caller-identity
@@ -32,16 +31,6 @@ sh_binary(
 sh_binary(
     name = "deploy",
     srcs = ["deploy.sh"],
-)
-
-markdown_lint_test(
-    name = "pymarkdown",
-    srcs = ["terraform/README.md"],
-)
-
-markdown_lint_test(
-    name = "pymarkdown_github",
-    srcs = ["github/README.md"],
 )
 
 format_srcs()

--- a/infra/github/BUILD.bazel
+++ b/infra/github/BUILD.bazel
@@ -1,0 +1,9 @@
+load("//tools/lint:format_check.bzl", "format_srcs")
+load("//tools/lint:linters.bzl", "markdown_lint_test")
+
+markdown_lint_test(
+    name = "pymarkdown",
+    srcs = ["README.md"],
+)
+
+format_srcs()

--- a/infra/terraform/BUILD.bazel
+++ b/infra/terraform/BUILD.bazel
@@ -1,0 +1,9 @@
+load("//tools/lint:format_check.bzl", "format_srcs")
+load("//tools/lint:linters.bzl", "markdown_lint_test")
+
+markdown_lint_test(
+    name = "pymarkdown",
+    srcs = ["README.md"],
+)
+
+format_srcs()

--- a/services/causes_api/README.md
+++ b/services/causes_api/README.md
@@ -123,7 +123,7 @@ Run migrations manually:
 
 ```sh
 DATABASE_URL=postgresql://causes:causes@localhost:5432/causes \
-  bazel run //tools:sqlx -- migrate run \
+  bazel run //tools/sqlx-cli:sqlx -- migrate run \
   --source lib/rust/api_db/migrations
 ```
 

--- a/tools/BUILD.bazel
+++ b/tools/BUILD.bazel
@@ -1,7 +1,6 @@
 load("@rules_python//python:defs.bzl", "py_binary", "py_library", "py_test")
 load("@rules_shell//shell:sh_binary.bzl", "sh_binary")
 load("@rules_shell//shell:sh_test.bzl", "sh_test")
-load("//build:rust.bzl", "rust_binary")
 load("//tools/lint:format_check.bzl", "format_srcs")
 load("//tools/lint:linters.bzl", "markdown_lint_test")
 
@@ -28,34 +27,6 @@ py_binary(
     name = "show_coverage",
     srcs = ["show_coverage.py"],
     main = "show_coverage.py",
-)
-
-# Hermetic sqlx binary compiled from tools/sqlx-cli via the crate_index.
-# Bazel caches and invalidates this like any other rust_binary target.
-rust_binary(
-    name = "sqlx_bin",
-    srcs = ["sqlx-cli/src/main.rs"],
-    edition = "2021",
-    visibility = ["//visibility:public"],
-    deps = [
-        "@crates//:clap",
-        "@crates//:console",
-        "@crates//:sqlx",
-        "@crates//:sqlx-cli",
-        "@crates//:tokio",
-    ],
-)
-
-# Run the hermetic sqlx binary.
-# DATABASE_URL must be set (or present in .env) for migrate.
-#   bazel run //tools:sqlx -- migrate run
-sh_binary(
-    name = "sqlx",
-    srcs = ["sqlx.sh"],
-    data = [
-        ":sqlx_bin",
-        "@bazel_tools//tools/bash/runfiles",
-    ],
 )
 
 # Run the hermetic cargo binary from the rules_rs toolchain.
@@ -161,24 +132,6 @@ sh_test(
 )
 
 sh_test(
-    name = "update_archive_sha_test",
-    srcs = ["renovate/update_archive_sha_test.sh"],
-    data = [
-        "renovate/update_archive_sha.sh",
-        "@bazel_tools//tools/bash/runfiles",
-    ],
-)
-
-sh_test(
-    name = "update_sha_test",
-    srcs = ["renovate/update_sha_test.sh"],
-    data = [
-        "renovate/update_sha.sh",
-        "@bazel_tools//tools/bash/runfiles",
-    ],
-)
-
-sh_test(
     name = "install_release_test",
     srcs = ["install_release_test.sh"],
     data = [
@@ -206,10 +159,10 @@ py_test(
         "proto_gen_impl.sh",
         "rustc.sh",
         "rustfmt.sh",
-        "sqlx.sh",
         "sqlx_prepare_check.sh",
         "sqlx_prepare_update.sh",
         "toolchain_versions_test.sh",
+        "//tools/sqlx-cli:sqlx.sh",
     ],
     main = "agent_action_guard_test.py",
     deps = [":agent_action_guard"],

--- a/tools/agent_action_guard.py
+++ b/tools/agent_action_guard.py
@@ -54,7 +54,7 @@ NATIVE_TOOLS = {
     "rustfmt": "bazel run //:format (or //tools:rustfmt)",
     # Database.
     "psql": "bazel run //infra/postgres:psql -- …",
-    "sqlx": "bazel run //tools:sqlx -- …",
+    "sqlx": "bazel run //tools/sqlx-cli:sqlx -- …",
     # Infrastructure.
     "tofu": "bazel run //infra:tofu -- …",
     "terraform": "bazel run //infra:tofu -- … (the repo uses OpenTofu)",

--- a/tools/agent_action_guard_test.py
+++ b/tools/agent_action_guard_test.py
@@ -306,17 +306,17 @@ class HelperScriptsTest(unittest.TestCase):
         "cargo.sh",
         "rustc.sh",
         "rustfmt.sh",
-        "sqlx.sh",
         "proto_gen_impl.sh",
         "sqlx_prepare_check.sh",
         "sqlx_prepare_update.sh",
         "toolchain_versions_test.sh",
+        "sqlx-cli/sqlx.sh",
     )
 
     def test_helpers_are_not_blocked(self):
         here = os.path.dirname(os.path.abspath(__file__))
         for name in self.HELPERS:
-            path = os.path.join(here, name)
+            path = os.path.normpath(os.path.join(here, name))
             with open(path, encoding="utf-8") as handle:
                 content = handle.read()
             self.assertIsNone(decide(write(path, content)), f"helper should pass: {name}")

--- a/tools/renovate/BUILD.bazel
+++ b/tools/renovate/BUILD.bazel
@@ -1,0 +1,22 @@
+load("@rules_shell//shell:sh_test.bzl", "sh_test")
+load("//tools/lint:format_check.bzl", "format_srcs")
+
+sh_test(
+    name = "update_archive_sha_test",
+    srcs = ["update_archive_sha_test.sh"],
+    data = [
+        "update_archive_sha.sh",
+        "@bazel_tools//tools/bash/runfiles",
+    ],
+)
+
+sh_test(
+    name = "update_sha_test",
+    srcs = ["update_sha_test.sh"],
+    data = [
+        "update_sha.sh",
+        "@bazel_tools//tools/bash/runfiles",
+    ],
+)
+
+format_srcs()

--- a/tools/renovate/README.md
+++ b/tools/renovate/README.md
@@ -1,0 +1,9 @@
+# tools/renovate
+
+Scripts the `renovate-sha` CI workflow runs against a Renovate bump branch to fill in what Renovate itself can't compute (renovatebot/renovate#22183).
+
+- `update_sha.sh` — rewrite an installer script's pinned sha256 to match its pinned version's release asset.
+- `update_archive_sha.sh` — recompute pinned archive sha256s in a `BUCK` file or `MODULE.bazel` for URLs that changed vs. the base version.
+
+Invoked directly with `bash` from CI, not through a Bazel target: a partway-applied Renovate bump has a version/sha256 mismatch, which fails a Bazel build before these scripts could run to fix it.
+The `sh_test` targets here only cover the scripts themselves under `bazel test //...`.

--- a/tools/sqlx-cli/BUILD.bazel
+++ b/tools/sqlx-cli/BUILD.bazel
@@ -1,0 +1,35 @@
+load("@rules_shell//shell:sh_binary.bzl", "sh_binary")
+load("//build:rust.bzl", "rust_binary")
+load("//tools/lint:format_check.bzl", "format_srcs")
+
+exports_files(["sqlx.sh"])
+
+# Hermetic sqlx binary compiled from this crate via the crate_index.
+# Bazel caches and invalidates this like any other rust_binary target.
+rust_binary(
+    name = "sqlx_bin",
+    srcs = ["src/main.rs"],
+    edition = "2021",
+    visibility = ["//visibility:public"],
+    deps = [
+        "@crates//:clap",
+        "@crates//:console",
+        "@crates//:sqlx",
+        "@crates//:sqlx-cli",
+        "@crates//:tokio",
+    ],
+)
+
+# Run the hermetic sqlx binary.
+# DATABASE_URL must be set (or present in .env) for migrate.
+#   bazel run //tools/sqlx-cli:sqlx -- migrate run
+sh_binary(
+    name = "sqlx",
+    srcs = ["sqlx.sh"],
+    data = [
+        ":sqlx_bin",
+        "@bazel_tools//tools/bash/runfiles",
+    ],
+)
+
+format_srcs()

--- a/tools/sqlx-cli/README.md
+++ b/tools/sqlx-cli/README.md
@@ -1,0 +1,4 @@
+# tools/sqlx-cli
+
+Thin `main.rs` wrapping the `sqlx-cli` crate, compiled hermetically as `:sqlx_bin`.
+Run via the wrapper at `:sqlx` (`bazel run //tools/sqlx-cli:sqlx -- migrate run`), not directly — the wrapper `cd`s to the repo root before exec so sqlx-cli's own `.env` lookup finds `DATABASE_URL`.

--- a/tools/sqlx-cli/sqlx.sh
+++ b/tools/sqlx-cli/sqlx.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
-# Runs the hermetic sqlx binary built by //tools:sqlx_bin.
-# Usage: bazel run //tools:sqlx -- <sqlx args>
-#   e.g. bazel run //tools:sqlx -- migrate run
+# Runs the hermetic sqlx binary built by :sqlx_bin.
+# Usage: bazel run //tools/sqlx-cli:sqlx -- <sqlx args>
+#   e.g. bazel run //tools/sqlx-cli:sqlx -- migrate run
 set -euo pipefail
 
 # Standard Bazel 3-way runfiles init.
@@ -21,4 +21,4 @@ else
 fi
 
 cd "${BUILD_WORKSPACE_DIRECTORY}"
-exec "$(rlocation _main/tools/sqlx_bin)" "$@"
+exec "$(rlocation _main/tools/sqlx-cli/sqlx_bin)" "$@"

--- a/tools/sqlx_prepare.bzl
+++ b/tools/sqlx_prepare.bzl
@@ -182,7 +182,7 @@ def sqlx_prepare(name, crate, migrations):
         migrations = migrations,
         pg_extracted = "//infra/postgres:postgres_extracted",
         pg_fixture = "//infra/postgres:testfixture.sh",
-        sqlx_bin = "//tools:sqlx_bin",
+        sqlx_bin = "//tools/sqlx-cli:sqlx_bin",
     )
     sh_test(
         name = name + "_test",


### PR DESCRIPTION
## Summary
- tools/BUILD.bazel and infra/BUILD.bazel each defined targets for subdirectories that had real files but no BUILD.bazel of their own — no per-directory README, no independent visibility, and unrelated subdirectories' internals coupled into one package.
- `tools/sqlx-cli/BUILD.bazel` now owns `:sqlx_bin` and the `:sqlx` run wrapper (moved from tools/BUILD.bazel so the wrapper lives with the binary it wraps).
- `tools/renovate/BUILD.bazel` now owns the two `update_*_test` targets.
- `infra/terraform/BUILD.bazel` and `infra/github/BUILD.bazel` now each own their README's markdown lint test, previously defined in infra/BUILD.bazel by relative path into the subdirectory.
- Updates every `//tools:sqlx` label reference (CLAUDE.md, services/causes_api/README.md, agent_action_guard.py, agent_action_guard_test.py) to `//tools/sqlx-cli:sqlx`.

Based directly on master.

## Test plan
- [x] `bash tools/check.sh agent //...` passes clean.
- [x] `bazel run //tools/sqlx-cli:sqlx -- --version` actually runs (`sqlx-cli 0.9.0`).
- [x] `bazel test //infra/terraform:pymarkdown //infra/github:pymarkdown` actually run and pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
