### PR TITLE
renovate: capture bare version in download url

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -144,14 +144,14 @@
       "extractVersionTemplate": "^v(?<version>.*)$"
     },
     {
-      "description": "Any github release download pinned in a BUCK file or MODULE.bazel; owner/repo is the dep, so a new pinned github tool is tracked with no per-tool config. The renovate-sha workflow recomputes the sha256 on the bump PR (renovatebot/renovate#22183). The match runs to the closing quote so the whole URL is the replace target, and autoReplaceGlobalMatch (on by default) rewrites every occurrence of the version within it — needed when a version or date repeats in the asset filename.",
+      "description": "Any github release download pinned in a BUCK file or MODULE.bazel; owner/repo is the dep, so a new pinned github tool is tracked with no per-tool config. The renovate-sha workflow recomputes the sha256 on the bump PR (renovatebot/renovate#22183). The match runs to the closing quote so the whole URL is the replace target, and autoReplaceGlobalMatch (on by default) rewrites every occurrence of the version within it — needed when a version or date repeats in the asset filename. currentValue excludes any leading v so a v-prefixed tag path plus a bare-version filename (e.g. opentofu, protoc-gen-doc) both rewrite; a v-prefixed capture would leave the filename stale and 404.",
       "customType": "regex",
       "managerFilePatterns": [
         "/(^|/)BUCK$/",
         "/^MODULE\\.bazel$/"
       ],
       "matchStrings": [
-        "https://github\\.com/(?<depName>[^/\"]+/[^/\"]+)/releases/download/(?<currentValue>[^/\"]+)/[^\"]*"
+        "https://github\\.com/(?<depName>[^/\"]+/[^/\"]+)/releases/download/v?(?<currentValue>[^/\"]+)/[^\"]*"
       ],
       "datasourceTemplate": "github-releases"
     },

--- a/tools/renovate/functional_check.sh
+++ b/tools/renovate/functional_check.sh
@@ -73,6 +73,11 @@ http_archive(
     sha256 = "8c88519b0ef0af9801fcdee419bbb12116bd9e6b18e162ae093c932d8b264050",
     url = "https://github.com/astral-sh/uv/releases/download/0.11.0/uv-x86_64-unknown-linux-gnu.tar.gz",
 )
+http_archive(
+    name = "opentofu_linux_amd64",
+    sha256 = "0000000000000000000000000000000000000000000000000000000000000000",
+    url = "https://github.com/opentofu/opentofu/releases/download/v1.11.0/tofu_1.11.0_linux_amd64.zip",
+)
 EOF
 # devcontainer feature pins: version and digest backdated together so the
 # customManagers regex over the lockfile must move both in one update.
@@ -166,7 +171,7 @@ update_proposed() {
 
 # Every backdated pin must yield an update decision, not just extract.
 for dep in TraceMachina/nativelink containers/crun astral-sh/uv \
-	google/go-containerregistry busybox \
+	google/go-containerregistry busybox opentofu/opentofu \
 	python/cpython astral-sh/python-build-standalone \
 	ghcr.io/devcontainers/features/docker-outside-of-docker \
 	ghcr.io/devcontainers/features/github-cli \
@@ -201,6 +206,27 @@ elif [[ "$new_value" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
 	echo "PASS: python/cpython newValue ${new_value} is a stable release"
 else
 	echo "FAIL: python/cpython newValue ${new_value} is a pre-release"
+	fail=1
+fi
+
+# opentofu's release URL carries the version twice — v1.11.0 in the path,
+# 1.11.0 in the filename — and autoReplaceGlobalMatch rewrites occurrences of
+# the captured currentValue verbatim. Only a bare (no-v) currentValue reaches
+# the filename; a v-prefixed one rewrites the path alone, leaving a 404 (#516).
+opentofu_current_value() {
+	awk -v dep="\"depName\": \"opentofu/opentofu\"" '
+		/"depName": "/ { cur = (index($0, dep) > 0) }
+		cur && /"currentValue"/ { print; exit }
+	' "$log" | grep -oE '"[^"]+"' | tail -1 | tr -d '"'
+}
+otf_cv="$(opentofu_current_value)"
+if [[ -z "$otf_cv" ]]; then
+	echo "FAIL: no currentValue found for opentofu/opentofu to check"
+	fail=1
+elif [[ "$otf_cv" =~ ^[0-9] ]]; then
+	echo "PASS: opentofu currentValue ${otf_cv} is the bare version"
+else
+	echo "FAIL: opentofu currentValue ${otf_cv} keeps a prefix; the filename won't rewrite"
 	fail=1
 fi
 


### PR DESCRIPTION
Fixes the half-bumped URL that 404'd the `renovate-sha` workflow on #516.

The BUCK/MODULE.bazel github-download manager captured `currentValue` with the leading `v` (`v1.11.0`). `autoReplaceGlobalMatch` rewrites that string verbatim, so a URL carrying `v1.11.0` in the path but `1.11.0` in the filename (opentofu, protoc-gen-doc) only bumped the path — leaving `.../download/v1.12.5/tofu_1.11.0_linux_amd64.zip`, which 404s.

Moving the optional `v` outside the capture makes `currentValue` bare, so the global replace reaches both occurrences.

Exposed by #482, which brought MODULE.bazel `http_archive` URLs under this manager; opentofu was its first bump.

## Test plan
- [x] `buck2 build //tools/renovate:functional_check` with a real `GH_TOKEN`: RED before the fix (`opentofu currentValue v1.11.0 keeps a prefix`), GREEN after — verified by reverting the regex.
- [x] `bash tools/check.sh agent //...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
