### PR TITLE
nativelink: add bash to the worker rootfs

### DIFF
--- a/tools/nativelink/BUCK
+++ b/tools/nativelink/BUCK
@@ -1,4 +1,5 @@
 load("//tools:defs.bzl", "cached_check")
+load("//tools/nativelink:bash.bzl", "bash_bundle")
 load("//tools/nativelink:busybox.bzl", "busybox")
 load("//tools/nativelink:layer.bzl", "worker_layer")
 load("//tools/nativelink:pin.bzl", "WORKER_LAYER_DIGEST")
@@ -35,8 +36,16 @@ cached_check(
     ],
 )
 
+bash_bundle(
+    name = "bash",
+    crane = "//third_party/crane:crane[crane]",
+    exec_compatible_with = ["//platforms:image_build_enabled"],
+    image = "bash:5.2@sha256:3bee76a96d86d5d2d5efc7c1c570e5a7c95db22348a26944e0e546fa174e3324",
+)
+
 busybox_rootfs(
     name = "rootfs",
+    bash = ":bash",
     busybox = ":busybox",
     exec_compatible_with = ["//platforms:image_build_enabled"],
 )

--- a/tools/nativelink/bash.bzl
+++ b/tools/nativelink/bash.bzl
@@ -1,0 +1,34 @@
+# Provide a real bash (plus its musl runtime deps) from the pinned docker bash
+# image, laid out as a rootfs overlay. buck2's rust/cxx build-script shims
+# (cc_shim.sh) are `#!/usr/bin/env bash` and use bash-only features
+# (BASH_SOURCE), so a busybox-sh shim is not sufficient.
+def _bash_bundle_impl(ctx: AnalysisContext) -> list[Provider]:
+    crane = ctx.attrs.crane[DefaultInfo].default_outputs[0]
+    out = ctx.actions.declare_output("bash_root", dir = True)
+    script = """
+set -eu
+crane="$1"; image="$2"; root="$3"
+d="$(mktemp -d)"
+"$crane" export "$image" "$d/rootfs.tar"
+tar -x -C "$d" -f "$d/rootfs.tar"
+mkdir -p "$root/bin" "$root/lib" "$root/usr/lib"
+cp "$d/usr/local/bin/bash" "$root/bin/bash"
+chmod 0755 "$root/bin/bash"
+# musl loader + libc (libc.musl-* is a symlink to ld-musl) and ncurses.
+cp -a "$d/lib/ld-musl-x86_64.so.1" "$root/lib/"
+cp -a "$d/lib/libc.musl-x86_64.so.1" "$root/lib/"
+cp -a "$d"/usr/lib/libncursesw.so.6* "$root/usr/lib/"
+"""
+    ctx.actions.run(
+        cmd_args("/bin/sh", "-c", script, "bash_bundle", crane, ctx.attrs.image, out.as_output()),
+        category = "bash_bundle",
+    )
+    return [DefaultInfo(default_output = out)]
+
+bash_bundle = rule(
+    impl = _bash_bundle_impl,
+    attrs = {
+        "crane": attrs.dep(providers = [DefaultInfo]),
+        "image": attrs.string(),
+    },
+)

--- a/tools/nativelink/busybox_rootfs_test.py
+++ b/tools/nativelink/busybox_rootfs_test.py
@@ -18,7 +18,12 @@ applets = set(
 for applet in ("sh", "tar", "ls", "ln"):
     link = os.path.join(root, "bin", applet)
     assert os.path.islink(link) and os.readlink(link) == "busybox", link
-links = {n for n in os.listdir(os.path.join(root, "bin")) if n != "busybox"}
+# bash is a real musl binary staged next to the applet symlinks (buck2's
+# prelude build-script and clippy wrappers are #!/usr/bin/env bash and use
+# BASH_SOURCE), not a busybox applet, so it is excluded from the symlink set.
+bash = os.path.join(root, "bin", "bash")
+assert os.path.isfile(bash) and not os.path.islink(bash) and os.access(bash, os.X_OK), bash
+links = {n for n in os.listdir(os.path.join(root, "bin")) if n not in ("busybox", "bash")}
 assert links == applets - {"busybox"}, sorted(applets - {"busybox"} ^ links)
 
 echoed = subprocess.run(
@@ -28,5 +33,8 @@ assert echoed == "ok", echoed
 
 for d in ("tmp", "proc", "dev", "etc"):
     assert os.path.isdir(os.path.join(root, d)), d
+
+env = os.path.join(root, "usr", "bin", "env")
+assert os.path.islink(env), env
 
 open(sys.argv[2], "w", encoding="utf-8").write("ok")

--- a/tools/nativelink/pin.bzl
+++ b/tools/nativelink/pin.bzl
@@ -3,4 +3,4 @@
 # platforms/BUCK (so bumping this digest also changes the container-image
 # property baked into every image_build action, invalidating NativeLink's
 # action cache for actions that ran under the old image).
-WORKER_LAYER_DIGEST = "fc1afd47c55bb3a8b26ce67c63ad58c624d184eef2f1f4982b2c7387eb415d77"
+WORKER_LAYER_DIGEST = "6ea801e86a66f81f164da8cd851be53223f305eef77e6f311bc70dad6ab11a2f"

--- a/tools/nativelink/rootfs.bzl
+++ b/tools/nativelink/rootfs.bzl
@@ -2,21 +2,27 @@
 # mount-point directories the runtime expects.
 def _busybox_rootfs_impl(ctx: AnalysisContext) -> list[Provider]:
     busybox = ctx.attrs.busybox[DefaultInfo].default_outputs[0]
+    bash = ctx.attrs.bash[DefaultInfo].default_outputs[0]
     out = ctx.actions.declare_output("rootfs", dir = True)
     script = """
 set -eu
 bb="$1"
 root="$2"
-mkdir -p "$root/bin" "$root/tmp" "$root/proc" "$root/dev" "$root/etc"
+bash="$3"
+mkdir -p "$root/bin" "$root/usr/bin" "$root/tmp" "$root/proc" "$root/dev" "$root/etc"
 cp "$bb" "$root/bin/busybox"
 chmod 0755 "$root/bin/busybox"
 "$bb" --list | while read -r applet; do
   [ "$applet" = busybox ] && continue
+  # env also at /usr/bin, where #!/usr/bin/env shebangs look.
+  [ "$applet" = env ] && ln -s /bin/busybox "$root/usr/bin/env"
   ln -s busybox "$root/bin/$applet"
 done
+# Real bash, not the busybox applet: the cc/cxx build-script shims use BASH_SOURCE.
+cp -a "$bash/." "$root/"
 """
     ctx.actions.run(
-        cmd_args("/bin/sh", "-c", script, "rootfs", busybox, out.as_output()),
+        cmd_args("/bin/sh", "-c", script, "rootfs", busybox, out.as_output(), bash),
         category = "busybox_rootfs",
     )
     return [DefaultInfo(default_output = out)]
@@ -24,6 +30,7 @@ done
 busybox_rootfs = rule(
     impl = _busybox_rootfs_impl,
     attrs = {
+        "bash": attrs.dep(providers = [DefaultInfo]),
         "busybox": attrs.dep(providers = [DefaultInfo]),
     },
 )


### PR DESCRIPTION
The from-scratch rootfs ships only busybox, whose sh lacks BASH_SOURCE.
buck2's rust and cxx build-script shims are `#!/usr/bin/env bash` and rely on it, so a busybox-sh shim is not enough.
Stage a real bash and its musl runtime deps from the pinned docker bash image.
Bumps `WORKER_LAYER_DIGEST`, invalidating the image_build action cache.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
