### PR TITLE
nativelink: base-OS files in the worker rootfs

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -156,6 +156,19 @@
       "datasourceTemplate": "github-releases"
     },
     {
+      "description": "An Alpine apk pinned by cached_http_archive URL in a BUCK file; repology tracks the upstream version. The -r package revision and sha256 are recomputed by the renovate-sha workflow on the bump PR (renovatebot/renovate#22183).",
+      "customType": "regex",
+      "managerFilePatterns": [
+        "/(^|/)BUCK$/"
+      ],
+      "matchStrings": [
+        "https://dl-cdn\\.alpinelinux\\.org/alpine/v3\\.19/[^/]+/[^/]+/(?<depName>[a-z][a-z0-9-]*)-(?<currentValue>\\d[\\w.]*)-r\\d+\\.apk"
+      ],
+      "datasourceTemplate": "repology",
+      "packageNameTemplate": "alpine_3_19/{{{depName}}}",
+      "versioningTemplate": "loose"
+    },
+    {
       "description": "A digest-pinned docker image in a BUCK file; the digest is content-addressed, so no sha-recompute is needed.",
       "customType": "regex",
       "managerFilePatterns": [

--- a/tools/nativelink/BUCK
+++ b/tools/nativelink/BUCK
@@ -1,4 +1,4 @@
-load("//tools:defs.bzl", "cached_check")
+load("//tools:defs.bzl", "cached_check", "cached_http_archive")
 load("//tools/nativelink:bash.bzl", "bash_bundle")
 load("//tools/nativelink:busybox.bzl", "busybox")
 load("//tools/nativelink:layer.bzl", "worker_layer")
@@ -43,11 +43,21 @@ bash_bundle(
     image = "bash:5.2@sha256:3bee76a96d86d5d2d5efc7c1c570e5a7c95db22348a26944e0e546fa174e3324",
 )
 
+cached_http_archive(
+    name = "tzdata",
+    exec_compatible_with = ["//platforms:image_build_enabled"],
+    paths = ["usr/share/zoneinfo"],
+    sha256 = "348693272f53109aa9687e022b52f27086f1d86ac3fc5a6be36f334b06c2f454",
+    urls = ["https://dl-cdn.alpinelinux.org/alpine/v3.19/main/x86_64/tzdata-2025b-r0.apk"],
+    visibility = ["//tools/renovate:"],
+)
+
 busybox_rootfs(
     name = "rootfs",
     bash = ":bash",
     busybox = ":busybox",
     exec_compatible_with = ["//platforms:image_build_enabled"],
+    zoneinfo = ":tzdata",
 )
 
 cached_check(

--- a/tools/nativelink/busybox_rootfs_test.py
+++ b/tools/nativelink/busybox_rootfs_test.py
@@ -37,4 +37,10 @@ for d in ("tmp", "proc", "dev", "etc"):
 env = os.path.join(root, "usr", "bin", "env")
 assert os.path.islink(env), env
 
+passwd = open(os.path.join(root, "etc", "passwd"), encoding="utf-8").read()
+assert ":12021:0:" in passwd, passwd
+hosts = open(os.path.join(root, "etc", "hosts"), encoding="utf-8").read()
+assert "127.0.0.1 localhost" in hosts, hosts
+assert os.path.isfile(os.path.join(root, "usr", "share", "zoneinfo", "UTC")), "zoneinfo/UTC"
+
 open(sys.argv[2], "w", encoding="utf-8").write("ok")

--- a/tools/nativelink/pin.bzl
+++ b/tools/nativelink/pin.bzl
@@ -3,4 +3,4 @@
 # platforms/BUCK (so bumping this digest also changes the container-image
 # property baked into every image_build action, invalidating NativeLink's
 # action cache for actions that ran under the old image).
-WORKER_LAYER_DIGEST = "6ea801e86a66f81f164da8cd851be53223f305eef77e6f311bc70dad6ab11a2f"
+WORKER_LAYER_DIGEST = "e290f8f7a910bb002e88673e72d94ff36f0c4170efbf7a0a439042437fca5b59"

--- a/tools/nativelink/rootfs.bzl
+++ b/tools/nativelink/rootfs.bzl
@@ -1,15 +1,18 @@
-# The worker rootfs tree: bin/busybox, one symlink per applet, and the
-# mount-point directories the runtime expects.
+# The worker rootfs tree: bin/busybox, one symlink per applet, a real bash, the
+# base-OS files (/etc/passwd, /etc/hosts, zoneinfo), and
+# the runtime mount points.
 def _busybox_rootfs_impl(ctx: AnalysisContext) -> list[Provider]:
     busybox = ctx.attrs.busybox[DefaultInfo].default_outputs[0]
     bash = ctx.attrs.bash[DefaultInfo].default_outputs[0]
+    zoneinfo = ctx.attrs.zoneinfo[DefaultInfo].default_outputs[0]
     out = ctx.actions.declare_output("rootfs", dir = True)
     script = """
 set -eu
 bb="$1"
 root="$2"
 bash="$3"
-mkdir -p "$root/bin" "$root/usr/bin" "$root/tmp" "$root/proc" "$root/dev" "$root/etc"
+zoneinfo="$4"
+mkdir -p "$root/bin" "$root/usr/bin" "$root/usr/share" "$root/tmp" "$root/proc" "$root/dev" "$root/etc"
 cp "$bb" "$root/bin/busybox"
 chmod 0755 "$root/bin/busybox"
 "$bb" --list | while read -r applet; do
@@ -20,9 +23,13 @@ chmod 0755 "$root/bin/busybox"
 done
 # Real bash, not the busybox applet: the cc/cxx build-script shims use BASH_SOURCE.
 cp -a "$bash/." "$root/"
+# passwd entry for the crun action uid (12021).
+printf 'root:x:0:0:root:/root:/bin/sh\\npostgres:x:12021:0:PostgreSQL:/tmp:/bin/sh\\n' >"$root/etc/passwd"
+printf '127.0.0.1 localhost\\n::1 localhost\\n' >"$root/etc/hosts"
+cp -a "$zoneinfo" "$root/usr/share/zoneinfo"
 """
     ctx.actions.run(
-        cmd_args("/bin/sh", "-c", script, "rootfs", busybox, out.as_output(), bash),
+        cmd_args("/bin/sh", "-c", script, "rootfs", busybox, out.as_output(), bash, zoneinfo),
         category = "busybox_rootfs",
     )
     return [DefaultInfo(default_output = out)]
@@ -32,5 +39,6 @@ busybox_rootfs = rule(
     attrs = {
         "bash": attrs.dep(providers = [DefaultInfo]),
         "busybox": attrs.dep(providers = [DefaultInfo]),
+        "zoneinfo": attrs.dep(providers = [DefaultInfo]),
     },
 )

--- a/tools/renovate/functional_check.sh
+++ b/tools/renovate/functional_check.sh
@@ -50,7 +50,10 @@ sed 's/^NATIVELINK_VERSION=.*/NATIVELINK_VERSION=1.5.0/' \
 	"$nativelink_install" >"$repo/tools/nativelink/install.sh"
 sed 's/^CRUN_VERSION=.*/CRUN_VERSION=1.20/' \
 	"$crun_install" >"$repo/tools/crun/install.sh"
-sed -E 's/busybox:[0-9.]+-musl@sha256:[0-9a-f]+/busybox:1.36.0-musl@sha256:0000000000000000000000000000000000000000000000000000000000000000/' \
+# busybox and tzdata backdated so their managers must propose an update.
+sed -E \
+	-e 's/busybox:[0-9.]+-musl@sha256:[0-9a-f]+/busybox:1.36.0-musl@sha256:0000000000000000000000000000000000000000000000000000000000000000/' \
+	-e 's/tzdata-[0-9a-z.]+-r[0-9]+\.apk/tzdata-2024a-r0.apk/' \
 	"$nativelink_buck" >"$repo/tools/nativelink/BUCK"
 sed 's|download/v[0-9.]*/|download/v0.19.0/|' \
 	"$crane_buck" >"$repo/third_party/crane/BUCK"
@@ -171,7 +174,7 @@ update_proposed() {
 
 # Every backdated pin must yield an update decision, not just extract.
 for dep in TraceMachina/nativelink containers/crun astral-sh/uv \
-	google/go-containerregistry busybox opentofu/opentofu \
+	google/go-containerregistry busybox tzdata opentofu/opentofu \
 	python/cpython astral-sh/python-build-standalone \
 	ghcr.io/devcontainers/features/docker-outside-of-docker \
 	ghcr.io/devcontainers/features/github-cli \


### PR DESCRIPTION
busybox alone is insufficient for postgres.
`getpwuid` needs an `/etc/passwd` entry for the crun action uid, a TCP `localhost` connection needs `/etc/hosts`, and named-zone lookups need `/usr/share/zoneinfo` (postgres is built `--with-system-tzdata`).
Write the passwd and hosts entries and stage the Alpine tzdata tree.
Bumps `WORKER_LAYER_DIGEST`.

Stacked on the bash rootfs PR; retarget to master once it merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
