### PR TITLE
platforms: key default-platform actions by the worker image

### DIFF
--- a/platforms/BUCK
+++ b/platforms/BUCK
@@ -3,6 +3,7 @@ load(":defs.bzl", "image_build_platform", "local_only_platform", "platform_group
 
 remote_cache_platform(
     name = "default",
+    container_image = WORKER_LAYER_DIGEST,
     cpu_configuration = "prelude//cpu:x86_64",
     os_configuration = "prelude//os:linux",
 )

--- a/platforms/defs.bzl
+++ b/platforms/defs.bzl
@@ -29,7 +29,10 @@ def _impl(ctx: AnalysisContext) -> list[Provider]:
             remote_enabled = True,
             remote_cache_enabled = True,
             allow_cache_uploads = True,
-            remote_execution_properties = {},
+            # container-image keys every action to the worker image, so a
+            # WORKER_LAYER_DIGEST bump invalidates the cache and re-runs on the
+            # new image rather than serving results produced under the old rootfs.
+            remote_execution_properties = {"container-image": ctx.attrs.container_image},
             remote_execution_use_case = "buck2-default",
             use_windows_path_separators = False,
         ),
@@ -47,6 +50,7 @@ def _impl(ctx: AnalysisContext) -> list[Provider]:
 remote_cache_platform = rule(
     impl = _impl,
     attrs = {
+        "container_image": attrs.string(doc = "Worker layer digest, advertised as the container-image RE property."),
         "cpu_configuration": attrs.dep(providers = [ConfigurationInfo]),
         "os_configuration": attrs.dep(providers = [ConfigurationInfo]),
     },


### PR DESCRIPTION
The `default` (remote_cache) platform advertised no `container-image`, so its action cache was not invalidated by a `WORKER_LAYER_DIGEST` bump.
A rootfs change then served stale results produced under the old image.

`image_build` already keys on `container-image`; `default` now does the same, using the shared `WORKER_LAYER_DIGEST` from `pin.bzl`.

Verified: `buck2 audit providers //platforms:default` shows `remote_execution_properties = {"container-image": "<digest>"}`; on the spike a `pg_db_test` action re-executed fresh (0% cache hits) after the change rather than serving a stale hit.