### PR TITLE
nativelink: drop bash from the worker rootfs

### DIFF
--- a/tools/nativelink/BUCK
+++ b/tools/nativelink/BUCK
@@ -54,7 +54,6 @@ cached_http_archive(
 
 busybox_rootfs(
     name = "rootfs",
-    bash = ":bash",
     busybox = ":busybox",
     exec_compatible_with = ["//platforms:image_build_enabled"],
     zoneinfo = ":tzdata",

--- a/tools/nativelink/busybox_rootfs_test.py
+++ b/tools/nativelink/busybox_rootfs_test.py
@@ -18,12 +18,7 @@ applets = set(
 for applet in ("sh", "tar", "ls", "ln"):
     link = os.path.join(root, "bin", applet)
     assert os.path.islink(link) and os.readlink(link) == "busybox", link
-# bash is a real musl binary staged next to the applet symlinks (buck2's
-# prelude build-script and clippy wrappers are #!/usr/bin/env bash and use
-# BASH_SOURCE), not a busybox applet, so it is excluded from the symlink set.
-bash = os.path.join(root, "bin", "bash")
-assert os.path.isfile(bash) and not os.path.islink(bash) and os.access(bash, os.X_OK), bash
-links = {n for n in os.listdir(os.path.join(root, "bin")) if n not in ("busybox", "bash")}
+links = {n for n in os.listdir(os.path.join(root, "bin")) if n != "busybox"}
 assert links == applets - {"busybox"}, sorted(applets - {"busybox"} ^ links)
 
 echoed = subprocess.run(

--- a/tools/nativelink/pin.bzl
+++ b/tools/nativelink/pin.bzl
@@ -3,4 +3,4 @@
 # platforms/BUCK (so bumping this digest also changes the container-image
 # property baked into every image_build action, invalidating NativeLink's
 # action cache for actions that ran under the old image).
-WORKER_LAYER_DIGEST = "e290f8f7a910bb002e88673e72d94ff36f0c4170efbf7a0a439042437fca5b59"
+WORKER_LAYER_DIGEST = "7917a34dce0bbd54ed1831c161409a6da234fcf3da32e255ddfb8ba654e7e098"

--- a/tools/nativelink/rootfs.bzl
+++ b/tools/nativelink/rootfs.bzl
@@ -1,17 +1,14 @@
-# The worker rootfs tree: bin/busybox, one symlink per applet, a real bash, the
-# base-OS files (/etc/passwd, /etc/hosts, zoneinfo), and
-# the runtime mount points.
+# The worker rootfs tree: bin/busybox, one symlink per applet, the base-OS
+# files (/etc/passwd, /etc/hosts, zoneinfo), and the runtime mount points.
 def _busybox_rootfs_impl(ctx: AnalysisContext) -> list[Provider]:
     busybox = ctx.attrs.busybox[DefaultInfo].default_outputs[0]
-    bash = ctx.attrs.bash[DefaultInfo].default_outputs[0]
     zoneinfo = ctx.attrs.zoneinfo[DefaultInfo].default_outputs[0]
     out = ctx.actions.declare_output("rootfs", dir = True)
     script = """
 set -eu
 bb="$1"
 root="$2"
-bash="$3"
-zoneinfo="$4"
+zoneinfo="$3"
 mkdir -p "$root/bin" "$root/usr/bin" "$root/usr/share" "$root/tmp" "$root/proc" "$root/dev" "$root/etc"
 cp "$bb" "$root/bin/busybox"
 chmod 0755 "$root/bin/busybox"
@@ -21,15 +18,13 @@ chmod 0755 "$root/bin/busybox"
   [ "$applet" = env ] && ln -s /bin/busybox "$root/usr/bin/env"
   ln -s busybox "$root/bin/$applet"
 done
-# Real bash, not the busybox applet: the cc/cxx build-script shims use BASH_SOURCE.
-cp -a "$bash/." "$root/"
 # passwd entry for the crun action uid (12021).
 printf 'root:x:0:0:root:/root:/bin/sh\\npostgres:x:12021:0:PostgreSQL:/tmp:/bin/sh\\n' >"$root/etc/passwd"
 printf '127.0.0.1 localhost\\n::1 localhost\\n' >"$root/etc/hosts"
 cp -a "$zoneinfo" "$root/usr/share/zoneinfo"
 """
     ctx.actions.run(
-        cmd_args("/bin/sh", "-c", script, "rootfs", busybox, out.as_output(), bash, zoneinfo),
+        cmd_args("/bin/sh", "-c", script, "rootfs", busybox, out.as_output(), zoneinfo),
         category = "busybox_rootfs",
     )
     return [DefaultInfo(default_output = out)]
@@ -37,7 +32,6 @@ cp -a "$zoneinfo" "$root/usr/share/zoneinfo"
 busybox_rootfs = rule(
     impl = _busybox_rootfs_impl,
     attrs = {
-        "bash": attrs.dep(providers = [DefaultInfo]),
         "busybox": attrs.dep(providers = [DefaultInfo]),
         "zoneinfo": attrs.dep(providers = [DefaultInfo]),
     },


### PR DESCRIPTION
The worker image is being reshaped toward a minimal rootfs, with the runtime to be supplied by a toolchain.
This removes bash from the rootfs as a step toward that.