### PR TITLE
buck2: move :py from tools to third_party/python

### DIFF
--- a/third_party/python/BUCK
+++ b/third_party/python/BUCK
@@ -1,8 +1,15 @@
-load("//tools:defs.bzl", "cached_check", "cached_http_archive")
+load("//tools:defs.bzl", "cached_check", "cached_http_archive", "tree_tool")
 
 export_file(
     name = "pin",
     src = "BUCK",
+    visibility = ["PUBLIC"],
+)
+
+tree_tool(
+    name = "py",
+    path = "bin/python3",
+    tree = ":cpython",
     visibility = ["PUBLIC"],
 )
 
@@ -22,7 +29,7 @@ cached_http_archive(
 
 cached_check(
     name = "cpython_layout_test",
-    exe = "//tools:py",
+    exe = ":py",
     srcs = [
         "cpython_layout_test.py",
         ":cpython",

--- a/tools/BUCK
+++ b/tools/BUCK
@@ -1,11 +1,4 @@
-load(":defs.bzl", "cached_check", "tree_tool")
-
-tree_tool(
-    name = "py",
-    path = "bin/python3",
-    tree = "//third_party/python:cpython",
-    visibility = ["PUBLIC"],
-)
+load(":defs.bzl", "cached_check")
 
 export_file(
     name = "agent_action_guard_src",
@@ -14,14 +7,14 @@ export_file(
 
 command_alias(
     name = "agent_action_guard",
-    exe = ":py",
+    exe = "//third_party/python:py",
     args = ["$(location :agent_action_guard_src)"],
     visibility = ["PUBLIC"],
 )
 
 cached_check(
     name = "py_version_check",
-    exe = ":py",
+    exe = "//third_party/python:py",
     srcs = [
         "py_version_check.py",
         "//third_party/python:pin",

--- a/tools/nativelink/BUCK
+++ b/tools/nativelink/BUCK
@@ -16,7 +16,7 @@ busybox(
 
 cached_check(
     name = "busybox_test",
-    exe = "//tools:py",
+    exe = "//third_party/python:py",
     srcs = [
         "busybox_test.py",
         ":busybox",
@@ -31,7 +31,7 @@ busybox_rootfs(
 
 cached_check(
     name = "rootfs_test",
-    exe = "//tools:py",
+    exe = "//third_party/python:py",
     srcs = [
         "busybox_rootfs_test.py",
         ":rootfs",
@@ -42,14 +42,14 @@ worker_layer(
     name = "layer",
     digest = WORKER_LAYER_DIGEST,
     exec_compatible_with = ["//platforms:image_build_enabled"],
-    py = "//tools:py",
+    py = "//third_party/python:py",
     rootfs = ":rootfs",
     script = "make_layer.py",
 )
 
 cached_check(
     name = "layer_test",
-    exe = "//tools:py",
+    exe = "//third_party/python:py",
     srcs = [
         "layer_test.py",
         ":layer",


### PR DESCRIPTION
## Summary
- `tools/BUCK` defined the `py` interpreter wrapper (`bin/python3` inside the cpython tree), but that path is `third_party/python`'s own layout knowledge, not `tools`'. `third_party/python` already depended back on it (`cpython_layout_test`) — the same coupling-through-a-shared-parent `tools/BUILD.bazel` had before the sqlx-cli/renovate split on the Bazel side (#513).
- Moves `:py` to `third_party/python/BUCK` and updates its seven consumers (`tools/BUCK`'s own two, `tools/nativelink/BUCK`'s four, `third_party/python/BUCK`'s own `cpython_layout_test`).

Based on master, independent of #482.

## Test plan
- [x] `buck2 build //...` succeeds.
- [x] `buck2 build //tools:py_version_check //third_party/python:cpython_layout_test //tools/nativelink:busybox_test //tools/nativelink:layer_test` succeeds — these are `cached_check` targets where build success means the check itself ran and passed, not just compiled.
- [x] `bash tools/check.sh agent //...` passes clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
