### PR TITLE
nativelink: rootfs manifest for re-pin telemetry

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -189,6 +189,23 @@ jobs:
       # NativeLink and warms the shared cache; nothing here executes local.
       - name: Build buck2 targets
         run: buck2 build --remote-only $REMOTE_ONLY_TARGETS
+      # A rootfs pin bump reshapes the worker image; diff the built tar's
+      # manifest against the base golden so review sees the member-level
+      # change without depending on the author regenerating rootfs.manifest.
+      - name: "Rootfs digest change: show the rootfs manifest diff"
+        if: steps.pin_check.outputs.pin_changed == 'true'
+        run: |
+          base="${{ steps.base_head.outputs.base }}"
+          git show "$base:tools/nativelink/rootfs.manifest" \
+            >"$RUNNER_TEMP/base.manifest" 2>/dev/null \
+            || : >"$RUNNER_TEMP/base.manifest"
+          tar="$(buck2 build --show-simple-output '//tools/nativelink:layer[layer]')"
+          buck2 run //third_party/python:py -- \
+            tools/nativelink/rootfs_manifest.py diff \
+            "$RUNNER_TEMP/base.manifest" "$tar" "$RUNNER_TEMP/manifest.diff"
+          echo "::group::worker rootfs manifest change (vs base)"
+          cat "$RUNNER_TEMP/manifest.diff"
+          echo "::endgroup::"
       # A green cached build cannot distinguish "cache works" from
       # "permanently missing"; only a demonstrated hit proves the read path.
       # buck2 clean + kill destroys buck2's local state, so the required

--- a/tools/buck2/buck2.sh
+++ b/tools/buck2/buck2.sh
@@ -44,6 +44,19 @@ if [[ -e "$root/.buckroot" ]] && no_daemon; then
 	# so the next command starts fresh under the committed config.
 	buck2-bin kill >/dev/null 2>&1 || true
 	if [[ "$bootstrap_rc" -ne 0 ]]; then
+		# The validated :layer build fails when the built tar's digest does
+		# not match the pin; :layer[layer] is that tar without the check, so
+		# its manifest still builds. Diff it against the committed golden to
+		# describe the rootfs change.
+		if manifest_diff="$(buck2-bin build --local-only \
+			--show-full-simple-output \
+			//tools/nativelink:rootfs_manifest_diff 2>/dev/null)" &&
+			[[ -s "$manifest_diff" ]]; then
+			echo "error: worker-layer digest does not match the pin; the" \
+				"built rootfs differs from tools/nativelink/rootfs.manifest:" >&2
+			cat "$manifest_diff" >&2
+		fi
+		buck2-bin kill >/dev/null 2>&1 || true
 		echo "error: local-only build of //tools/nativelink:layer" \
 			"failed; refusing to start NativeLink over unverified bytes" >&2
 		exit 1

--- a/tools/nativelink/BUCK
+++ b/tools/nativelink/BUCK
@@ -4,6 +4,7 @@ load("//tools/nativelink:busybox.bzl", "busybox")
 load("//tools/nativelink:layer.bzl", "worker_layer")
 load("//tools/nativelink:pin.bzl", "WORKER_LAYER_DIGEST")
 load("//tools/nativelink:rootfs.bzl", "busybox_rootfs")
+load("//tools/nativelink:rootfs_manifest.bzl", "rootfs_manifest_diff", "rootfs_manifest_update")
 
 export_file(
     name = "install_sh",
@@ -66,6 +67,49 @@ cached_check(
         "busybox_rootfs_test.py",
         ":rootfs",
     ],
+)
+
+# The golden rootfs.manifest reads back the layer tar and lists every field its
+# digest depends on, so a re-pin's PR diff shows what changed in the worker
+# image. On a re-pin, regenerate it alongside WORKER_LAYER_DIGEST with:
+#   buck2 run //tools/nativelink:rootfs_manifest_update
+cached_check(
+    name = "rootfs_manifest_test",
+    exe = "//third_party/python:py",
+    srcs = [
+        "rootfs_manifest.py",
+        ":layer[layer]",
+        "rootfs.manifest",
+    ],
+)
+
+cached_check(
+    name = "rootfs_manifest_unit_test",
+    exe = "//third_party/python:py",
+    srcs = [
+        "rootfs_manifest_unit_test.py",
+        "rootfs_manifest.py",
+    ],
+)
+
+rootfs_manifest_update(
+    name = "rootfs_manifest_update",
+    dest = "tools/nativelink/rootfs.manifest",
+    exec_compatible_with = ["//platforms:image_build_enabled"],
+    py = "//third_party/python:py",
+    script = "rootfs_manifest.py",
+    tar = ":layer[layer]",
+)
+
+# buck2.sh builds this and prints it when the bootstrap digest check fails, so a
+# worker-layer pin mismatch describes the rootfs change, not two hashes.
+rootfs_manifest_diff(
+    name = "rootfs_manifest_diff",
+    exec_compatible_with = ["//platforms:image_build_enabled"],
+    golden = "rootfs.manifest",
+    py = "//third_party/python:py",
+    script = "rootfs_manifest.py",
+    tar = ":layer[layer]",
 )
 
 worker_layer(

--- a/tools/nativelink/rootfs.manifest
+++ b/tools/nativelink/rootfs.manifest
@@ -1,0 +1,1659 @@
+d 0755          - bin/
+l 0755          - bin/[ -> busybox
+l 0755          - bin/[[ -> busybox
+l 0755          - bin/acpid -> busybox
+l 0755          - bin/add-shell -> busybox
+l 0755          - bin/addgroup -> busybox
+l 0755          - bin/adduser -> busybox
+l 0755          - bin/adjtimex -> busybox
+l 0755          - bin/ar -> busybox
+l 0755          - bin/arch -> busybox
+l 0755          - bin/arp -> busybox
+l 0755          - bin/arping -> busybox
+l 0755          - bin/ascii -> busybox
+l 0755          - bin/ash -> busybox
+l 0755          - bin/awk -> busybox
+l 0755          - bin/base32 -> busybox
+l 0755          - bin/base64 -> busybox
+l 0755          - bin/basename -> busybox
+l 0755          - bin/bc -> busybox
+l 0755          - bin/beep -> busybox
+l 0755          - bin/blkdiscard -> busybox
+l 0755          - bin/blkid -> busybox
+l 0755          - bin/blockdev -> busybox
+l 0755          - bin/bootchartd -> busybox
+l 0755          - bin/brctl -> busybox
+l 0755          - bin/bunzip2 -> busybox
+- 0755    1239304 bin/busybox  sha256:899f11dd0dbf8ac0042c67cb7791f6d10c1bf1efd1c5f82dc65047b9729fb583
+l 0755          - bin/bzcat -> busybox
+l 0755          - bin/bzip2 -> busybox
+l 0755          - bin/cal -> busybox
+l 0755          - bin/cat -> busybox
+l 0755          - bin/chat -> busybox
+l 0755          - bin/chattr -> busybox
+l 0755          - bin/chgrp -> busybox
+l 0755          - bin/chmod -> busybox
+l 0755          - bin/chown -> busybox
+l 0755          - bin/chpasswd -> busybox
+l 0755          - bin/chpst -> busybox
+l 0755          - bin/chroot -> busybox
+l 0755          - bin/chrt -> busybox
+l 0755          - bin/chvt -> busybox
+l 0755          - bin/cksum -> busybox
+l 0755          - bin/clear -> busybox
+l 0755          - bin/cmp -> busybox
+l 0755          - bin/comm -> busybox
+l 0755          - bin/conspy -> busybox
+l 0755          - bin/cp -> busybox
+l 0755          - bin/cpio -> busybox
+l 0755          - bin/crc32 -> busybox
+l 0755          - bin/crond -> busybox
+l 0755          - bin/crontab -> busybox
+l 0755          - bin/cryptpw -> busybox
+l 0755          - bin/cttyhack -> busybox
+l 0755          - bin/cut -> busybox
+l 0755          - bin/date -> busybox
+l 0755          - bin/dc -> busybox
+l 0755          - bin/dd -> busybox
+l 0755          - bin/deallocvt -> busybox
+l 0755          - bin/delgroup -> busybox
+l 0755          - bin/deluser -> busybox
+l 0755          - bin/depmod -> busybox
+l 0755          - bin/devmem -> busybox
+l 0755          - bin/df -> busybox
+l 0755          - bin/dhcprelay -> busybox
+l 0755          - bin/diff -> busybox
+l 0755          - bin/dirname -> busybox
+l 0755          - bin/dmesg -> busybox
+l 0755          - bin/dnsd -> busybox
+l 0755          - bin/dnsdomainname -> busybox
+l 0755          - bin/dos2unix -> busybox
+l 0755          - bin/dpkg -> busybox
+l 0755          - bin/dpkg-deb -> busybox
+l 0755          - bin/du -> busybox
+l 0755          - bin/dumpkmap -> busybox
+l 0755          - bin/dumpleases -> busybox
+l 0755          - bin/echo -> busybox
+l 0755          - bin/ed -> busybox
+l 0755          - bin/egrep -> busybox
+l 0755          - bin/eject -> busybox
+l 0755          - bin/env -> busybox
+l 0755          - bin/envdir -> busybox
+l 0755          - bin/envuidgid -> busybox
+l 0755          - bin/ether-wake -> busybox
+l 0755          - bin/expand -> busybox
+l 0755          - bin/expr -> busybox
+l 0755          - bin/factor -> busybox
+l 0755          - bin/fakeidentd -> busybox
+l 0755          - bin/fallocate -> busybox
+l 0755          - bin/false -> busybox
+l 0755          - bin/fatattr -> busybox
+l 0755          - bin/fbset -> busybox
+l 0755          - bin/fbsplash -> busybox
+l 0755          - bin/fdflush -> busybox
+l 0755          - bin/fdformat -> busybox
+l 0755          - bin/fdisk -> busybox
+l 0755          - bin/fgconsole -> busybox
+l 0755          - bin/fgrep -> busybox
+l 0755          - bin/find -> busybox
+l 0755          - bin/findfs -> busybox
+l 0755          - bin/flock -> busybox
+l 0755          - bin/fold -> busybox
+l 0755          - bin/free -> busybox
+l 0755          - bin/freeramdisk -> busybox
+l 0755          - bin/fsck -> busybox
+l 0755          - bin/fsck.minix -> busybox
+l 0755          - bin/fsfreeze -> busybox
+l 0755          - bin/fstrim -> busybox
+l 0755          - bin/fsync -> busybox
+l 0755          - bin/ftpd -> busybox
+l 0755          - bin/ftpget -> busybox
+l 0755          - bin/ftpput -> busybox
+l 0755          - bin/fuser -> busybox
+l 0755          - bin/getfattr -> busybox
+l 0755          - bin/getopt -> busybox
+l 0755          - bin/getty -> busybox
+l 0755          - bin/grep -> busybox
+l 0755          - bin/groups -> busybox
+l 0755          - bin/gunzip -> busybox
+l 0755          - bin/gzip -> busybox
+l 0755          - bin/halt -> busybox
+l 0755          - bin/hd -> busybox
+l 0755          - bin/hdparm -> busybox
+l 0755          - bin/head -> busybox
+l 0755          - bin/hexdump -> busybox
+l 0755          - bin/hexedit -> busybox
+l 0755          - bin/hostid -> busybox
+l 0755          - bin/hostname -> busybox
+l 0755          - bin/httpd -> busybox
+l 0755          - bin/hush -> busybox
+l 0755          - bin/hwclock -> busybox
+l 0755          - bin/i2cdetect -> busybox
+l 0755          - bin/i2cdump -> busybox
+l 0755          - bin/i2cget -> busybox
+l 0755          - bin/i2cset -> busybox
+l 0755          - bin/i2ctransfer -> busybox
+l 0755          - bin/id -> busybox
+l 0755          - bin/ifconfig -> busybox
+l 0755          - bin/ifdown -> busybox
+l 0755          - bin/ifenslave -> busybox
+l 0755          - bin/ifplugd -> busybox
+l 0755          - bin/ifup -> busybox
+l 0755          - bin/inetd -> busybox
+l 0755          - bin/init -> busybox
+l 0755          - bin/inotifyd -> busybox
+l 0755          - bin/insmod -> busybox
+l 0755          - bin/install -> busybox
+l 0755          - bin/ionice -> busybox
+l 0755          - bin/iostat -> busybox
+l 0755          - bin/ip -> busybox
+l 0755          - bin/ipaddr -> busybox
+l 0755          - bin/ipcalc -> busybox
+l 0755          - bin/ipcrm -> busybox
+l 0755          - bin/ipcs -> busybox
+l 0755          - bin/iplink -> busybox
+l 0755          - bin/ipneigh -> busybox
+l 0755          - bin/iproute -> busybox
+l 0755          - bin/iprule -> busybox
+l 0755          - bin/iptunnel -> busybox
+l 0755          - bin/kbd_mode -> busybox
+l 0755          - bin/kill -> busybox
+l 0755          - bin/killall -> busybox
+l 0755          - bin/killall5 -> busybox
+l 0755          - bin/klogd -> busybox
+l 0755          - bin/less -> busybox
+l 0755          - bin/link -> busybox
+l 0755          - bin/linux32 -> busybox
+l 0755          - bin/linux64 -> busybox
+l 0755          - bin/linuxrc -> busybox
+l 0755          - bin/ln -> busybox
+l 0755          - bin/loadfont -> busybox
+l 0755          - bin/loadkmap -> busybox
+l 0755          - bin/logger -> busybox
+l 0755          - bin/login -> busybox
+l 0755          - bin/logname -> busybox
+l 0755          - bin/logread -> busybox
+l 0755          - bin/losetup -> busybox
+l 0755          - bin/lpd -> busybox
+l 0755          - bin/lpq -> busybox
+l 0755          - bin/lpr -> busybox
+l 0755          - bin/ls -> busybox
+l 0755          - bin/lsattr -> busybox
+l 0755          - bin/lsblk -> busybox
+l 0755          - bin/lsmod -> busybox
+l 0755          - bin/lsof -> busybox
+l 0755          - bin/lspci -> busybox
+l 0755          - bin/lsscsi -> busybox
+l 0755          - bin/lsusb -> busybox
+l 0755          - bin/lzcat -> busybox
+l 0755          - bin/lzma -> busybox
+l 0755          - bin/lzop -> busybox
+l 0755          - bin/makedevs -> busybox
+l 0755          - bin/makemime -> busybox
+l 0755          - bin/man -> busybox
+l 0755          - bin/md5sum -> busybox
+l 0755          - bin/mdev -> busybox
+l 0755          - bin/mesg -> busybox
+l 0755          - bin/microcom -> busybox
+l 0755          - bin/mim -> busybox
+l 0755          - bin/mkdir -> busybox
+l 0755          - bin/mkdosfs -> busybox
+l 0755          - bin/mke2fs -> busybox
+l 0755          - bin/mkfifo -> busybox
+l 0755          - bin/mkfs.ext2 -> busybox
+l 0755          - bin/mkfs.minix -> busybox
+l 0755          - bin/mkfs.vfat -> busybox
+l 0755          - bin/mknod -> busybox
+l 0755          - bin/mkpasswd -> busybox
+l 0755          - bin/mkswap -> busybox
+l 0755          - bin/mktemp -> busybox
+l 0755          - bin/modinfo -> busybox
+l 0755          - bin/modprobe -> busybox
+l 0755          - bin/more -> busybox
+l 0755          - bin/mount -> busybox
+l 0755          - bin/mountpoint -> busybox
+l 0755          - bin/mpstat -> busybox
+l 0755          - bin/mt -> busybox
+l 0755          - bin/mv -> busybox
+l 0755          - bin/nameif -> busybox
+l 0755          - bin/nanddump -> busybox
+l 0755          - bin/nandwrite -> busybox
+l 0755          - bin/nbd-client -> busybox
+l 0755          - bin/nc -> busybox
+l 0755          - bin/netstat -> busybox
+l 0755          - bin/nice -> busybox
+l 0755          - bin/nl -> busybox
+l 0755          - bin/nmeter -> busybox
+l 0755          - bin/nohup -> busybox
+l 0755          - bin/nologin -> busybox
+l 0755          - bin/nproc -> busybox
+l 0755          - bin/nsenter -> busybox
+l 0755          - bin/nslookup -> busybox
+l 0755          - bin/ntpd -> busybox
+l 0755          - bin/od -> busybox
+l 0755          - bin/openvt -> busybox
+l 0755          - bin/partprobe -> busybox
+l 0755          - bin/passwd -> busybox
+l 0755          - bin/paste -> busybox
+l 0755          - bin/patch -> busybox
+l 0755          - bin/pgrep -> busybox
+l 0755          - bin/pidof -> busybox
+l 0755          - bin/ping -> busybox
+l 0755          - bin/ping6 -> busybox
+l 0755          - bin/pipe_progress -> busybox
+l 0755          - bin/pivot_root -> busybox
+l 0755          - bin/pkill -> busybox
+l 0755          - bin/pmap -> busybox
+l 0755          - bin/popmaildir -> busybox
+l 0755          - bin/poweroff -> busybox
+l 0755          - bin/powertop -> busybox
+l 0755          - bin/printenv -> busybox
+l 0755          - bin/printf -> busybox
+l 0755          - bin/ps -> busybox
+l 0755          - bin/pscan -> busybox
+l 0755          - bin/pstree -> busybox
+l 0755          - bin/pwd -> busybox
+l 0755          - bin/pwdx -> busybox
+l 0755          - bin/raidautorun -> busybox
+l 0755          - bin/rdate -> busybox
+l 0755          - bin/rdev -> busybox
+l 0755          - bin/readahead -> busybox
+l 0755          - bin/readlink -> busybox
+l 0755          - bin/readprofile -> busybox
+l 0755          - bin/realpath -> busybox
+l 0755          - bin/reboot -> busybox
+l 0755          - bin/reformime -> busybox
+l 0755          - bin/remove-shell -> busybox
+l 0755          - bin/renice -> busybox
+l 0755          - bin/reset -> busybox
+l 0755          - bin/resize -> busybox
+l 0755          - bin/resume -> busybox
+l 0755          - bin/rev -> busybox
+l 0755          - bin/rm -> busybox
+l 0755          - bin/rmdir -> busybox
+l 0755          - bin/rmmod -> busybox
+l 0755          - bin/route -> busybox
+l 0755          - bin/rpm -> busybox
+l 0755          - bin/rpm2cpio -> busybox
+l 0755          - bin/rtcwake -> busybox
+l 0755          - bin/run-init -> busybox
+l 0755          - bin/run-parts -> busybox
+l 0755          - bin/runsv -> busybox
+l 0755          - bin/runsvdir -> busybox
+l 0755          - bin/rx -> busybox
+l 0755          - bin/script -> busybox
+l 0755          - bin/scriptreplay -> busybox
+l 0755          - bin/sed -> busybox
+l 0755          - bin/seedrng -> busybox
+l 0755          - bin/sendmail -> busybox
+l 0755          - bin/seq -> busybox
+l 0755          - bin/setarch -> busybox
+l 0755          - bin/setconsole -> busybox
+l 0755          - bin/setfattr -> busybox
+l 0755          - bin/setfont -> busybox
+l 0755          - bin/setkeycodes -> busybox
+l 0755          - bin/setlogcons -> busybox
+l 0755          - bin/setpriv -> busybox
+l 0755          - bin/setserial -> busybox
+l 0755          - bin/setsid -> busybox
+l 0755          - bin/setuidgid -> busybox
+l 0755          - bin/sh -> busybox
+l 0755          - bin/sha1sum -> busybox
+l 0755          - bin/sha256sum -> busybox
+l 0755          - bin/sha384sum -> busybox
+l 0755          - bin/sha3sum -> busybox
+l 0755          - bin/sha512sum -> busybox
+l 0755          - bin/showkey -> busybox
+l 0755          - bin/shred -> busybox
+l 0755          - bin/shuf -> busybox
+l 0755          - bin/slattach -> busybox
+l 0755          - bin/sleep -> busybox
+l 0755          - bin/smemcap -> busybox
+l 0755          - bin/softlimit -> busybox
+l 0755          - bin/sort -> busybox
+l 0755          - bin/split -> busybox
+l 0755          - bin/ssl_client -> busybox
+l 0755          - bin/ssl_server -> busybox
+l 0755          - bin/start-stop-daemon -> busybox
+l 0755          - bin/stat -> busybox
+l 0755          - bin/strings -> busybox
+l 0755          - bin/stty -> busybox
+l 0755          - bin/su -> busybox
+l 0755          - bin/sulogin -> busybox
+l 0755          - bin/sum -> busybox
+l 0755          - bin/sv -> busybox
+l 0755          - bin/svc -> busybox
+l 0755          - bin/svlogd -> busybox
+l 0755          - bin/svok -> busybox
+l 0755          - bin/swapoff -> busybox
+l 0755          - bin/swapon -> busybox
+l 0755          - bin/switch_root -> busybox
+l 0755          - bin/sync -> busybox
+l 0755          - bin/sysctl -> busybox
+l 0755          - bin/syslogd -> busybox
+l 0755          - bin/tac -> busybox
+l 0755          - bin/tail -> busybox
+l 0755          - bin/tar -> busybox
+l 0755          - bin/taskset -> busybox
+l 0755          - bin/tc -> busybox
+l 0755          - bin/tcpsvd -> busybox
+l 0755          - bin/tee -> busybox
+l 0755          - bin/telnet -> busybox
+l 0755          - bin/telnetd -> busybox
+l 0755          - bin/test -> busybox
+l 0755          - bin/tftp -> busybox
+l 0755          - bin/tftpd -> busybox
+l 0755          - bin/time -> busybox
+l 0755          - bin/timeout -> busybox
+l 0755          - bin/top -> busybox
+l 0755          - bin/touch -> busybox
+l 0755          - bin/tr -> busybox
+l 0755          - bin/traceroute -> busybox
+l 0755          - bin/traceroute6 -> busybox
+l 0755          - bin/tree -> busybox
+l 0755          - bin/true -> busybox
+l 0755          - bin/truncate -> busybox
+l 0755          - bin/ts -> busybox
+l 0755          - bin/tsort -> busybox
+l 0755          - bin/tty -> busybox
+l 0755          - bin/ttysize -> busybox
+l 0755          - bin/tunctl -> busybox
+l 0755          - bin/ubiattach -> busybox
+l 0755          - bin/ubidetach -> busybox
+l 0755          - bin/ubimkvol -> busybox
+l 0755          - bin/ubirename -> busybox
+l 0755          - bin/ubirmvol -> busybox
+l 0755          - bin/ubirsvol -> busybox
+l 0755          - bin/ubiupdatevol -> busybox
+l 0755          - bin/udhcpc -> busybox
+l 0755          - bin/udhcpc6 -> busybox
+l 0755          - bin/udhcpd -> busybox
+l 0755          - bin/udpsvd -> busybox
+l 0755          - bin/uevent -> busybox
+l 0755          - bin/umount -> busybox
+l 0755          - bin/uname -> busybox
+l 0755          - bin/unexpand -> busybox
+l 0755          - bin/uniq -> busybox
+l 0755          - bin/unix2dos -> busybox
+l 0755          - bin/unlink -> busybox
+l 0755          - bin/unlzma -> busybox
+l 0755          - bin/unshare -> busybox
+l 0755          - bin/unxz -> busybox
+l 0755          - bin/unzip -> busybox
+l 0755          - bin/uptime -> busybox
+l 0755          - bin/usleep -> busybox
+l 0755          - bin/uudecode -> busybox
+l 0755          - bin/uuencode -> busybox
+l 0755          - bin/uuidgen -> busybox
+l 0755          - bin/vconfig -> busybox
+l 0755          - bin/vi -> busybox
+l 0755          - bin/vlock -> busybox
+l 0755          - bin/vmstat -> busybox
+l 0755          - bin/volname -> busybox
+l 0755          - bin/watch -> busybox
+l 0755          - bin/watchdog -> busybox
+l 0755          - bin/wc -> busybox
+l 0755          - bin/wget -> busybox
+l 0755          - bin/which -> busybox
+l 0755          - bin/whoami -> busybox
+l 0755          - bin/whois -> busybox
+l 0755          - bin/xargs -> busybox
+l 0755          - bin/xxd -> busybox
+l 0755          - bin/xz -> busybox
+l 0755          - bin/xzcat -> busybox
+l 0755          - bin/yes -> busybox
+l 0755          - bin/zcat -> busybox
+l 0755          - bin/zcip -> busybox
+d 0755          - dev/
+d 0755          - etc/
+- 0644         34 etc/hosts  sha256:b69b2c741be48691edabe3771c644c70473ccd6aa8effd9f17cc07fa129917f9
+- 0644         73 etc/passwd  sha256:a56ccbe86e6017c04241e5533585732e5736aba55fa57d153bbd9d6963adf8e2
+d 0755          - proc/
+d 0755          - tmp/
+d 0755          - usr/
+d 0755          - usr/bin/
+l 0755          - usr/bin/env -> /bin/busybox
+d 0755          - usr/share/
+d 0755          - usr/share/zoneinfo/
+d 0755          - usr/share/zoneinfo/Africa/
+- 0644        148 usr/share/zoneinfo/Africa/Abidjan  sha256:d2efac4e5f23d88c95d72c1db42807170f52f43dd98a205af5a92a91b9f2d997
+h 0644          - usr/share/zoneinfo/Africa/Accra => usr/share/zoneinfo/Africa/Abidjan
+- 0644        265 usr/share/zoneinfo/Africa/Addis_Ababa  sha256:c89b2e253a8926a6cecf7eff34e4bfcdb7fe24daff22d84718c30deec0ea4968
+- 0644        735 usr/share/zoneinfo/Africa/Algiers  sha256:bda1698cd542c0e6e76dfbbcdab390cdd26f37a9d5826a57a50d5aab37f3b2a6
+h 0644          - usr/share/zoneinfo/Africa/Asmara => usr/share/zoneinfo/Africa/Addis_Ababa
+h 0644          - usr/share/zoneinfo/Africa/Asmera => usr/share/zoneinfo/Africa/Addis_Ababa
+h 0644          - usr/share/zoneinfo/Africa/Bamako => usr/share/zoneinfo/Africa/Abidjan
+- 0644        235 usr/share/zoneinfo/Africa/Bangui  sha256:cffeb0282ccbd7fba0e493ff8677a1e5a6dd5197885042e437f95a773f844846
+h 0644          - usr/share/zoneinfo/Africa/Banjul => usr/share/zoneinfo/Africa/Abidjan
+- 0644        194 usr/share/zoneinfo/Africa/Bissau  sha256:223bb10cfe846620c716f97f6c74ba34deec751c4b297965a28042f36f69a1a9
+- 0644        149 usr/share/zoneinfo/Africa/Blantyre  sha256:444ed3a710414bc6bf43eb27e591da49d3be3db153449a6a0c9473f7e39fdbcb
+h 0644          - usr/share/zoneinfo/Africa/Brazzaville => usr/share/zoneinfo/Africa/Bangui
+h 0644          - usr/share/zoneinfo/Africa/Bujumbura => usr/share/zoneinfo/Africa/Blantyre
+- 0644       2399 usr/share/zoneinfo/Africa/Cairo  sha256:2dfb7e1822d085a4899bd56a526b041681c84b55617daee91499fd1990a989fb
+- 0644       2429 usr/share/zoneinfo/Africa/Casablanca  sha256:e11a956f0fc5dd9b9ca29202da2bc027c583c23e7044e0c007aeed0697577200
+- 0644       2052 usr/share/zoneinfo/Africa/Ceuta  sha256:0b0fb6fe714319b37c5aa22c56971abb2668a165fc8f72a6c763e70b47c7badf
+h 0644          - usr/share/zoneinfo/Africa/Conakry => usr/share/zoneinfo/Africa/Abidjan
+h 0644          - usr/share/zoneinfo/Africa/Dakar => usr/share/zoneinfo/Africa/Abidjan
+h 0644          - usr/share/zoneinfo/Africa/Dar_es_Salaam => usr/share/zoneinfo/Africa/Addis_Ababa
+h 0644          - usr/share/zoneinfo/Africa/Djibouti => usr/share/zoneinfo/Africa/Addis_Ababa
+h 0644          - usr/share/zoneinfo/Africa/Douala => usr/share/zoneinfo/Africa/Bangui
+- 0644       2295 usr/share/zoneinfo/Africa/El_Aaiun  sha256:516082a902c9c5df2ab13630f36933f56d6cbb05b94d1827670df5b03583cf6d
+h 0644          - usr/share/zoneinfo/Africa/Freetown => usr/share/zoneinfo/Africa/Abidjan
+h 0644          - usr/share/zoneinfo/Africa/Gaborone => usr/share/zoneinfo/Africa/Blantyre
+h 0644          - usr/share/zoneinfo/Africa/Harare => usr/share/zoneinfo/Africa/Blantyre
+- 0644        246 usr/share/zoneinfo/Africa/Johannesburg  sha256:6c1bcc752668e77585a308ae8543bd0bccd8e813865626e809bf94f3fe3d977e
+- 0644        679 usr/share/zoneinfo/Africa/Juba  sha256:5159c8a843c9c072d3302fabe6a6501cdbfda29a1856c29dabeb5aff95d4c3f4
+h 0644          - usr/share/zoneinfo/Africa/Kampala => usr/share/zoneinfo/Africa/Addis_Ababa
+- 0644        679 usr/share/zoneinfo/Africa/Khartoum  sha256:318583a09dc070222d65d029a1e3a0b565830f1aaec13a27e6fe533863fbd3ea
+h 0644          - usr/share/zoneinfo/Africa/Kigali => usr/share/zoneinfo/Africa/Blantyre
+h 0644          - usr/share/zoneinfo/Africa/Kinshasa => usr/share/zoneinfo/Africa/Bangui
+h 0644          - usr/share/zoneinfo/Africa/Lagos => usr/share/zoneinfo/Africa/Bangui
+h 0644          - usr/share/zoneinfo/Africa/Libreville => usr/share/zoneinfo/Africa/Bangui
+h 0644          - usr/share/zoneinfo/Africa/Lome => usr/share/zoneinfo/Africa/Abidjan
+h 0644          - usr/share/zoneinfo/Africa/Luanda => usr/share/zoneinfo/Africa/Bangui
+h 0644          - usr/share/zoneinfo/Africa/Lubumbashi => usr/share/zoneinfo/Africa/Blantyre
+h 0644          - usr/share/zoneinfo/Africa/Lusaka => usr/share/zoneinfo/Africa/Blantyre
+h 0644          - usr/share/zoneinfo/Africa/Malabo => usr/share/zoneinfo/Africa/Bangui
+h 0644          - usr/share/zoneinfo/Africa/Maputo => usr/share/zoneinfo/Africa/Blantyre
+h 0644          - usr/share/zoneinfo/Africa/Maseru => usr/share/zoneinfo/Africa/Johannesburg
+h 0644          - usr/share/zoneinfo/Africa/Mbabane => usr/share/zoneinfo/Africa/Johannesburg
+h 0644          - usr/share/zoneinfo/Africa/Mogadishu => usr/share/zoneinfo/Africa/Addis_Ababa
+- 0644        208 usr/share/zoneinfo/Africa/Monrovia  sha256:f95b095b9714e0a76f7e061a415bf895cbb399a28854531de369cee915ce05d5
+h 0644          - usr/share/zoneinfo/Africa/Nairobi => usr/share/zoneinfo/Africa/Addis_Ababa
+- 0644        199 usr/share/zoneinfo/Africa/Ndjamena  sha256:f13dc0d199bd1a3d01be6eab77cf2ddc60172a229d1947c7948a98964608d0a3
+h 0644          - usr/share/zoneinfo/Africa/Niamey => usr/share/zoneinfo/Africa/Bangui
+h 0644          - usr/share/zoneinfo/Africa/Nouakchott => usr/share/zoneinfo/Africa/Abidjan
+h 0644          - usr/share/zoneinfo/Africa/Ouagadougou => usr/share/zoneinfo/Africa/Abidjan
+h 0644          - usr/share/zoneinfo/Africa/Porto-Novo => usr/share/zoneinfo/Africa/Bangui
+- 0644        254 usr/share/zoneinfo/Africa/Sao_Tome  sha256:31d8f1a50dbaf2ecc9ed9c7566ba0552d454c2ab09e85ff263701857d157c352
+h 0644          - usr/share/zoneinfo/Africa/Timbuktu => usr/share/zoneinfo/Africa/Abidjan
+- 0644        625 usr/share/zoneinfo/Africa/Tripoli  sha256:5b5769b460fbd13ee9a46a28d1f733150783888a749ee96d2cd3d5eba3300767
+- 0644        689 usr/share/zoneinfo/Africa/Tunis  sha256:38554c10ce1e613d84cf46deba1114093488a5c165756c6c576b84a1364850d2
+- 0644        955 usr/share/zoneinfo/Africa/Windhoek  sha256:c6e86fb9dacc1f86a59d59a8b924d023c60bf05fc76e0b05d8443b0192b3b87b
+d 0755          - usr/share/zoneinfo/America/
+- 0644       2356 usr/share/zoneinfo/America/Adak  sha256:201d4387025000a6e13c9f631cb7fccd6e4369dec7224052f9d86feb81353a53
+- 0644       2371 usr/share/zoneinfo/America/Anchorage  sha256:a190353523d2d8159dca66299c21c53bc0656154be965e4a2e0d84cfd09b113b
+- 0644        246 usr/share/zoneinfo/America/Anguilla  sha256:8491e557ff801a8306516b8ca5946ff5f2e6821af31477eb47d7d191cc5a6497
+h 0644          - usr/share/zoneinfo/America/Antigua => usr/share/zoneinfo/America/Anguilla
+- 0644        870 usr/share/zoneinfo/America/Araguaina  sha256:1babfdc18159f040785907c8b2a45b6e288a7766f6ee3ed9b797458c16f3c76a
+d 0755          - usr/share/zoneinfo/America/Argentina/
+- 0644       1062 usr/share/zoneinfo/America/Argentina/Buenos_Aires  sha256:26653c941c26cb6f6047a3a67b2b6f15d311c7a39b24a9d834798bc8c9975f63
+- 0644       1062 usr/share/zoneinfo/America/Argentina/Catamarca  sha256:b8c0895d719898d1121d5be3e5160167431cace744d788709b5ee5db9320456d
+h 0644          - usr/share/zoneinfo/America/Argentina/ComodRivadavia => usr/share/zoneinfo/America/Argentina/Catamarca
+- 0644       1062 usr/share/zoneinfo/America/Argentina/Cordoba  sha256:ba788d8a184c1e7af85cae16a7088f527ac04f460f9afcea07a7f48512ed5ef6
+- 0644       1034 usr/share/zoneinfo/America/Argentina/Jujuy  sha256:3c69807a1ca90b18f45c27a70925aaca50c83db28b2b40e5af024aff6e03e7dd
+- 0644       1076 usr/share/zoneinfo/America/Argentina/La_Rioja  sha256:526e97a155e1b2beb669dd665ae79b7ba358d191dab81751f6d3060e0a823878
+- 0644       1062 usr/share/zoneinfo/America/Argentina/Mendoza  sha256:c5c395b6f47255814053dd32d90630a72421a4c2f2029efe171be4bb89209747
+- 0644       1062 usr/share/zoneinfo/America/Argentina/Rio_Gallegos  sha256:17d64a478a3c80b1d7ed006e22331aa4621d9b3271a6ac1ba2e3e067932a0e96
+- 0644       1034 usr/share/zoneinfo/America/Argentina/Salta  sha256:875298ac33486a9bc3918862d4f681f160f5a9639ee2f8618032560c2195e237
+- 0644       1076 usr/share/zoneinfo/America/Argentina/San_Juan  sha256:008d8696d03cd263cdce11f163272e13021b3b500d5f222a05064ca63a8aa9d4
+- 0644       1088 usr/share/zoneinfo/America/Argentina/San_Luis  sha256:d88b4645c2d52b6c31f0cc89b076c8041780914e01f8c379c7567137267b5091
+- 0644       1090 usr/share/zoneinfo/America/Argentina/Tucuman  sha256:b703be16ab4d255f173b3593bc543ec6711c582a035076378295481b43336dff
+- 0644       1062 usr/share/zoneinfo/America/Argentina/Ushuaia  sha256:03a21ba55958f4820fa1228c15147d0cc44e7705d44837361ec012b9e3929eaa
+h 0644          - usr/share/zoneinfo/America/Aruba => usr/share/zoneinfo/America/Anguilla
+- 0644       1644 usr/share/zoneinfo/America/Asuncion  sha256:f727c68843615cd81ddbfd311d5b05fa12de264192a91b3ecc3f4ef78e4a2567
+- 0644        182 usr/share/zoneinfo/America/Atikokan  sha256:91ac80fe976931c490d058c8ce8b5d71ffa6d4961f6ca13ea9c153f0b0bccea0
+h 0644          - usr/share/zoneinfo/America/Atka => usr/share/zoneinfo/America/Adak
+- 0644       1010 usr/share/zoneinfo/America/Bahia  sha256:aa2edd03a1687c384bc553267762fc6cadc779a42773d5fe8e28a3c327e1b378
+- 0644       1100 usr/share/zoneinfo/America/Bahia_Banderas  sha256:32fad7189e4bcda1ce7a0b89ab1b33c63c4c85569f1956e4fa88d711ceff6042
+- 0644        436 usr/share/zoneinfo/America/Barbados  sha256:8a66be42bae16b3bb841fbeed99d3e7ba13e193898927b8906ee9cdb2546f4b1
+- 0644        562 usr/share/zoneinfo/America/Belem  sha256:69931482d1437473484a9ab241161b992d88043f81012dc26899e1bbaa272c26
+- 0644       1614 usr/share/zoneinfo/America/Belize  sha256:a647cb63629f3dc85b7896b5a56717996030a7866546fc562d57b35e7adb930b
+h 0644          - usr/share/zoneinfo/America/Blanc-Sablon => usr/share/zoneinfo/America/Anguilla
+- 0644        618 usr/share/zoneinfo/America/Boa_Vista  sha256:74cb5a1b5d641a526b8092601961036590269cefc77d3dcbe17f2923bd8b2c56
+- 0644        232 usr/share/zoneinfo/America/Bogota  sha256:6757ab9d9646431ba513c28558761670cdd25758e7dbf404735434389cc745a9
+- 0644       2410 usr/share/zoneinfo/America/Boise  sha256:ec742c34f262521790805cf99152ef4e77f9c615c061a78036a0ec9312b3d95b
+h 0644          - usr/share/zoneinfo/America/Buenos_Aires => usr/share/zoneinfo/America/Argentina/Buenos_Aires
+- 0644       2254 usr/share/zoneinfo/America/Cambridge_Bay  sha256:ff8c51957dd6755a4472aa13ea6c83ecd7930979e7f4e624fe21f4d3a6f050ba
+- 0644       1430 usr/share/zoneinfo/America/Campo_Grande  sha256:8083625e0e62d9ee9187635ba366c5aa13c024be05e1c02a1a705a9e45d30d7c
+- 0644        864 usr/share/zoneinfo/America/Cancun  sha256:11d574370d968cced59e3147a2ae63b126cbbae13b78fd4e13be2eb44c96246e
+- 0644        250 usr/share/zoneinfo/America/Caracas  sha256:99434c15d0f364b6affde3c0d68701766a950627ab91e12ccd3205a4d0a6e49d
+h 0644          - usr/share/zoneinfo/America/Catamarca => usr/share/zoneinfo/America/Argentina/Catamarca
+- 0644        184 usr/share/zoneinfo/America/Cayenne  sha256:e24ec8bf5c285f86ada9e3caadcbcc403d9593d4e699aeeb5bf016fd1eb6a427
+h 0644          - usr/share/zoneinfo/America/Cayman => usr/share/zoneinfo/America/Atikokan
+- 0644       3592 usr/share/zoneinfo/America/Chicago  sha256:feba326ebe88eac20017a718748c46c68469a1e7f5e7716dcb8f1d43a6e6f686
+- 0644       1102 usr/share/zoneinfo/America/Chihuahua  sha256:dcd8336de760f00cc0ab1b1b4121b48d5471f8bc58970d62de4c7e63397ed887
+- 0644       1538 usr/share/zoneinfo/America/Ciudad_Juarez  sha256:8abe1bdbb0e216b84bd07e1f650f769c46be041a0f7cb588cf7a61537ef77601
+h 0644          - usr/share/zoneinfo/America/Coral_Harbour => usr/share/zoneinfo/America/Atikokan
+h 0644          - usr/share/zoneinfo/America/Cordoba => usr/share/zoneinfo/America/Argentina/Cordoba
+- 0644        316 usr/share/zoneinfo/America/Costa_Rica  sha256:ef8ad86ba96b80893296cf4f907a3c482625f683aa8ae1b94bb31676725e94fe
+- 0644       2126 usr/share/zoneinfo/America/Coyhaique  sha256:6de65753a2f0e63c765a9ddd3519058a87d71a66b674ce83b2abc94fd0921dd7
+- 0644        360 usr/share/zoneinfo/America/Creston  sha256:8a5973d2c62e2cbf2520f2b44e4a2ee9d2f455c93f0f45bfdeb4533af1584664
+- 0644       1402 usr/share/zoneinfo/America/Cuiaba  sha256:19126a92145736c3947208d975d43144825d4586b0f6933f60b59bba7f3c7648
+h 0644          - usr/share/zoneinfo/America/Curacao => usr/share/zoneinfo/America/Anguilla
+- 0644        698 usr/share/zoneinfo/America/Danmarkshavn  sha256:6116407d40a856d68bd4bf8c60c60c1f5c3239a5509df528fe0167bcc5d2bb3c
+- 0644       1614 usr/share/zoneinfo/America/Dawson  sha256:ac01e1cae32eca37ff7b20364811bbe8c4417ff7e3ff18b9140ba2595420261c
+- 0644       1050 usr/share/zoneinfo/America/Dawson_Creek  sha256:6895c2c8fe23de0804e3018237e2eb4bd8690ffe73587cd04de4802935843d43
+- 0644       2460 usr/share/zoneinfo/America/Denver  sha256:32e819c00a43b3c348f539d700d425504f20b8d068c16418d26fa9b693e775c9
+- 0644       2230 usr/share/zoneinfo/America/Detroit  sha256:85e733f32a98d828f907ad46de02d9740559bd180af65d0ff7473f80dfae0f98
+h 0644          - usr/share/zoneinfo/America/Dominica => usr/share/zoneinfo/America/Anguilla
+- 0644       2332 usr/share/zoneinfo/America/Edmonton  sha256:f939087dcdd096f6827f4a7c08e678dd8d47441025fa7011522f8975778ad6f1
+- 0644        642 usr/share/zoneinfo/America/Eirunepe  sha256:8f9784c648c56aab42f83f172b4ac6ce817dc8481b4a54db3ea546f562a111af
+- 0644        224 usr/share/zoneinfo/America/El_Salvador  sha256:82f18df0b923fac1a6dbfaecf0e52300c7f5a0cb4aa765deb3a51f593d16aa05
+- 0644       2458 usr/share/zoneinfo/America/Ensenada  sha256:4a5b95ef1cd99b6e0b80c5d2515b75703d40944ef2fdb744eb91e10c87572dcb
+- 0644       2240 usr/share/zoneinfo/America/Fort_Nelson  sha256:7ab7ce0ebdc3ad2a73eb990074eed3b367466d9c6f75d10fea0c78057df2d89d
+- 0644       1682 usr/share/zoneinfo/America/Fort_Wayne  sha256:90d2b2f4a8fd202b226187c209b020833300edec5ff86a463ccc685e8707532c
+- 0644        702 usr/share/zoneinfo/America/Fortaleza  sha256:ae3892074ab5701b8c0ce33da2b5bfbb07b950e2c1c1395f8c5a2dc0e61ed665
+- 0644       2192 usr/share/zoneinfo/America/Glace_Bay  sha256:1bc0c62c609aa47fda60217f3a168be50a277fb14e02000fc1e94ee61b425817
+- 0644       1889 usr/share/zoneinfo/America/Godthab  sha256:2865eb30df98918a550a02dda5c7f030543bec4b11006b235021b7c8052f55fc
+- 0644       3210 usr/share/zoneinfo/America/Goose_Bay  sha256:26068bb9e8214af5f683bdb914e7c882982fb2ac591b29163a1019586a506516
+- 0644       1834 usr/share/zoneinfo/America/Grand_Turk  sha256:e1838510f2bad017a5dbf7c2b18eaf499c5470c24a8e22adc8e7ff4349211305
+h 0644          - usr/share/zoneinfo/America/Grenada => usr/share/zoneinfo/America/Anguilla
+h 0644          - usr/share/zoneinfo/America/Guadeloupe => usr/share/zoneinfo/America/Anguilla
+- 0644        280 usr/share/zoneinfo/America/Guatemala  sha256:76e81480277a418e76c87907b943f88d15b3a39c78dfd2108a06980af105e3a4
+- 0644        232 usr/share/zoneinfo/America/Guayaquil  sha256:8f652e228fb846048e95335fbbbee6859f76c1a35378a152be6a157a6268a13d
+- 0644        248 usr/share/zoneinfo/America/Guyana  sha256:4746cebc24430bc49121ec6686c76e3dd1db6d13f02361af883f68b44c6252b9
+- 0644       3424 usr/share/zoneinfo/America/Halifax  sha256:4d9a667393f05a82df4df42843f6f7535ec113689529278d911d07a3c99b4e7f
+- 0644       2416 usr/share/zoneinfo/America/Havana  sha256:1d441e02e281b04908e522d98eaca75c808e51539a8e42b3287e6bf8ebf939d7
+- 0644        388 usr/share/zoneinfo/America/Hermosillo  sha256:8b160a7acb4b992ee05a86e4f4aaba16d2d9a35caa6d601cb6b1542a5bb372dc
+d 0755          - usr/share/zoneinfo/America/Indiana/
+h 0644          - usr/share/zoneinfo/America/Indiana/Indianapolis => usr/share/zoneinfo/America/Fort_Wayne
+- 0644       2444 usr/share/zoneinfo/America/Indiana/Knox  sha256:0acbd9e412b0daa55abf7c7f17c094f6d68974393b8d7e3509fb2a9acea35d5f
+- 0644       1738 usr/share/zoneinfo/America/Indiana/Marengo  sha256:7f7b50fa580c49403b9ef9fae295e12ad24bee65b319a8e809e81ae4c10949b2
+- 0644       1920 usr/share/zoneinfo/America/Indiana/Petersburg  sha256:03cf0e1ee334460de230b1e32a05eafddda36427554b2b5442cfbd5b429c1724
+- 0644       1700 usr/share/zoneinfo/America/Indiana/Tell_City  sha256:e1d5aa02bf58d815df2f8a40424fbcd5cde01a5d9c35d1d7383effc09861867f
+- 0644       1430 usr/share/zoneinfo/America/Indiana/Vevay  sha256:1fb551d86fbfb03fc2e519b83f78358910b515608f8389b43060f73f53cbcec9
+- 0644       1710 usr/share/zoneinfo/America/Indiana/Vincennes  sha256:eb6980c53ec03c509aa3281f96713374ea5ef9fb96d7239b23a9ba11451c4bb0
+- 0644       1794 usr/share/zoneinfo/America/Indiana/Winamac  sha256:69918cda347c087f411d252aed7ca08b078377a768ad72cf5e0db8e97b1b47ab
+h 0644          - usr/share/zoneinfo/America/Indianapolis => usr/share/zoneinfo/America/Fort_Wayne
+- 0644       2074 usr/share/zoneinfo/America/Inuvik  sha256:e89fa66a90e7ae4f40d4bb6cc28137e2da92cbfb9f79d70404dc62c64ac48c8a
+- 0644       2202 usr/share/zoneinfo/America/Iqaluit  sha256:7de3a7c40374374afe335aa592b03824cc9ac28734b6a69ed2288108f0c0b389
+- 0644        482 usr/share/zoneinfo/America/Jamaica  sha256:c256a089e50f45fe7e6de89efa1ed0b0e35b3738c6b26f2f32cf2e7f6f29c36f
+h 0644          - usr/share/zoneinfo/America/Jujuy => usr/share/zoneinfo/America/Argentina/Jujuy
+- 0644       2353 usr/share/zoneinfo/America/Juneau  sha256:93b8716f46864677e713e0c18b72e472303344fc807f4fc7c34bd515f8c679bd
+d 0755          - usr/share/zoneinfo/America/Kentucky/
+- 0644       2788 usr/share/zoneinfo/America/Kentucky/Louisville  sha256:b4fd3bdb157f9ffbc8423c71709efb0067868fac8bd4a3e99f77f089db3d8355
+- 0644       2368 usr/share/zoneinfo/America/Kentucky/Monticello  sha256:2ed7720a8f3906b5d0b3aae51fad589bef0aa961c7e8fc003a30f44318487733
+h 0644          - usr/share/zoneinfo/America/Knox_IN => usr/share/zoneinfo/America/Indiana/Knox
+h 0644          - usr/share/zoneinfo/America/Kralendijk => usr/share/zoneinfo/America/Anguilla
+- 0644        218 usr/share/zoneinfo/America/La_Paz  sha256:86a7c3f0b407ba97598638b67bddfff69390013f91ee6bb3ce33f49f27db1576
+- 0644        392 usr/share/zoneinfo/America/Lima  sha256:1c78139c3527099ce26ef2f432b1bcab23aebe3998630ddedd1e556e7c4c66cf
+- 0644       2852 usr/share/zoneinfo/America/Los_Angeles  sha256:68977bb9ad6d186fefc6c7abd36010a66e30008dcb2d376087a41c49861e7268
+h 0644          - usr/share/zoneinfo/America/Louisville => usr/share/zoneinfo/America/Kentucky/Louisville
+h 0644          - usr/share/zoneinfo/America/Lower_Princes => usr/share/zoneinfo/America/Anguilla
+- 0644        730 usr/share/zoneinfo/America/Maceio  sha256:dd1e439527b7da44039a8495216a5cca4da8eeaa21afeae58b0a834861483324
+- 0644        430 usr/share/zoneinfo/America/Managua  sha256:c41cc5d350079f61367c3f10772f831c57b7e94aa878da4a3df0a176e04a59d9
+- 0644        590 usr/share/zoneinfo/America/Manaus  sha256:17a44b38e78e8bd972999890990f6947cb45a4f67a120b8d74f7ce73a0615c31
+h 0644          - usr/share/zoneinfo/America/Marigot => usr/share/zoneinfo/America/Anguilla
+- 0644        232 usr/share/zoneinfo/America/Martinique  sha256:7ccb3cd24394d9816f0b47fdcb67a37bdec9780b536016a65eb9e54ee9cd2f34
+- 0644       1418 usr/share/zoneinfo/America/Matamoros  sha256:7eaf8fa9d999ad0f7c52c1661c0f62be3059bf91840514ceb8b4390aee5a8d6f
+- 0644       1060 usr/share/zoneinfo/America/Mazatlan  sha256:0561f636a54f0353ecc842cf37fd8117c2a596bb26424aa0d5eba3b10be79f1f
+h 0644          - usr/share/zoneinfo/America/Mendoza => usr/share/zoneinfo/America/Argentina/Mendoza
+- 0644       2274 usr/share/zoneinfo/America/Menominee  sha256:02bbfd58b6df84d72946c5231c353be7b044770969d3c1addf4022c46de0674e
+- 0644       1004 usr/share/zoneinfo/America/Merida  sha256:4953441c26b38e899fb67b8f5416b2148f84f884345a696e1df4e91cfd21dddd
+- 0644       1423 usr/share/zoneinfo/America/Metlakatla  sha256:b709a27864d563657e53c9c5c6abf1edab18bfc1958de59d2edace23b500a552
+- 0644       1222 usr/share/zoneinfo/America/Mexico_City  sha256:528836f85316cf6a35da347ab0af6f7a625a98b7a8e8e105310477b34c53c647
+- 0644       1652 usr/share/zoneinfo/America/Miquelon  sha256:979b7104961ef474d166520b71b48bfc734362b8d46f4a2e79c372ed012483d7
+- 0644       3154 usr/share/zoneinfo/America/Moncton  sha256:5a6bfe6e4f5a28a7165b33a9735505bbaec739fc1a224d969a1dcb82a19cb72b
+- 0644       1114 usr/share/zoneinfo/America/Monterrey  sha256:622c5311226e6dfe990545f2ea0df6840336811e065d73ea394e2dbf42f7906d
+- 0644       1496 usr/share/zoneinfo/America/Montevideo  sha256:7501011389a364fb724632972ba67e6cc1c9745aa9c21233c431f8c74e2b2989
+- 0644       3494 usr/share/zoneinfo/America/Montreal  sha256:a587a1a1607439f7bac283e1815f2bdbafb9649a453d18e06c2e44e6996d888f
+h 0644          - usr/share/zoneinfo/America/Montserrat => usr/share/zoneinfo/America/Anguilla
+h 0644          - usr/share/zoneinfo/America/Nassau => usr/share/zoneinfo/America/Montreal
+- 0644       3552 usr/share/zoneinfo/America/New_York  sha256:e9ed07d7bee0c76a9d442d091ef1f01668fee7c4f26014c0a868b19fe6c18a95
+h 0644          - usr/share/zoneinfo/America/Nipigon => usr/share/zoneinfo/America/Montreal
+- 0644       2367 usr/share/zoneinfo/America/Nome  sha256:da2cccdfe3fe3ea27dcdae8c761cc57ccbcf14dabb1a29baf6d02f1303de636b
+- 0644        702 usr/share/zoneinfo/America/Noronha  sha256:7de7910228d0a8aca5660a9ef389ca86c14bc9c4f9cc8066ee62c8bddc86c38c
+d 0755          - usr/share/zoneinfo/America/North_Dakota/
+- 0644       2396 usr/share/zoneinfo/America/North_Dakota/Beulah  sha256:aad81ba8dbbc3370241c5da7fbfa12a6cd69613e12c607256e490f29b5da047b
+- 0644       2396 usr/share/zoneinfo/America/North_Dakota/Center  sha256:f5959b2bd60a92ab942f2054152dcbaff89dc5bb7b57bcb85b810ed0a9f6d2cc
+- 0644       2396 usr/share/zoneinfo/America/North_Dakota/New_Salem  sha256:0c7fdbb107ee5272b6a1b75bd3a2a08ac3b85cbaa1b75d815ddae052c659bde8
+h 0644          - usr/share/zoneinfo/America/Nuuk => usr/share/zoneinfo/America/Godthab
+- 0644       1524 usr/share/zoneinfo/America/Ojinaga  sha256:6f7f10ffb55d902673695c1bece5ee75d8a1240cd428f4d3a97726a419b59ed1
+h 0644          - usr/share/zoneinfo/America/Panama => usr/share/zoneinfo/America/Atikokan
+h 0644          - usr/share/zoneinfo/America/Pangnirtung => usr/share/zoneinfo/America/Iqaluit
+- 0644        248 usr/share/zoneinfo/America/Paramaribo  sha256:67b519bcd96077ea845078c43d85c890b35382331c0b393d11f51412653277b3
+h 0644          - usr/share/zoneinfo/America/Phoenix => usr/share/zoneinfo/America/Creston
+- 0644       1434 usr/share/zoneinfo/America/Port-au-Prince  sha256:d3d64025de083a23297dda54b85d54e3847f851b7a06fa409055ce9d83bdc8e3
+h 0644          - usr/share/zoneinfo/America/Port_of_Spain => usr/share/zoneinfo/America/Anguilla
+- 0644        614 usr/share/zoneinfo/America/Porto_Acre  sha256:d20a49525e3a8506e9d0fe978f54b4340ac859e02bcaeb835e3b2576f0791871
+- 0644        562 usr/share/zoneinfo/America/Porto_Velho  sha256:b92315da16568fe572061141c02f79d3071385f3778eae8a9727044a64132ce0
+h 0644          - usr/share/zoneinfo/America/Puerto_Rico => usr/share/zoneinfo/America/Anguilla
+- 0644       1902 usr/share/zoneinfo/America/Punta_Arenas  sha256:b51e6e21fd77e7501616aaea36d9979e14169ca444989699a8a0736964553134
+- 0644       2868 usr/share/zoneinfo/America/Rainy_River  sha256:ecffbf610ae77857289fb40a4933a79221a3129a450e7dd9e3c309d6aabc541c
+- 0644       2066 usr/share/zoneinfo/America/Rankin_Inlet  sha256:9d782a8cbdced815747a6f9793ca9545165bfd7d324261c4eaf9924af23d2b37
+- 0644        702 usr/share/zoneinfo/America/Recife  sha256:6c9fc7134f89162a38fa8c29674a4b3bc5376a2d1f886bbc4072f40dec4b88b7
+- 0644        980 usr/share/zoneinfo/America/Regina  sha256:ca3a93d3ca476c80987bcdc7f099ad68306f085a91bfb4dfcdedd8f31b97ba4c
+- 0644       2066 usr/share/zoneinfo/America/Resolute  sha256:0a7314d9d048fbadefb7cf89d10d51a29c7ef1bf694422e386faf270c21e7468
+h 0644          - usr/share/zoneinfo/America/Rio_Branco => usr/share/zoneinfo/America/Porto_Acre
+h 0644          - usr/share/zoneinfo/America/Rosario => usr/share/zoneinfo/America/Argentina/Cordoba
+h 0644          - usr/share/zoneinfo/America/Santa_Isabel => usr/share/zoneinfo/America/Ensenada
+- 0644        588 usr/share/zoneinfo/America/Santarem  sha256:56664ff52e693ee705c72a80395f74f049965d066f8028162e6949253525d0b1
+- 0644       2515 usr/share/zoneinfo/America/Santiago  sha256:d020f0d77742314b28aae32ea68260ba99330143610cae84d2557151103ba2c0
+- 0644        458 usr/share/zoneinfo/America/Santo_Domingo  sha256:0cab5a123f1f43ddb26c84d3594e019b5eb44bda732665156e36964677a7c54e
+- 0644       1430 usr/share/zoneinfo/America/Sao_Paulo  sha256:04c06744ee3fe078ef3b8b779e38eb30666bf993e67a092fcaf2fc28f63a64ce
+- 0644       1935 usr/share/zoneinfo/America/Scoresbysund  sha256:2beaa488c08216039ef1c70f300040fa50e373dbdbeb0a65b8138255f88174b2
+h 0644          - usr/share/zoneinfo/America/Shiprock => usr/share/zoneinfo/America/Denver
+- 0644       2329 usr/share/zoneinfo/America/Sitka  sha256:6a24bb164dfb859a7367d56478941e17e06a4cb442d503930a03002704fc5310
+h 0644          - usr/share/zoneinfo/America/St_Barthelemy => usr/share/zoneinfo/America/Anguilla
+- 0644       3655 usr/share/zoneinfo/America/St_Johns  sha256:af5fb5eee2afdbb799dc9b15930fc32d941ba3ac2f8eeb95bbb0b6a43b263a02
+h 0644          - usr/share/zoneinfo/America/St_Kitts => usr/share/zoneinfo/America/Anguilla
+h 0644          - usr/share/zoneinfo/America/St_Lucia => usr/share/zoneinfo/America/Anguilla
+h 0644          - usr/share/zoneinfo/America/St_Thomas => usr/share/zoneinfo/America/Anguilla
+h 0644          - usr/share/zoneinfo/America/St_Vincent => usr/share/zoneinfo/America/Anguilla
+- 0644        560 usr/share/zoneinfo/America/Swift_Current  sha256:45128e17bbd90bc56f6310fc3cfe09d7f8543dac8a04fecbbbcd1abd191f3c36
+- 0644        252 usr/share/zoneinfo/America/Tegucigalpa  sha256:1333b3ee7b5396b78cabaf4967609c01bf0fb3df15f5b50c378f34b693c8cb0e
+- 0644       1502 usr/share/zoneinfo/America/Thule  sha256:f31b8f45a654f1180ee440aa1581d89a71e2a1cf35b0139a8a5915bbc634da2f
+h 0644          - usr/share/zoneinfo/America/Thunder_Bay => usr/share/zoneinfo/America/Montreal
+h 0644          - usr/share/zoneinfo/America/Tijuana => usr/share/zoneinfo/America/Ensenada
+h 0644          - usr/share/zoneinfo/America/Toronto => usr/share/zoneinfo/America/Montreal
+h 0644          - usr/share/zoneinfo/America/Tortola => usr/share/zoneinfo/America/Anguilla
+- 0644       2892 usr/share/zoneinfo/America/Vancouver  sha256:b249ca1f48d23d66a6f831df337e6a5ecf0d6a6edde5316591423d4a0c6bcb28
+h 0644          - usr/share/zoneinfo/America/Virgin => usr/share/zoneinfo/America/Anguilla
+- 0644       1614 usr/share/zoneinfo/America/Whitehorse  sha256:4eb47a3c29d81be9920a504ca21aa53fcaa76215cc52cc9d23e2feaae5c5c723
+h 0644          - usr/share/zoneinfo/America/Winnipeg => usr/share/zoneinfo/America/Rainy_River
+- 0644       2305 usr/share/zoneinfo/America/Yakutat  sha256:b45c2729bbf0872ca7e0b353027e727bf2560ddc6309eacd0edee83b05303b63
+h 0644          - usr/share/zoneinfo/America/Yellowknife => usr/share/zoneinfo/America/Edmonton
+d 0755          - usr/share/zoneinfo/Antarctica/
+- 0644        423 usr/share/zoneinfo/Antarctica/Casey  sha256:55e68b3b14df0f28df197ab9525f7924420c5cd587496fb4377c8ea12ed52be7
+- 0644        283 usr/share/zoneinfo/Antarctica/Davis  sha256:5c1d76744ab443edd793304d4cd0bb1b57f31fe5b1c5cb48b99a88df3a7cca92
+- 0644        172 usr/share/zoneinfo/Antarctica/DumontDUrville  sha256:9c1dfa1c15994dd8774e53f40cb14dcf529143468721f1dba7b2c2e14ae9f5f0
+- 0644       2260 usr/share/zoneinfo/Antarctica/Macquarie  sha256:89eed195a53c4474e8ad5563f8c5fc4ad28cab1fe85dfe141f63d4aa9cdcc1ed
+- 0644        185 usr/share/zoneinfo/Antarctica/Mawson  sha256:1232056ea45daf664905a2355efa16469b679d6d4b16b961c9dc430ee2108d22
+- 0644       2437 usr/share/zoneinfo/Antarctica/McMurdo  sha256:8000e3a323e8fd0212414e9426b020707a771c368ca0e151747f9ddb7b814b27
+- 0644       1404 usr/share/zoneinfo/Antarctica/Palmer  sha256:1d3658d0cf2d77ba14c794443e04421eea8a8395777e32448b895804d2f812d8
+- 0644        150 usr/share/zoneinfo/Antarctica/Rothera  sha256:ffd358f9ff2f928cd062b8db5073f96237080a0d3e2eec80f4f9c878ad76dd15
+h 0644          - usr/share/zoneinfo/Antarctica/South_Pole => usr/share/zoneinfo/Antarctica/McMurdo
+- 0644        151 usr/share/zoneinfo/Antarctica/Syowa  sha256:a02287eee69f37c475a3e8a35c6a13e54d49671c2fa0bcc9bbfd82ab28b68543
+- 0644       1148 usr/share/zoneinfo/Antarctica/Troll  sha256:7e3718a69c2bd459e312cb1e7be44b806380373a14c9f8ec7be4462b8e8f4761
+- 0644        213 usr/share/zoneinfo/Antarctica/Vostok  sha256:29f7edc1dccae8f90c0f3d1df83df3e0728806063d2aab2a1e74e7aac3ccad48
+d 0755          - usr/share/zoneinfo/Arctic/
+- 0644       2298 usr/share/zoneinfo/Arctic/Longyearbyen  sha256:5ee475f71a0fc1a32faeb849f8c39c6e7aa66d6d41ec742b97b3a7436b3b0701
+d 0755          - usr/share/zoneinfo/Asia/
+h 0644          - usr/share/zoneinfo/Asia/Aden => usr/share/zoneinfo/Antarctica/Syowa
+- 0644        983 usr/share/zoneinfo/Asia/Almaty  sha256:94f2d65e4d9fd66598450645908aeaff91e486872c5018acd0cfb285d0c77014
+- 0644       1433 usr/share/zoneinfo/Asia/Amman  sha256:42fe1c5d7c3b28141613cf367208f4923437c21d6fa55d68ac9dafd898f1af65
+- 0644       1174 usr/share/zoneinfo/Asia/Anadyr  sha256:5aa2a71e8e481d2599d3c776b12e72b47b6fd0c40ca1cccfdd6f736c30eb6d85
+- 0644        969 usr/share/zoneinfo/Asia/Aqtau  sha256:e27eb9e0566d0ecb1749f850b338d91b93a6b5b136ce8d4a6e259c62b149834d
+- 0644        997 usr/share/zoneinfo/Asia/Aqtobe  sha256:d681474dbfb26dc4ea2d79b4af564e5607583131e51a836cf8f82fbb1e747771
+- 0644        605 usr/share/zoneinfo/Asia/Ashgabat  sha256:fac7c69d1ba68a8eff06cf30f581f8c510d6823077c01796edcd02e7a42a93ae
+h 0644          - usr/share/zoneinfo/Asia/Ashkhabad => usr/share/zoneinfo/Asia/Ashgabat
+- 0644        977 usr/share/zoneinfo/Asia/Atyrau  sha256:fd4f02394204f671bf1ca75d644d50d2c3eecf7accc1f8f099f9d50d8fef4a68
+- 0644        969 usr/share/zoneinfo/Asia/Baghdad  sha256:4bea65288e3308ba88d22746001124de84536b3372ac88f64fdf3e12d5ad643f
+- 0644        185 usr/share/zoneinfo/Asia/Bahrain  sha256:c2494663758f1a9fb3d4e5306ff28e1f3453c019ddb7545f0e0f54b6db77e86e
+- 0644       1213 usr/share/zoneinfo/Asia/Baku  sha256:ebf86af7c4861b48f4240f2a631f7a59c20c6522d6e30e3ad105e1fce33f71c8
+- 0644        185 usr/share/zoneinfo/Asia/Bangkok  sha256:85fff93d57a041c1524bad028d2f340bb87e4c63ab7d0e27726f3737c5666649
+- 0644       1207 usr/share/zoneinfo/Asia/Barnaul  sha256:df37948a62d332b219134bd7e971c5bc1dcca2a131a156c4e424a6e86574cdfd
+- 0644       2154 usr/share/zoneinfo/Asia/Beirut  sha256:fd9ff664083f88bf6f539d490c1f02074e2e5c10eb7f590b222b3e2675da4b6a
+- 0644        969 usr/share/zoneinfo/Asia/Bishkek  sha256:20ea14ca300120b0a45eed6b8c222a4b002e7d16059257396000b88dd855c3a4
+- 0644        469 usr/share/zoneinfo/Asia/Brunei  sha256:0f9aadc9627f48cf1b4d0789248621aaaa23c6554a6eb142d4460c0d4f46cd74
+- 0644        285 usr/share/zoneinfo/Asia/Calcutta  sha256:e90c341036cb7203200e293cb3b513267e104a39a594f35e195254e6bc0a17cf
+- 0644       1207 usr/share/zoneinfo/Asia/Chita  sha256:2db4a54b6decc0590035449c83cce4351d2298035635f388698777f476cb7484
+- 0644        877 usr/share/zoneinfo/Asia/Choibalsan  sha256:a9491746c4dcfeeec1f7427150b4aeef2cca6c6b467ca71f10521ab063c2d9e7
+- 0644        561 usr/share/zoneinfo/Asia/Chongqing  sha256:64ffc2e43a94435a043c040d1d3af7e92d031adc78e7737af1861baa4eeef3e6
+h 0644          - usr/share/zoneinfo/Asia/Chungking => usr/share/zoneinfo/Asia/Chongqing
+- 0644        358 usr/share/zoneinfo/Asia/Colombo  sha256:c39d8bedb813e26e6172046e7af20f63cdf1cad7e406690b86728cc29d7a2ac6
+- 0644        323 usr/share/zoneinfo/Asia/Dacca  sha256:fb1ba527629586f2a9eab9592ccc9da70ee85d58ab93eae2107fb5f35c4f139e
+- 0644       1873 usr/share/zoneinfo/Asia/Damascus  sha256:12d84685e6875a6cb922b2c273d3663378ef0124051edf13b01174ec8d6d81b8
+h 0644          - usr/share/zoneinfo/Asia/Dhaka => usr/share/zoneinfo/Asia/Dacca
+- 0644        257 usr/share/zoneinfo/Asia/Dili  sha256:d80f6e166c12c28140e68d9e9352c0d2e72884f9cce368215af0fd0f94dd9c99
+- 0644        151 usr/share/zoneinfo/Asia/Dubai  sha256:a667613e16894702b038dbf18993467854880a3956cf263d265147bfe1fdba96
+- 0644        577 usr/share/zoneinfo/Asia/Dushanbe  sha256:9286279d85ae16c057775bc97d9b06769c276c51c4c2f9060664abaf1dca22cb
+- 0644       2028 usr/share/zoneinfo/Asia/Famagusta  sha256:085adcca077cb9d7b9c7a384b5f33f0f0d0a607a31a4f3f3ab8e8aa075718e37
+- 0644       3844 usr/share/zoneinfo/Asia/Gaza  sha256:b7463171440be7754d2a729b2a28e7d0e13f31aaf21329e89da6ec7be893b73b
+h 0644          - usr/share/zoneinfo/Asia/Harbin => usr/share/zoneinfo/Asia/Chongqing
+- 0644       3872 usr/share/zoneinfo/Asia/Hebron  sha256:e98d144872b1fb1a02c42aff5a90ae337a253f5bd41a7ceb7271a2c9015ca9d4
+- 0644        337 usr/share/zoneinfo/Asia/Ho_Chi_Minh  sha256:2e7bf5be950d017068f2fd1bf5df40429cbe004c8ee506b6220d0fbc3923ae65
+- 0644       1233 usr/share/zoneinfo/Asia/Hong_Kong  sha256:6a5fcee243e5ab92698242d88c4699ceb7208a22ee97d342d11e41ebd2555a17
+- 0644        877 usr/share/zoneinfo/Asia/Hovd  sha256:667e0f2c6943f944490ec6c2868af96ea593cee022976b5bac6256d23e532dbb
+- 0644       1229 usr/share/zoneinfo/Asia/Irkutsk  sha256:215ba85c2c1d788f8a2147c5904b7ac818ea60fdd5f464eb17efd62e77df1739
+- 0644       1933 usr/share/zoneinfo/Asia/Istanbul  sha256:264e308e7743b5afee2d673c5b57567636dabc925bb0be513939996e856718a5
+- 0644        383 usr/share/zoneinfo/Asia/Jakarta  sha256:4ef13306f4b37f314274eb0c019d10811f79240e717f790064e361cb98045d11
+- 0644        221 usr/share/zoneinfo/Asia/Jayapura  sha256:8a1cd477e2fc1d456a1be35ad743323c4f986308d5163fb17abaa34cde04259b
+- 0644       2388 usr/share/zoneinfo/Asia/Jerusalem  sha256:254b964265b94e16b4a498f0eb543968dec25f4cf80fba29b3d38e4a775ae837
+- 0644        194 usr/share/zoneinfo/Asia/Kabul  sha256:25911ba3c6d28ff2fb1e75d49b68005253650af2654498459121c2839a378209
+- 0644       1152 usr/share/zoneinfo/Asia/Kamchatka  sha256:298d4f949bd148d918ff9872241c63e430f079e61541a04ad396602f791d7026
+- 0644        379 usr/share/zoneinfo/Asia/Karachi  sha256:881fa658c4d75327c1c00919773f3f526130d31b20c48b9bf8a348eda9338649
+- 0644        151 usr/share/zoneinfo/Asia/Kashgar  sha256:17564e759643b151f00c98a792c47e86372a3f3a8e963bddade648585ba52716
+- 0644        198 usr/share/zoneinfo/Asia/Kathmandu  sha256:fd1b1f79259b0abf24338611262ed7bfa8401221d6d7820586c5ec7e16cf8e83
+h 0644          - usr/share/zoneinfo/Asia/Katmandu => usr/share/zoneinfo/Asia/Kathmandu
+- 0644       1257 usr/share/zoneinfo/Asia/Khandyga  sha256:6ca7e6c3a939a980d0b041c6dccbfe5588acdd8842795eea8a30f17f140d9ff8
+h 0644          - usr/share/zoneinfo/Asia/Kolkata => usr/share/zoneinfo/Asia/Calcutta
+- 0644       1193 usr/share/zoneinfo/Asia/Krasnoyarsk  sha256:0f9284ff5c16483d98762c43cbc9f72c135a025135ff2dd3597c3a36bc4528a0
+- 0644        401 usr/share/zoneinfo/Asia/Kuala_Lumpur  sha256:5e67952267aa709f212739bb4e302d8b59d6240c5ac0eaaaee32330e71d7da12
+h 0644          - usr/share/zoneinfo/Asia/Kuching => usr/share/zoneinfo/Asia/Brunei
+h 0644          - usr/share/zoneinfo/Asia/Kuwait => usr/share/zoneinfo/Antarctica/Syowa
+- 0644       1227 usr/share/zoneinfo/Asia/Macao  sha256:32f02447246cac0dabd39d88b65c85e5b8761617918c8d233f0834b88887d989
+h 0644          - usr/share/zoneinfo/Asia/Macau => usr/share/zoneinfo/Asia/Macao
+- 0644       1208 usr/share/zoneinfo/Asia/Magadan  sha256:1dc704117050bcc98ba02fc913eccffcc94b019d5698d2d02df337b49b79e4ce
+- 0644        254 usr/share/zoneinfo/Asia/Makassar  sha256:3a126d0aa493114faee67d28a4154ee41bbec10cdc60fcbd4bfe9a02125780ec
+- 0644        422 usr/share/zoneinfo/Asia/Manila  sha256:f314d21c542e615756dd385d36a896cd57ba16fef983fe6b4d061444bbf1ac9e
+h 0644          - usr/share/zoneinfo/Asia/Muscat => usr/share/zoneinfo/Asia/Dubai
+- 0644       2002 usr/share/zoneinfo/Asia/Nicosia  sha256:d149e6d08153ec7c86790ec5def4daffe9257f2b0282bba5a853ba043d699595
+- 0644       1151 usr/share/zoneinfo/Asia/Novokuznetsk  sha256:a72c71b5252d6037959859340a0f85df795a652d222ad75ef7f1899cbf5fd0a3
+- 0644       1207 usr/share/zoneinfo/Asia/Novosibirsk  sha256:e4adbe1b1d794e19477e89725bce52e73444b4070c8de1c16162b813cc762dd6
+- 0644       1193 usr/share/zoneinfo/Asia/Omsk  sha256:1f25c8588b495c12951d4cd67103e2d4c99de992e6664f90851528f4abf65ce2
+- 0644        991 usr/share/zoneinfo/Asia/Oral  sha256:5904f8a91982f5123f965f3307d16f9002fc7b319bf2aa2a59def9193942ee44
+h 0644          - usr/share/zoneinfo/Asia/Phnom_Penh => usr/share/zoneinfo/Asia/Bangkok
+- 0644        353 usr/share/zoneinfo/Asia/Pontianak  sha256:8a7397c2e2ad8cabf5cff7a588f65222a8d2b7ac21b6ec613de1b56298d4fc14
+- 0644        237 usr/share/zoneinfo/Asia/Pyongyang  sha256:ffe8371a70c0b5f0d7e17024b571fd8c5a2e2d40e63a8be78e839fbd1a540ec1
+h 0644          - usr/share/zoneinfo/Asia/Qatar => usr/share/zoneinfo/Asia/Bahrain
+- 0644       1025 usr/share/zoneinfo/Asia/Qostanay  sha256:1c88e59fc4083cd454e8c916cf23e2eaf0eb8e59956785f31717141ed5cc8bbb
+- 0644       1011 usr/share/zoneinfo/Asia/Qyzylorda  sha256:2592cd37a36e2e4a9a5847956826625bf80be81ac814bf65afae622bb9b254f8
+- 0644        254 usr/share/zoneinfo/Asia/Rangoon  sha256:fd81c04aae19e5871420b21d844ce0dbb0862f36ab5073c31ecd438f44203463
+h 0644          - usr/share/zoneinfo/Asia/Riyadh => usr/share/zoneinfo/Antarctica/Syowa
+h 0644          - usr/share/zoneinfo/Asia/Saigon => usr/share/zoneinfo/Asia/Ho_Chi_Minh
+- 0644       1188 usr/share/zoneinfo/Asia/Sakhalin  sha256:c73028afcda28407bec971300ba39688cce8f5be99fa8425dfd348914e4785bb
+- 0644        563 usr/share/zoneinfo/Asia/Samarkand  sha256:cc929246dde512f77a42f83d6f8f500323b87132725674cac8f61ccae7691f19
+- 0644        617 usr/share/zoneinfo/Asia/Seoul  sha256:2c8f4bb15dd77090b497e2a841ff3323ecbbae4f9dbb9edead2f8dd8fb5d8bb4
+h 0644          - usr/share/zoneinfo/Asia/Shanghai => usr/share/zoneinfo/Asia/Chongqing
+h 0644          - usr/share/zoneinfo/Asia/Singapore => usr/share/zoneinfo/Asia/Kuala_Lumpur
+- 0644       1194 usr/share/zoneinfo/Asia/Srednekolymsk  sha256:79f69a4fc8851eb71c729f9564a34cbed4ee3cb3631b957d247e4a287847dd22
+- 0644        761 usr/share/zoneinfo/Asia/Taipei  sha256:0cc990c0ea4faa5db9b9edcd7fcbc028a4f87a6d3a0f567dac76cb222b718b19
+- 0644        577 usr/share/zoneinfo/Asia/Tashkent  sha256:6a944fcb6e757d2472fe2c6c83704e64d9946c774ef3a3f9f8f7600b55f0b3b5
+- 0644       1021 usr/share/zoneinfo/Asia/Tbilisi  sha256:cd0fb66d5ab9fd449449bc0deaad2abd68c3f875e429a1f889f315ab59447883
+- 0644       1248 usr/share/zoneinfo/Asia/Tehran  sha256:2dbd87f410815edcfcd7d14be84de0040ef0d913a22203e0c7e7f4f17a6a915a
+h 0644          - usr/share/zoneinfo/Asia/Tel_Aviv => usr/share/zoneinfo/Asia/Jerusalem
+- 0644        189 usr/share/zoneinfo/Asia/Thimbu  sha256:1b69d341510c98a956b7407be3f7d400beca437600bbffc9e87722898b362325
+h 0644          - usr/share/zoneinfo/Asia/Thimphu => usr/share/zoneinfo/Asia/Thimbu
+- 0644        309 usr/share/zoneinfo/Asia/Tokyo  sha256:a02b9e66044dc5c35c5f76467627fdcba4aee1cc958606b85c777095cad82ceb
+- 0644       1207 usr/share/zoneinfo/Asia/Tomsk  sha256:72bd142d981606741fcc38897989aaa40ed7a39411ceeaefac7b2b6d9b2784e4
+h 0644          - usr/share/zoneinfo/Asia/Ujung_Pandang => usr/share/zoneinfo/Asia/Makassar
+h 0644          - usr/share/zoneinfo/Asia/Ulaanbaatar => usr/share/zoneinfo/Asia/Choibalsan
+h 0644          - usr/share/zoneinfo/Asia/Ulan_Bator => usr/share/zoneinfo/Asia/Choibalsan
+h 0644          - usr/share/zoneinfo/Asia/Urumqi => usr/share/zoneinfo/Asia/Kashgar
+- 0644       1238 usr/share/zoneinfo/Asia/Ust-Nera  sha256:cec1bc9209f0d0572ce4dd96c0d4d59af5a44e5a707fb3a8f32ebc1dc5e3632c
+h 0644          - usr/share/zoneinfo/Asia/Vientiane => usr/share/zoneinfo/Asia/Bangkok
+- 0644       1194 usr/share/zoneinfo/Asia/Vladivostok  sha256:5cc40b321e523db23a0b847750ee0a85b9c6e2159590735e7730907aac4593a0
+- 0644       1193 usr/share/zoneinfo/Asia/Yakutsk  sha256:3cf36b446820f6379f39433ee8cf17a9a226f8495f991652580b5218a2f33574
+h 0644          - usr/share/zoneinfo/Asia/Yangon => usr/share/zoneinfo/Asia/Rangoon
+- 0644       1229 usr/share/zoneinfo/Asia/Yekaterinburg  sha256:e0dc845ba5e3af852c58f87adc720f2381ba193fed546d57920736c5bc068f30
+- 0644       1137 usr/share/zoneinfo/Asia/Yerevan  sha256:14cd29500e0d6d35816ff0ac2792822d5acba0d99a77b9e304aa85ac9043a311
+d 0755          - usr/share/zoneinfo/Atlantic/
+- 0644       3442 usr/share/zoneinfo/Atlantic/Azores  sha256:eba843c5a2bcc459e4b4b32ba4dc640f8af58069214be3c4a657aec33b86440d
+- 0644       2396 usr/share/zoneinfo/Atlantic/Bermuda  sha256:2cd18a7ccb2762fc089a34f2cd7acb84c3871c3bbba88ebb45b60d2afbc8d792
+- 0644       1897 usr/share/zoneinfo/Atlantic/Canary  sha256:ca62bdb9faa986f3630cade1ce290de067e4711dd07820623cac9573a16395b0
+- 0644        256 usr/share/zoneinfo/Atlantic/Cape_Verde  sha256:a3dda92dd2c55ff6fdbd48aadeb36971ae2dba920edddc7dacdae73dc03ce3be
+- 0644       1815 usr/share/zoneinfo/Atlantic/Faeroe  sha256:3626dd64f66d6a99d847f9b22199cc753692286b0e04682e8e3d3f4f636f033b
+h 0644          - usr/share/zoneinfo/Atlantic/Faroe => usr/share/zoneinfo/Atlantic/Faeroe
+h 0644          - usr/share/zoneinfo/Atlantic/Jan_Mayen => usr/share/zoneinfo/Arctic/Longyearbyen
+- 0644       3377 usr/share/zoneinfo/Atlantic/Madeira  sha256:95863ce4c0b9f8650a1319b7e778b1c2d643c5ab186af4d35842efbf94572f11
+h 0644          - usr/share/zoneinfo/Atlantic/Reykjavik => usr/share/zoneinfo/Africa/Abidjan
+- 0644        150 usr/share/zoneinfo/Atlantic/South_Georgia  sha256:23d48070f3ee9b2e977fd3fb760d9a135ea8c700c8ab2285aa29c94c2f97b203
+h 0644          - usr/share/zoneinfo/Atlantic/St_Helena => usr/share/zoneinfo/Africa/Abidjan
+- 0644       1200 usr/share/zoneinfo/Atlantic/Stanley  sha256:b221235d302e4ee9bfe171ad4bdf0c044df85d6ff9c605d28445f938c9d2163a
+d 0755          - usr/share/zoneinfo/Australia/
+- 0644       2190 usr/share/zoneinfo/Australia/ACT  sha256:42c3857585b16db2f8ffd47ba19faa60f473340de8d4fe9320ea7be861605906
+- 0644       2208 usr/share/zoneinfo/Australia/Adelaide  sha256:95dd846f153be6856098f7bbd37cfe23a6aa2e0d0a9afeb665c086ce44f9476d
+- 0644        419 usr/share/zoneinfo/Australia/Brisbane  sha256:796e90cf37b6b74faca5e2669afb7524ccdb91269d20a744f385c773b254b467
+- 0644       2229 usr/share/zoneinfo/Australia/Broken_Hill  sha256:de4ff79634ef4b91927e8ed787ac3bd54811dda03060f06c9c227e9a51180aa4
+h 0644          - usr/share/zoneinfo/Australia/Canberra => usr/share/zoneinfo/Australia/ACT
+- 0644       2358 usr/share/zoneinfo/Australia/Currie  sha256:18b412ce021fb16c4ebe628eae1a5fa1f5aa20d41fea1dfa358cb799caba81c8
+- 0644        325 usr/share/zoneinfo/Australia/Darwin  sha256:7e7d08661216f7c1409f32e283efc606d5b92c0e788da8dd79e533838b421afa
+- 0644        456 usr/share/zoneinfo/Australia/Eucla  sha256:8b5f97186f08e84d1d5c8756185e039647c32d686203127fde0329b7e9e6feee
+h 0644          - usr/share/zoneinfo/Australia/Hobart => usr/share/zoneinfo/Australia/Currie
+- 0644       1846 usr/share/zoneinfo/Australia/LHI  sha256:a323c5433991a963eb497b7da4d1d09848bf3ef5f5d64d9c9649f388e4bab9df
+- 0644        475 usr/share/zoneinfo/Australia/Lindeman  sha256:c4ce94771db6a0b3682d1d58ec64211ce628bfc9f0df140daa073f35543624ae
+h 0644          - usr/share/zoneinfo/Australia/Lord_Howe => usr/share/zoneinfo/Australia/LHI
+- 0644       2190 usr/share/zoneinfo/Australia/Melbourne  sha256:96fc7f31072e9cc73abb6b2622b97c5f8dbb6cbb17be3920a4249d8d80933413
+h 0644          - usr/share/zoneinfo/Australia/NSW => usr/share/zoneinfo/Australia/ACT
+h 0644          - usr/share/zoneinfo/Australia/North => usr/share/zoneinfo/Australia/Darwin
+- 0644        446 usr/share/zoneinfo/Australia/Perth  sha256:025d4339487853fa1f3144127959734b20f7c7b4948cff5d72149a0541a67968
+h 0644          - usr/share/zoneinfo/Australia/Queensland => usr/share/zoneinfo/Australia/Brisbane
+h 0644          - usr/share/zoneinfo/Australia/South => usr/share/zoneinfo/Australia/Adelaide
+h 0644          - usr/share/zoneinfo/Australia/Sydney => usr/share/zoneinfo/Australia/ACT
+h 0644          - usr/share/zoneinfo/Australia/Tasmania => usr/share/zoneinfo/Australia/Currie
+h 0644          - usr/share/zoneinfo/Australia/Victoria => usr/share/zoneinfo/Australia/Melbourne
+h 0644          - usr/share/zoneinfo/Australia/West => usr/share/zoneinfo/Australia/Perth
+h 0644          - usr/share/zoneinfo/Australia/Yancowinna => usr/share/zoneinfo/Australia/Broken_Hill
+d 0755          - usr/share/zoneinfo/Brazil/
+h 0644          - usr/share/zoneinfo/Brazil/Acre => usr/share/zoneinfo/America/Porto_Acre
+h 0644          - usr/share/zoneinfo/Brazil/DeNoronha => usr/share/zoneinfo/America/Noronha
+h 0644          - usr/share/zoneinfo/Brazil/East => usr/share/zoneinfo/America/Sao_Paulo
+h 0644          - usr/share/zoneinfo/Brazil/West => usr/share/zoneinfo/America/Manaus
+- 0644       2933 usr/share/zoneinfo/CET  sha256:812f55aeb6e8cde9ddf4786e15eb4256b21e82cf5f5d28da1bad17d94570cac0
+h 0644          - usr/share/zoneinfo/CST6CDT => usr/share/zoneinfo/America/Chicago
+d 0755          - usr/share/zoneinfo/Canada/
+h 0644          - usr/share/zoneinfo/Canada/Atlantic => usr/share/zoneinfo/America/Halifax
+h 0644          - usr/share/zoneinfo/Canada/Central => usr/share/zoneinfo/America/Rainy_River
+h 0644          - usr/share/zoneinfo/Canada/Eastern => usr/share/zoneinfo/America/Montreal
+h 0644          - usr/share/zoneinfo/Canada/Mountain => usr/share/zoneinfo/America/Edmonton
+h 0644          - usr/share/zoneinfo/Canada/Newfoundland => usr/share/zoneinfo/America/St_Johns
+h 0644          - usr/share/zoneinfo/Canada/Pacific => usr/share/zoneinfo/America/Vancouver
+h 0644          - usr/share/zoneinfo/Canada/Saskatchewan => usr/share/zoneinfo/America/Regina
+h 0644          - usr/share/zoneinfo/Canada/Yukon => usr/share/zoneinfo/America/Whitehorse
+d 0755          - usr/share/zoneinfo/Chile/
+h 0644          - usr/share/zoneinfo/Chile/Continental => usr/share/zoneinfo/America/Santiago
+- 0644       2219 usr/share/zoneinfo/Chile/EasterIsland  sha256:41bb9b06cff1425bcac1e027bab8721e320ae238bbec68781bebac5ee97a5d53
+h 0644          - usr/share/zoneinfo/Cuba => usr/share/zoneinfo/America/Havana
+- 0644       2262 usr/share/zoneinfo/EET  sha256:5c363e14151d751c901cdf06c502d9e1ac23b8e956973954763bfb39d5c53730
+h 0644          - usr/share/zoneinfo/EST => usr/share/zoneinfo/America/Atikokan
+h 0644          - usr/share/zoneinfo/EST5EDT => usr/share/zoneinfo/America/New_York
+h 0644          - usr/share/zoneinfo/Egypt => usr/share/zoneinfo/Africa/Cairo
+- 0644       3492 usr/share/zoneinfo/Eire  sha256:40e8d2a1c3b572284da39f6f4245b1bc814f452c44f5aa73d0a011571d5ccc43
+d 0755          - usr/share/zoneinfo/Etc/
+- 0644        114 usr/share/zoneinfo/Etc/GMT  sha256:6d9f378883c079f86c0387a5547a92c449869d806e07de10084ab04f0249018d
+h 0644          - usr/share/zoneinfo/Etc/GMT+0 => usr/share/zoneinfo/Etc/GMT
+- 0644        116 usr/share/zoneinfo/Etc/GMT+1  sha256:d50ce5d97f6b43f45711fd75c87d3dc10642affa61e947453fb134caef6cf884
+- 0644        117 usr/share/zoneinfo/Etc/GMT+10  sha256:244432432425902d28e994dd7958d984220e87a70ae5317b1f4d0f925b3eb142
+- 0644        117 usr/share/zoneinfo/Etc/GMT+11  sha256:b56bdcbd830509a13ad27255bc3aeba2feecb49becd4a4183b2ae1977773714b
+- 0644        117 usr/share/zoneinfo/Etc/GMT+12  sha256:6fbd0712112babc2099aaf31edc399cb8791fffddfab9b871e98ef3c1107a8c0
+- 0644        116 usr/share/zoneinfo/Etc/GMT+2  sha256:4fa129e7386c94129b61a10215407a8142a1de24d93f23285b59238689f1ad4a
+- 0644        116 usr/share/zoneinfo/Etc/GMT+3  sha256:406a18ac4d386d427e3b32f7eddb763194f917158d2e92433d55e025bb2d6190
+- 0644        116 usr/share/zoneinfo/Etc/GMT+4  sha256:456ae43648bec15ed7f9ca1ed15bee7c17ba2eb595a643c98226b94106049c1a
+- 0644        116 usr/share/zoneinfo/Etc/GMT+5  sha256:a1199e0b8d5d8185d3fb3cf264844a5cdf48bdd2f60dae674eec261b6fe9ac80
+- 0644        116 usr/share/zoneinfo/Etc/GMT+6  sha256:77a7409f089e8f2148da7ec0cc59455b4685013eb360d123048106d2ebb4b1b4
+- 0644        116 usr/share/zoneinfo/Etc/GMT+7  sha256:4ea8d86f3774607a71d708ac160d3c275f704e983aced24b2e89e0658fe5a33b
+- 0644        116 usr/share/zoneinfo/Etc/GMT+8  sha256:b61ffc6c832662044f09eb01adb981851af48d03bbc2177bd0b898f477f02729
+- 0644        116 usr/share/zoneinfo/Etc/GMT+9  sha256:42ae44ea2512ec9309232993ed8a2a948f0cb6ab55cb49abf6deb3585b5673d6
+h 0644          - usr/share/zoneinfo/Etc/GMT-0 => usr/share/zoneinfo/Etc/GMT
+- 0644        117 usr/share/zoneinfo/Etc/GMT-1  sha256:ef7175794f2e01018fde6728076abdf428df31a9c61479377de7e58e9f69602e
+- 0644        118 usr/share/zoneinfo/Etc/GMT-10  sha256:7ca5963702c13a9d4e90a8ed735c3d2c85c94759934c3f8976f61f951cb522b5
+- 0644        118 usr/share/zoneinfo/Etc/GMT-11  sha256:0f64bbf67ea9b1af6df7fdaf8f9c08ac5a471f63892dc08a3fabedc3315920d6
+- 0644        118 usr/share/zoneinfo/Etc/GMT-12  sha256:99ee15ea599623c812afc1fb378d56003d04c30d5a9e1fc4177e10afd5284a72
+- 0644        118 usr/share/zoneinfo/Etc/GMT-13  sha256:c5b99b1b505003a0e5a5afe2530106c89c56e1adedea599ac1d3ca004f2f6d1f
+- 0644        118 usr/share/zoneinfo/Etc/GMT-14  sha256:3e95e8444061d36a85a6fc55323da957d200cd242f044ed73ef9cdf6a499f8a7
+- 0644        117 usr/share/zoneinfo/Etc/GMT-2  sha256:bdeea158b75eba22e1a9a81a58ba8c0fa1cdc9b4b57214708ee75f4d9d9b6011
+- 0644        117 usr/share/zoneinfo/Etc/GMT-3  sha256:37bee320b6a7b8b0d590bb1dba35d94aef9db078b0379308a7087b7cc5227eca
+- 0644        117 usr/share/zoneinfo/Etc/GMT-4  sha256:2d2928e5f547a8f979cdfc231aa91b31afce167beda53ea8ff8c58c4dcfd9f9a
+- 0644        117 usr/share/zoneinfo/Etc/GMT-5  sha256:b8b69247931bd7c1d14ec000e52bde63d3c027dedd3bc433216a8d5dedf065be
+- 0644        117 usr/share/zoneinfo/Etc/GMT-6  sha256:25237e454029849e747e922fedc602eae9ebb6bcfd4b55a66bea620c79467bb7
+- 0644        117 usr/share/zoneinfo/Etc/GMT-7  sha256:bd500e17cc54f53f444a7c3af1cd12157a5cbe4a28a5a8b04d1d336de7c71d25
+- 0644        117 usr/share/zoneinfo/Etc/GMT-8  sha256:4bbc4541b14ca620d9cb8bf92f80fd7c2ae3448cf3a0b0b9a7c49edb7c62eeeb
+- 0644        117 usr/share/zoneinfo/Etc/GMT-9  sha256:239bc736650af98ca0fd2d6c905378e15195cc1824b6316055088320a3b868c2
+h 0644          - usr/share/zoneinfo/Etc/GMT0 => usr/share/zoneinfo/Etc/GMT
+h 0644          - usr/share/zoneinfo/Etc/Greenwich => usr/share/zoneinfo/Etc/GMT
+- 0644        114 usr/share/zoneinfo/Etc/UCT  sha256:8b85846791ab2c8a5463c83a5be3c043e2570d7448434d41398969ed47e3e6f2
+h 0644          - usr/share/zoneinfo/Etc/UTC => usr/share/zoneinfo/Etc/UCT
+h 0644          - usr/share/zoneinfo/Etc/Universal => usr/share/zoneinfo/Etc/UCT
+h 0644          - usr/share/zoneinfo/Etc/Zulu => usr/share/zoneinfo/Etc/UCT
+d 0755          - usr/share/zoneinfo/Europe/
+h 0644          - usr/share/zoneinfo/Europe/Amsterdam => usr/share/zoneinfo/CET
+- 0644       1742 usr/share/zoneinfo/Europe/Andorra  sha256:8130798c2426bc8c372498b5fef01c398ba1b733c147a457531f60555ea9eae8
+- 0644       1151 usr/share/zoneinfo/Europe/Astrakhan  sha256:65e183663c15551a1e47e27ae36cc49cddba04f2f9f1589324b6f09e4ee92d79
+h 0644          - usr/share/zoneinfo/Europe/Athens => usr/share/zoneinfo/EET
+- 0644       3664 usr/share/zoneinfo/Europe/Belfast  sha256:c85495070dca42687df6a1c3ee780a27cbcb82f1844750ea6f642833a44d29b4
+- 0644       1920 usr/share/zoneinfo/Europe/Belgrade  sha256:3a95adb06156044fd2fa662841c0268c2b5af47c1b19000d9d299563d387093a
+h 0644          - usr/share/zoneinfo/Europe/Berlin => usr/share/zoneinfo/Arctic/Longyearbyen
+- 0644       2301 usr/share/zoneinfo/Europe/Bratislava  sha256:1bd7dd8545e6cf1eb9d419f267a57b00e60857d115e5a309326e3878968b2d9c
+h 0644          - usr/share/zoneinfo/Europe/Brussels => usr/share/zoneinfo/CET
+- 0644       2184 usr/share/zoneinfo/Europe/Bucharest  sha256:9df83af9b5360fa0cc1166fd10c2014799319cdb1b0d2c7450a7c71ff673a857
+- 0644       2368 usr/share/zoneinfo/Europe/Budapest  sha256:94dc2ac5672206fc3d7a2f35550c082876c2fd90c98e980753a1c5838c025246
+- 0644       1909 usr/share/zoneinfo/Europe/Busingen  sha256:2b9418ed48e3d9551c84a4786e185bd2181d009866c040fbd729170d038629ef
+- 0644       2390 usr/share/zoneinfo/Europe/Chisinau  sha256:a7527faea144d77a4bf1ca4146b1057beb5e088f1fd1f28ae2e4d4cbfe1d885e
+h 0644          - usr/share/zoneinfo/Europe/Copenhagen => usr/share/zoneinfo/Arctic/Longyearbyen
+h 0644          - usr/share/zoneinfo/Europe/Dublin => usr/share/zoneinfo/Eire
+- 0644       3068 usr/share/zoneinfo/Europe/Gibraltar  sha256:6bced6a5a065bf123880053d3a940e90df155096e2ad55987fe55f14b4c8a12e
+h 0644          - usr/share/zoneinfo/Europe/Guernsey => usr/share/zoneinfo/Europe/Belfast
+- 0644       1900 usr/share/zoneinfo/Europe/Helsinki  sha256:184901ecbb158667a0b7b62eb9685e083bc3182edbecdc3d6d3743192f6a9097
+h 0644          - usr/share/zoneinfo/Europe/Isle_of_Man => usr/share/zoneinfo/Europe/Belfast
+h 0644          - usr/share/zoneinfo/Europe/Istanbul => usr/share/zoneinfo/Asia/Istanbul
+h 0644          - usr/share/zoneinfo/Europe/Jersey => usr/share/zoneinfo/Europe/Belfast
+- 0644       1493 usr/share/zoneinfo/Europe/Kaliningrad  sha256:b3b19749ed58bcc72cec089484735303a2389c03909ff2a6cff66a2583be2cc3
+- 0644       2120 usr/share/zoneinfo/Europe/Kiev  sha256:fb0ae91bd8cfb882853f5360055be7c6c3117fd2ff879cf727a4378e3d40c0d3
+- 0644       1185 usr/share/zoneinfo/Europe/Kirov  sha256:3fb4f665fe44a3aa382f80db83f05f8858d48138f47505e5af063e419d5e0559
+h 0644          - usr/share/zoneinfo/Europe/Kyiv => usr/share/zoneinfo/Europe/Kiev
+- 0644       3527 usr/share/zoneinfo/Europe/Lisbon  sha256:92b07cb24689226bf934308d1f1bd33c306aa4da610c52cd5bce25077960502c
+h 0644          - usr/share/zoneinfo/Europe/Ljubljana => usr/share/zoneinfo/Europe/Belgrade
+h 0644          - usr/share/zoneinfo/Europe/London => usr/share/zoneinfo/Europe/Belfast
+h 0644          - usr/share/zoneinfo/Europe/Luxembourg => usr/share/zoneinfo/CET
+- 0644       2614 usr/share/zoneinfo/Europe/Madrid  sha256:9a42d7d37ad6dedd2d9b328120f7bf9e852f6850c4af00baff964f659b161cea
+- 0644       2620 usr/share/zoneinfo/Europe/Malta  sha256:12129c6cf2f8efbeb9b56022439edcbac68ad9368842a64282d268119b3751dd
+h 0644          - usr/share/zoneinfo/Europe/Mariehamn => usr/share/zoneinfo/Europe/Helsinki
+- 0644       1307 usr/share/zoneinfo/Europe/Minsk  sha256:2a03e6d1f1f2727b60777c5b4e69839783b5dd787ff5edb352777c5c5494dbda
+- 0644       2962 usr/share/zoneinfo/Europe/Monaco  sha256:ab77a1488a2dd4667a4f23072236e0d2845fe208405eec1b4834985629ba7af8
+- 0644       1535 usr/share/zoneinfo/Europe/Moscow  sha256:2a69287d1723e93f0f876f0f242866f09569d77b91bde7fa4d9d06b8fcd4883c
+h 0644          - usr/share/zoneinfo/Europe/Nicosia => usr/share/zoneinfo/Asia/Nicosia
+h 0644          - usr/share/zoneinfo/Europe/Oslo => usr/share/zoneinfo/Arctic/Longyearbyen
+h 0644          - usr/share/zoneinfo/Europe/Paris => usr/share/zoneinfo/Europe/Monaco
+h 0644          - usr/share/zoneinfo/Europe/Podgorica => usr/share/zoneinfo/Europe/Belgrade
+h 0644          - usr/share/zoneinfo/Europe/Prague => usr/share/zoneinfo/Europe/Bratislava
+- 0644       2198 usr/share/zoneinfo/Europe/Riga  sha256:849dbfd26d6d696f48b80fa13323f99fe597ed83ab47485e2accc98609634569
+- 0644       2641 usr/share/zoneinfo/Europe/Rome  sha256:d5ade82cc4a232949b87d43157c84b2c355b66a6ac87cf6250ed6ead80b5018f
+- 0644       1201 usr/share/zoneinfo/Europe/Samara  sha256:9d72f42316d3eaabb5d0236e6831f1c785b539a02769a293b4827d37d5113285
+h 0644          - usr/share/zoneinfo/Europe/San_Marino => usr/share/zoneinfo/Europe/Rome
+h 0644          - usr/share/zoneinfo/Europe/Sarajevo => usr/share/zoneinfo/Europe/Belgrade
+- 0644       1169 usr/share/zoneinfo/Europe/Saratov  sha256:ca0c23bd7375dd381a5b18e0eb2b161271d6371c2b56d9046eb93cb7d6f3555c
+- 0644       1469 usr/share/zoneinfo/Europe/Simferopol  sha256:b7397bc5d355499a6b342ba5e181392d2a6847d268ba398eabc55b6c1f301e27
+h 0644          - usr/share/zoneinfo/Europe/Skopje => usr/share/zoneinfo/Europe/Belgrade
+- 0644       2077 usr/share/zoneinfo/Europe/Sofia  sha256:84240a5df30dae7039c47370feecd38cacd5c38f81becab9a063b8c940afe6d6
+h 0644          - usr/share/zoneinfo/Europe/Stockholm => usr/share/zoneinfo/Arctic/Longyearbyen
+- 0644       2148 usr/share/zoneinfo/Europe/Tallinn  sha256:e1ae890b4688a4ccea215ecedf9ce81b42cb270910ab90285d9da2be489cebec
+- 0644       2084 usr/share/zoneinfo/Europe/Tirane  sha256:ced959c824bd5825de556f2706e9f74f28b91d463412d15b8816c473582e72ec
+h 0644          - usr/share/zoneinfo/Europe/Tiraspol => usr/share/zoneinfo/Europe/Chisinau
+- 0644       1253 usr/share/zoneinfo/Europe/Ulyanovsk  sha256:73c01de69ec22a3ff570203b95546970fa9b417198697f3772ebbab88171f818
+h 0644          - usr/share/zoneinfo/Europe/Uzhgorod => usr/share/zoneinfo/Europe/Kiev
+h 0644          - usr/share/zoneinfo/Europe/Vaduz => usr/share/zoneinfo/Europe/Busingen
+h 0644          - usr/share/zoneinfo/Europe/Vatican => usr/share/zoneinfo/Europe/Rome
+- 0644       2200 usr/share/zoneinfo/Europe/Vienna  sha256:6662379000c4e9b9eb24471caa1ef75d7058dfa2f51b80e4a624d0226b4dad49
+- 0644       2162 usr/share/zoneinfo/Europe/Vilnius  sha256:505cd15f7a2b09307c77d23397124fcb9794036a013ee0aed54265fb60fb0b75
+- 0644       1193 usr/share/zoneinfo/Europe/Volgograd  sha256:46016fb7b9b367e4ed20a2fd0551e6a0d64b21e2c8ba20dd5de635d20dbfbe4b
+- 0644       2654 usr/share/zoneinfo/Europe/Warsaw  sha256:4e22c33db79517472480b54491a49e0da299f3072d7490ce97f1c4fd6779acab
+h 0644          - usr/share/zoneinfo/Europe/Zagreb => usr/share/zoneinfo/Europe/Belgrade
+h 0644          - usr/share/zoneinfo/Europe/Zaporozhye => usr/share/zoneinfo/Europe/Kiev
+h 0644          - usr/share/zoneinfo/Europe/Zurich => usr/share/zoneinfo/Europe/Busingen
+- 0644        116 usr/share/zoneinfo/Factory  sha256:6851652b1f771d7a09a05e124ae4e50fc719b4903e9dee682b301ae9e5f65789
+h 0644          - usr/share/zoneinfo/GB => usr/share/zoneinfo/Europe/Belfast
+h 0644          - usr/share/zoneinfo/GB-Eire => usr/share/zoneinfo/Europe/Belfast
+h 0644          - usr/share/zoneinfo/GMT => usr/share/zoneinfo/Etc/GMT
+h 0644          - usr/share/zoneinfo/GMT+0 => usr/share/zoneinfo/Etc/GMT
+h 0644          - usr/share/zoneinfo/GMT-0 => usr/share/zoneinfo/Etc/GMT
+h 0644          - usr/share/zoneinfo/GMT0 => usr/share/zoneinfo/Etc/GMT
+h 0644          - usr/share/zoneinfo/Greenwich => usr/share/zoneinfo/Etc/GMT
+- 0644        329 usr/share/zoneinfo/HST  sha256:7f03d1bf5264e7ab023a2ef9b997ddfc8cb6936692407c770762b9c549523f33
+h 0644          - usr/share/zoneinfo/Hongkong => usr/share/zoneinfo/Asia/Hong_Kong
+h 0644          - usr/share/zoneinfo/Iceland => usr/share/zoneinfo/Africa/Abidjan
+d 0755          - usr/share/zoneinfo/Indian/
+h 0644          - usr/share/zoneinfo/Indian/Antananarivo => usr/share/zoneinfo/Africa/Addis_Ababa
+- 0644        185 usr/share/zoneinfo/Indian/Chagos  sha256:d9eaeb5f329d1487295342fe5d18521f184d69b2336c8e655d5dcfaba96de346
+h 0644          - usr/share/zoneinfo/Indian/Christmas => usr/share/zoneinfo/Asia/Bangkok
+h 0644          - usr/share/zoneinfo/Indian/Cocos => usr/share/zoneinfo/Asia/Rangoon
+h 0644          - usr/share/zoneinfo/Indian/Comoro => usr/share/zoneinfo/Africa/Addis_Ababa
+- 0644        185 usr/share/zoneinfo/Indian/Kerguelen  sha256:17bddf7d57c1a14a07aded3e0f0b2242b60970ba4f396f892469379fcf253395
+h 0644          - usr/share/zoneinfo/Indian/Mahe => usr/share/zoneinfo/Asia/Dubai
+h 0644          - usr/share/zoneinfo/Indian/Maldives => usr/share/zoneinfo/Indian/Kerguelen
+- 0644        227 usr/share/zoneinfo/Indian/Mauritius  sha256:667aab7357218a695c889b1804e97436f2079eb35d0b19dc1b159ccead4f05e2
+h 0644          - usr/share/zoneinfo/Indian/Mayotte => usr/share/zoneinfo/Africa/Addis_Ababa
+h 0644          - usr/share/zoneinfo/Indian/Reunion => usr/share/zoneinfo/Asia/Dubai
+h 0644          - usr/share/zoneinfo/Iran => usr/share/zoneinfo/Asia/Tehran
+h 0644          - usr/share/zoneinfo/Israel => usr/share/zoneinfo/Asia/Jerusalem
+h 0644          - usr/share/zoneinfo/Jamaica => usr/share/zoneinfo/America/Jamaica
+h 0644          - usr/share/zoneinfo/Japan => usr/share/zoneinfo/Asia/Tokyo
+- 0644        302 usr/share/zoneinfo/Kwajalein  sha256:4e667fd1ffb2490fac6810254575747f8f48b709dee755415e7eab59cad6a874
+h 0644          - usr/share/zoneinfo/Libya => usr/share/zoneinfo/Africa/Tripoli
+h 0644          - usr/share/zoneinfo/MET => usr/share/zoneinfo/CET
+h 0644          - usr/share/zoneinfo/MST => usr/share/zoneinfo/America/Creston
+h 0644          - usr/share/zoneinfo/MST7MDT => usr/share/zoneinfo/America/Denver
+d 0755          - usr/share/zoneinfo/Mexico/
+h 0644          - usr/share/zoneinfo/Mexico/BajaNorte => usr/share/zoneinfo/America/Ensenada
+h 0644          - usr/share/zoneinfo/Mexico/BajaSur => usr/share/zoneinfo/America/Mazatlan
+h 0644          - usr/share/zoneinfo/Mexico/General => usr/share/zoneinfo/America/Mexico_City
+h 0644          - usr/share/zoneinfo/NZ => usr/share/zoneinfo/Antarctica/McMurdo
+- 0644       2054 usr/share/zoneinfo/NZ-CHAT  sha256:c617b155ce657c9fea02fd9ddc7ac823a95f452c4a6580408d8db3a58902184f
+h 0644          - usr/share/zoneinfo/Navajo => usr/share/zoneinfo/America/Denver
+h 0644          - usr/share/zoneinfo/PRC => usr/share/zoneinfo/Asia/Chongqing
+h 0644          - usr/share/zoneinfo/PST8PDT => usr/share/zoneinfo/America/Los_Angeles
+d 0755          - usr/share/zoneinfo/Pacific/
+- 0644        598 usr/share/zoneinfo/Pacific/Apia  sha256:33740ab29ef943b1f55f769e13ff59a90962f5a12434209072d650e6c10abb4d
+h 0644          - usr/share/zoneinfo/Pacific/Auckland => usr/share/zoneinfo/Antarctica/McMurdo
+- 0644        254 usr/share/zoneinfo/Pacific/Bougainville  sha256:85613ce9e5e7371faf0016e9efe61222a5b279c1cf30858b7ed565a00a0f84bf
+h 0644          - usr/share/zoneinfo/Pacific/Chatham => usr/share/zoneinfo/NZ-CHAT
+h 0644          - usr/share/zoneinfo/Pacific/Chuuk => usr/share/zoneinfo/Antarctica/DumontDUrville
+h 0644          - usr/share/zoneinfo/Pacific/Easter => usr/share/zoneinfo/Chile/EasterIsland
+- 0644        524 usr/share/zoneinfo/Pacific/Efate  sha256:a12c4d710631e7ed45536ff21f31c8fa14fe74c25c3f1cf2e1799d2355315c0a
+- 0644        220 usr/share/zoneinfo/Pacific/Enderbury  sha256:1cd4c02abb07fd1d96dd046529c98d95de4a71774fd328170a3128bdcd62fba4
+- 0644        186 usr/share/zoneinfo/Pacific/Fakaofo  sha256:a8ea1da5330a8f3b6f6485d52defdffe467a59c1e5f5f08b13d66ccaf74528b2
+- 0644        564 usr/share/zoneinfo/Pacific/Fiji  sha256:8c1e456ceb029c7550436a213e25844143e11ba2726c1dcda20dea4fa5894342
+- 0644        152 usr/share/zoneinfo/Pacific/Funafuti  sha256:53268a8a6b11f0b8e02fc67683ae48d074efaf7b4c66e036c1478107afd9a7d7
+- 0644        224 usr/share/zoneinfo/Pacific/Galapagos  sha256:fc625460e8d28888e83413b6a9dab6de2b0b309e0d0959370ca21119e0dcf010
+- 0644        150 usr/share/zoneinfo/Pacific/Gambier  sha256:8004bb82bd471ffaded2e6272fa796a3928627e07941a88cf26576718e664311
+- 0644        152 usr/share/zoneinfo/Pacific/Guadalcanal  sha256:3389135aa69241a57500c8722d2be6c2804917b5fd89cac82dbbd0270a7de348
+- 0644        494 usr/share/zoneinfo/Pacific/Guam  sha256:131f739e67faacd7c6cdeea036964908caf54d3e2b925d929eb85e72b749b9f2
+h 0644          - usr/share/zoneinfo/Pacific/Honolulu => usr/share/zoneinfo/HST
+h 0644          - usr/share/zoneinfo/Pacific/Johnston => usr/share/zoneinfo/HST
+h 0644          - usr/share/zoneinfo/Pacific/Kanton => usr/share/zoneinfo/Pacific/Enderbury
+- 0644        224 usr/share/zoneinfo/Pacific/Kiritimati  sha256:8589353a8cfe2e3d4fb9909b355d96248bce2ed0b04b0ab6bbaddc6f567edcd4
+- 0644        337 usr/share/zoneinfo/Pacific/Kosrae  sha256:4348eb6f8cde0eb77ad5b53857c4ea8cc73421ea7cad667266a274baab2e9f1b
+h 0644          - usr/share/zoneinfo/Pacific/Kwajalein => usr/share/zoneinfo/Kwajalein
+h 0644          - usr/share/zoneinfo/Pacific/Majuro => usr/share/zoneinfo/Pacific/Funafuti
+- 0644        159 usr/share/zoneinfo/Pacific/Marquesas  sha256:153c4f2535ad938f0b55bdcdd94eb828ba4bb26beed03401b9b4c283e76fc863
+- 0644        175 usr/share/zoneinfo/Pacific/Midway  sha256:7c262b62985863aad47f13b0ef5db2e5cc917b5d38002de9a2ea83ddb0883458
+- 0644        238 usr/share/zoneinfo/Pacific/Nauru  sha256:f4048a80b1c1fbc9ec4c42b5029cdf4c7d3242d6cd026197f8923bb87662aa70
+- 0644        189 usr/share/zoneinfo/Pacific/Niue  sha256:3a5957c6e927711edaf92326745a31e5acf5c6920f3216da85086d39b9a9b833
+- 0644        866 usr/share/zoneinfo/Pacific/Norfolk  sha256:0cc757d419b5f25ccdba2096cf07de1d43111973d2f2fe405a787efc45ff019c
+- 0644        290 usr/share/zoneinfo/Pacific/Noumea  sha256:b641f1c67c6c5d33aacf76335a2d269214c220e37383e5bb12949131d3e329d4
+h 0644          - usr/share/zoneinfo/Pacific/Pago_Pago => usr/share/zoneinfo/Pacific/Midway
+- 0644        166 usr/share/zoneinfo/Pacific/Palau  sha256:68dd876d3d2b7aac0aaed2ca0caf4cdb36f47748a474d953aeb9ed571747ebaa
+- 0644        188 usr/share/zoneinfo/Pacific/Pitcairn  sha256:5388c052ebec44da32f17acf6b5e98a5c5c272a1c9634bba26f08d80f1163b57
+h 0644          - usr/share/zoneinfo/Pacific/Pohnpei => usr/share/zoneinfo/Pacific/Guadalcanal
+h 0644          - usr/share/zoneinfo/Pacific/Ponape => usr/share/zoneinfo/Pacific/Guadalcanal
+h 0644          - usr/share/zoneinfo/Pacific/Port_Moresby => usr/share/zoneinfo/Antarctica/DumontDUrville
+- 0644        589 usr/share/zoneinfo/Pacific/Rarotonga  sha256:c0f12ca176f20e7ba17f39202ef52a852ceb331fc50f8dae00f96e48f321dc17
+h 0644          - usr/share/zoneinfo/Pacific/Saipan => usr/share/zoneinfo/Pacific/Guam
+h 0644          - usr/share/zoneinfo/Pacific/Samoa => usr/share/zoneinfo/Pacific/Midway
+- 0644        151 usr/share/zoneinfo/Pacific/Tahiti  sha256:0517dff46dc4fa258a84e591d56bb4d99d223208ebc035d5f9736ba88b577536
+h 0644          - usr/share/zoneinfo/Pacific/Tarawa => usr/share/zoneinfo/Pacific/Funafuti
+- 0644        358 usr/share/zoneinfo/Pacific/Tongatapu  sha256:3a9a4166a4c06626fd1d8ed4f400be25abceee6e8dc4f194b547cf40097da016
+h 0644          - usr/share/zoneinfo/Pacific/Truk => usr/share/zoneinfo/Antarctica/DumontDUrville
+h 0644          - usr/share/zoneinfo/Pacific/Wake => usr/share/zoneinfo/Pacific/Funafuti
+h 0644          - usr/share/zoneinfo/Pacific/Wallis => usr/share/zoneinfo/Pacific/Funafuti
+h 0644          - usr/share/zoneinfo/Pacific/Yap => usr/share/zoneinfo/Antarctica/DumontDUrville
+h 0644          - usr/share/zoneinfo/Poland => usr/share/zoneinfo/Europe/Warsaw
+h 0644          - usr/share/zoneinfo/Portugal => usr/share/zoneinfo/Europe/Lisbon
+h 0644          - usr/share/zoneinfo/ROC => usr/share/zoneinfo/Asia/Taipei
+h 0644          - usr/share/zoneinfo/ROK => usr/share/zoneinfo/Asia/Seoul
+h 0644          - usr/share/zoneinfo/Singapore => usr/share/zoneinfo/Asia/Kuala_Lumpur
+h 0644          - usr/share/zoneinfo/Turkey => usr/share/zoneinfo/Asia/Istanbul
+h 0644          - usr/share/zoneinfo/UCT => usr/share/zoneinfo/Etc/UCT
+d 0755          - usr/share/zoneinfo/US/
+h 0644          - usr/share/zoneinfo/US/Alaska => usr/share/zoneinfo/America/Anchorage
+h 0644          - usr/share/zoneinfo/US/Aleutian => usr/share/zoneinfo/America/Adak
+h 0644          - usr/share/zoneinfo/US/Arizona => usr/share/zoneinfo/America/Creston
+h 0644          - usr/share/zoneinfo/US/Central => usr/share/zoneinfo/America/Chicago
+h 0644          - usr/share/zoneinfo/US/East-Indiana => usr/share/zoneinfo/America/Fort_Wayne
+h 0644          - usr/share/zoneinfo/US/Eastern => usr/share/zoneinfo/America/New_York
+h 0644          - usr/share/zoneinfo/US/Hawaii => usr/share/zoneinfo/HST
+h 0644          - usr/share/zoneinfo/US/Indiana-Starke => usr/share/zoneinfo/America/Indiana/Knox
+h 0644          - usr/share/zoneinfo/US/Michigan => usr/share/zoneinfo/America/Detroit
+h 0644          - usr/share/zoneinfo/US/Mountain => usr/share/zoneinfo/America/Denver
+h 0644          - usr/share/zoneinfo/US/Pacific => usr/share/zoneinfo/America/Los_Angeles
+h 0644          - usr/share/zoneinfo/US/Samoa => usr/share/zoneinfo/Pacific/Midway
+h 0644          - usr/share/zoneinfo/UTC => usr/share/zoneinfo/Etc/UCT
+h 0644          - usr/share/zoneinfo/Universal => usr/share/zoneinfo/Etc/UCT
+h 0644          - usr/share/zoneinfo/W-SU => usr/share/zoneinfo/Europe/Moscow
+h 0644          - usr/share/zoneinfo/WET => usr/share/zoneinfo/Europe/Lisbon
+h 0644          - usr/share/zoneinfo/Zulu => usr/share/zoneinfo/Etc/UCT
+- 0644       4791 usr/share/zoneinfo/iso3166.tab  sha256:a01a5d158f31d46ad8e6f8cc2a06c641810682a9397d460320f68d5421b65e71
+- 0644       5069 usr/share/zoneinfo/leap-seconds.list  sha256:0bd731802f83a7ffbb3a7cd17f87af670032e16ad71b14747b057ca655277c25
+h 0644          - usr/share/zoneinfo/posixrules => usr/share/zoneinfo/America/New_York
+d 0755          - usr/share/zoneinfo/right/
+d 0755          - usr/share/zoneinfo/right/Africa/
+- 0644        688 usr/share/zoneinfo/right/Africa/Abidjan  sha256:f4233616006266407f7cb61f082a30b7346cfc41cb473faeace08240db03ebaf
+h 0644          - usr/share/zoneinfo/right/Africa/Accra => usr/share/zoneinfo/right/Africa/Abidjan
+- 0644        805 usr/share/zoneinfo/right/Africa/Addis_Ababa  sha256:3aa7d8468964feede0a79c2295b2545cd666714f7f8f173a7df597a58c6703e7
+- 0644       1275 usr/share/zoneinfo/right/Africa/Algiers  sha256:d02d23d1418aa96f67421bd719a2bc0e18eb7fea9dc577a3f718a9f88572eb34
+h 0644          - usr/share/zoneinfo/right/Africa/Asmara => usr/share/zoneinfo/right/Africa/Addis_Ababa
+h 0644          - usr/share/zoneinfo/right/Africa/Asmera => usr/share/zoneinfo/right/Africa/Addis_Ababa
+h 0644          - usr/share/zoneinfo/right/Africa/Bamako => usr/share/zoneinfo/right/Africa/Abidjan
+- 0644        775 usr/share/zoneinfo/right/Africa/Bangui  sha256:4dd77f825f7133e6125b66c9354c7a4158a45bdcd68b9a8a33a8bc8951770d5b
+h 0644          - usr/share/zoneinfo/right/Africa/Banjul => usr/share/zoneinfo/right/Africa/Abidjan
+- 0644        734 usr/share/zoneinfo/right/Africa/Bissau  sha256:abfd4d46b7f68e7833b05af8e17ed098c86aae1b305add3990c4d955b51c8613
+- 0644        689 usr/share/zoneinfo/right/Africa/Blantyre  sha256:104f9c0d29896e42a1eede8db7c24ecfd252fbf2edccb86b707526281f52bb8c
+h 0644          - usr/share/zoneinfo/right/Africa/Brazzaville => usr/share/zoneinfo/right/Africa/Bangui
+h 0644          - usr/share/zoneinfo/right/Africa/Bujumbura => usr/share/zoneinfo/right/Africa/Blantyre
+- 0644       2939 usr/share/zoneinfo/right/Africa/Cairo  sha256:a8245264ff0d0ffc60149218436d3e6e8e84ff32c042dc15a416f31666112d8d
+- 0644       2969 usr/share/zoneinfo/right/Africa/Casablanca  sha256:03fd202ba98d914fc76a27e342d677c19dba8be46c3079daeafbd97a9481f581
+- 0644       2592 usr/share/zoneinfo/right/Africa/Ceuta  sha256:45ad241f670667961640bc49249327fe45086b0644d6f89d2efe552c9c77b561
+h 0644          - usr/share/zoneinfo/right/Africa/Conakry => usr/share/zoneinfo/right/Africa/Abidjan
+h 0644          - usr/share/zoneinfo/right/Africa/Dakar => usr/share/zoneinfo/right/Africa/Abidjan
+h 0644          - usr/share/zoneinfo/right/Africa/Dar_es_Salaam => usr/share/zoneinfo/right/Africa/Addis_Ababa
+h 0644          - usr/share/zoneinfo/right/Africa/Djibouti => usr/share/zoneinfo/right/Africa/Addis_Ababa
+h 0644          - usr/share/zoneinfo/right/Africa/Douala => usr/share/zoneinfo/right/Africa/Bangui
+- 0644       2835 usr/share/zoneinfo/right/Africa/El_Aaiun  sha256:8e7634d74b2f98a99b5e2c97b24ee0f5d4e48df2220beb4bb38fb68a2b93cb8d
+h 0644          - usr/share/zoneinfo/right/Africa/Freetown => usr/share/zoneinfo/right/Africa/Abidjan
+h 0644          - usr/share/zoneinfo/right/Africa/Gaborone => usr/share/zoneinfo/right/Africa/Blantyre
+h 0644          - usr/share/zoneinfo/right/Africa/Harare => usr/share/zoneinfo/right/Africa/Blantyre
+- 0644        786 usr/share/zoneinfo/right/Africa/Johannesburg  sha256:170db51e1f05eea6e9a14a085884136f4aa78e000b1aa8605806e09ac2cf94be
+- 0644       1219 usr/share/zoneinfo/right/Africa/Juba  sha256:9ed0073fe89423937cd7847b315c793813c7a0a729fd067559d7a12993630256
+h 0644          - usr/share/zoneinfo/right/Africa/Kampala => usr/share/zoneinfo/right/Africa/Addis_Ababa
+- 0644       1219 usr/share/zoneinfo/right/Africa/Khartoum  sha256:5fb7ac496978d461f873e95044333153dc47e4d4172505122f850f1b45c7f33f
+h 0644          - usr/share/zoneinfo/right/Africa/Kigali => usr/share/zoneinfo/right/Africa/Blantyre
+h 0644          - usr/share/zoneinfo/right/Africa/Kinshasa => usr/share/zoneinfo/right/Africa/Bangui
+h 0644          - usr/share/zoneinfo/right/Africa/Lagos => usr/share/zoneinfo/right/Africa/Bangui
+h 0644          - usr/share/zoneinfo/right/Africa/Libreville => usr/share/zoneinfo/right/Africa/Bangui
+h 0644          - usr/share/zoneinfo/right/Africa/Lome => usr/share/zoneinfo/right/Africa/Abidjan
+h 0644          - usr/share/zoneinfo/right/Africa/Luanda => usr/share/zoneinfo/right/Africa/Bangui
+h 0644          - usr/share/zoneinfo/right/Africa/Lubumbashi => usr/share/zoneinfo/right/Africa/Blantyre
+h 0644          - usr/share/zoneinfo/right/Africa/Lusaka => usr/share/zoneinfo/right/Africa/Blantyre
+h 0644          - usr/share/zoneinfo/right/Africa/Malabo => usr/share/zoneinfo/right/Africa/Bangui
+h 0644          - usr/share/zoneinfo/right/Africa/Maputo => usr/share/zoneinfo/right/Africa/Blantyre
+h 0644          - usr/share/zoneinfo/right/Africa/Maseru => usr/share/zoneinfo/right/Africa/Johannesburg
+h 0644          - usr/share/zoneinfo/right/Africa/Mbabane => usr/share/zoneinfo/right/Africa/Johannesburg
+h 0644          - usr/share/zoneinfo/right/Africa/Mogadishu => usr/share/zoneinfo/right/Africa/Addis_Ababa
+- 0644        748 usr/share/zoneinfo/right/Africa/Monrovia  sha256:7f08d659647669a66b01775a4a05c0a105d54593f1077aecee1df6f76cca3ad4
+h 0644          - usr/share/zoneinfo/right/Africa/Nairobi => usr/share/zoneinfo/right/Africa/Addis_Ababa
+- 0644        739 usr/share/zoneinfo/right/Africa/Ndjamena  sha256:768c12a3f11682eeb1f6cd0ba9282196a35e1786d37e107645819eb7dc0cce9d
+h 0644          - usr/share/zoneinfo/right/Africa/Niamey => usr/share/zoneinfo/right/Africa/Bangui
+h 0644          - usr/share/zoneinfo/right/Africa/Nouakchott => usr/share/zoneinfo/right/Africa/Abidjan
+h 0644          - usr/share/zoneinfo/right/Africa/Ouagadougou => usr/share/zoneinfo/right/Africa/Abidjan
+h 0644          - usr/share/zoneinfo/right/Africa/Porto-Novo => usr/share/zoneinfo/right/Africa/Bangui
+- 0644        794 usr/share/zoneinfo/right/Africa/Sao_Tome  sha256:d276a52c133e1fd3d6d37d15265a883e65155050f4bc4b5d92f38a6fb46c937c
+h 0644          - usr/share/zoneinfo/right/Africa/Timbuktu => usr/share/zoneinfo/right/Africa/Abidjan
+- 0644       1165 usr/share/zoneinfo/right/Africa/Tripoli  sha256:1b7a209b9c51b16703eae332b7145f7d45b9a4b0f5a0fae3bf129616a2cae375
+- 0644       1229 usr/share/zoneinfo/right/Africa/Tunis  sha256:a892830b9eb033baddf9279b3348286ff9c9b05ff761f3fd28bad037e6496f5d
+- 0644       1495 usr/share/zoneinfo/right/Africa/Windhoek  sha256:b229e77f5f935574748331a836931531c856f51a6c39cf59092b9abde0976dbe
+d 0755          - usr/share/zoneinfo/right/America/
+- 0644       2896 usr/share/zoneinfo/right/America/Adak  sha256:0a34da27e56939efe9de64c2cc247cdcfeba2b8b9e50c7874a37f2686fdefd3f
+- 0644       2911 usr/share/zoneinfo/right/America/Anchorage  sha256:15dfc71e1a15500bee1deec7ca1d9b6d48f90303369e6554a7654c698631930f
+- 0644        786 usr/share/zoneinfo/right/America/Anguilla  sha256:380d72f2d6623dac48cff2dfb46eec2e48b68053c708dca04168321b6453d185
+h 0644          - usr/share/zoneinfo/right/America/Antigua => usr/share/zoneinfo/right/America/Anguilla
+- 0644       1410 usr/share/zoneinfo/right/America/Araguaina  sha256:f64e9c23a80b7243ecfb2ccda042c122b8938d218758e1d13d638c8bfb0fcef0
+d 0755          - usr/share/zoneinfo/right/America/Argentina/
+- 0644       1602 usr/share/zoneinfo/right/America/Argentina/Buenos_Aires  sha256:5bbe114444683c1394aedfcdcb50651bf142b1641bfb4eda8eaccf6b00c577bb
+- 0644       1602 usr/share/zoneinfo/right/America/Argentina/Catamarca  sha256:9485357c05421b291776e56fcceece8cfe48dd334d2698108e8d4a836c3532e0
+h 0644          - usr/share/zoneinfo/right/America/Argentina/ComodRivadavia => usr/share/zoneinfo/right/America/Argentina/Catamarca
+- 0644       1602 usr/share/zoneinfo/right/America/Argentina/Cordoba  sha256:18907fe2cfc55bbf51f21958bdcdbc809ee8c2f5c68e59a8d712c2279150c8ee
+- 0644       1574 usr/share/zoneinfo/right/America/Argentina/Jujuy  sha256:18344222894ae5988d301ab87150cf36d1782e05ea4749d77e94f711e5a3687c
+- 0644       1616 usr/share/zoneinfo/right/America/Argentina/La_Rioja  sha256:bc55341f54cda1455748ccf3f0996fb7c9c0c65805e1d838c9f0f96677b3b166
+- 0644       1602 usr/share/zoneinfo/right/America/Argentina/Mendoza  sha256:09728754c717a119dd518bb15c5ddfe6703b2ea075539c940d3cd1fa01b6d59b
+- 0644       1602 usr/share/zoneinfo/right/America/Argentina/Rio_Gallegos  sha256:28c7d6070a16cca26e8fc8e19bb4a4fc619da0a95b67da58266f74cf48fad075
+- 0644       1574 usr/share/zoneinfo/right/America/Argentina/Salta  sha256:3fd63998194309a2ef277b355b78343110bb353fecdfdbcb962eaa7ec24b0626
+- 0644       1616 usr/share/zoneinfo/right/America/Argentina/San_Juan  sha256:cbc5ad702a832d9c2606128988d08c960d2859305231c2d64dc534008a1a2b27
+- 0644       1628 usr/share/zoneinfo/right/America/Argentina/San_Luis  sha256:9debc2f03d41847c27507e63cdb05dd521720d381fd3c72affde649d142545e5
+- 0644       1630 usr/share/zoneinfo/right/America/Argentina/Tucuman  sha256:0c64cddbfaebd13aa6e0e769b394be2938e67a977694fbe67137e0dfb7df6f76
+- 0644       1602 usr/share/zoneinfo/right/America/Argentina/Ushuaia  sha256:91e4d4c3c0931ddeecc8b4da02020a14d7d8cd11ebd4915b024770283b270414
+h 0644          - usr/share/zoneinfo/right/America/Aruba => usr/share/zoneinfo/right/America/Anguilla
+- 0644       2184 usr/share/zoneinfo/right/America/Asuncion  sha256:8964200355d58e4172e42a43c727eb3a65a3e45fd8aab968e1e401b324e61f3f
+- 0644        722 usr/share/zoneinfo/right/America/Atikokan  sha256:9cc0b99b474b6e7ac5d34f9a72fb686c77dc3e89c94d5c7541bc4e2bf33eca80
+h 0644          - usr/share/zoneinfo/right/America/Atka => usr/share/zoneinfo/right/America/Adak
+- 0644       1550 usr/share/zoneinfo/right/America/Bahia  sha256:d49cf8b300965e1479c8fdfa847075c11468c19dcc4a8c43d6c213172d9548cc
+- 0644       1640 usr/share/zoneinfo/right/America/Bahia_Banderas  sha256:afb472d810345ff237accbe2faa037999b99ac41596218899e9e3c74dd595f77
+- 0644        976 usr/share/zoneinfo/right/America/Barbados  sha256:54ec52f42d10af87788633750887026b0d07e67784f47a886d7919e9876f1b95
+- 0644       1102 usr/share/zoneinfo/right/America/Belem  sha256:2b44adfa0fdce7b822eef06a0ad9c293899d4e8facbad621467107375fc4414d
+- 0644       2154 usr/share/zoneinfo/right/America/Belize  sha256:b2af883061a226e991631b038fa337151e71ed40b8c583c0367dcbb100b418e3
+h 0644          - usr/share/zoneinfo/right/America/Blanc-Sablon => usr/share/zoneinfo/right/America/Anguilla
+- 0644       1158 usr/share/zoneinfo/right/America/Boa_Vista  sha256:2f7609f16195a9fbf86631a4fba7d67c12aebf8f6bec3945cfdfe177ef756c92
+- 0644        772 usr/share/zoneinfo/right/America/Bogota  sha256:7b53812f2fa251abb476d01dcdc58074061286ed9a4604e808ff704e84db9431
+- 0644       2950 usr/share/zoneinfo/right/America/Boise  sha256:d9d14321a0868ed1a754f46ec46fcfb216d6dd38fff1757d9a81a70663f01894
+h 0644          - usr/share/zoneinfo/right/America/Buenos_Aires => usr/share/zoneinfo/right/America/Argentina/Buenos_Aires
+- 0644       2794 usr/share/zoneinfo/right/America/Cambridge_Bay  sha256:4dd3933664bb1bc989be1edd1b655f9644e48b0f9b966e652b5e0826c906ce38
+- 0644       1970 usr/share/zoneinfo/right/America/Campo_Grande  sha256:fb0e381f18f370109affbe036d0a1ff1d8d007fa4253d1dc789f0fed58427b1a
+- 0644       1404 usr/share/zoneinfo/right/America/Cancun  sha256:fcf548470161dfa824bd1856f2f3430f3f42da7e4731d83d5d85162c4781bbd0
+- 0644        790 usr/share/zoneinfo/right/America/Caracas  sha256:e7485fc23a6187ea5dccbf1f8ab2b75d59bbbc9127c93f7b16c4d17d46d1694b
+h 0644          - usr/share/zoneinfo/right/America/Catamarca => usr/share/zoneinfo/right/America/Argentina/Catamarca
+- 0644        724 usr/share/zoneinfo/right/America/Cayenne  sha256:1c339795c2891f95dd87513a052682761b076c3e37b5f1afeae4f428366d74aa
+h 0644          - usr/share/zoneinfo/right/America/Cayman => usr/share/zoneinfo/right/America/Atikokan
+- 0644       4132 usr/share/zoneinfo/right/America/Chicago  sha256:11a2746cca461012a7b56741cf111c459fed3e89309d9c627556921c4f0216f1
+- 0644       1642 usr/share/zoneinfo/right/America/Chihuahua  sha256:3fdfc581d0dc261755aaadfe48b557b631b2a3c9817267eb15b2452432a66690
+- 0644       2078 usr/share/zoneinfo/right/America/Ciudad_Juarez  sha256:907d4d6590917570f8140e2815be1919623a91d8f34f9e236972ecb30124c001
+h 0644          - usr/share/zoneinfo/right/America/Coral_Harbour => usr/share/zoneinfo/right/America/Atikokan
+h 0644          - usr/share/zoneinfo/right/America/Cordoba => usr/share/zoneinfo/right/America/Argentina/Cordoba
+- 0644        856 usr/share/zoneinfo/right/America/Costa_Rica  sha256:931a8cbc44a17c76d8ac879eb70bc36fe3836e56334b167fc30375ed60226f4b
+- 0644       2666 usr/share/zoneinfo/right/America/Coyhaique  sha256:01f89105f2c8912dc8ed4e5cc9f053e2faecc77c549339aac0ec570f0b5e2ec8
+- 0644        900 usr/share/zoneinfo/right/America/Creston  sha256:375e12ff9f754d07a23e02bf0c4fd9453cd94d6af6eb934fcc280c79f427e5c5
+- 0644       1942 usr/share/zoneinfo/right/America/Cuiaba  sha256:1b86529e12ed8837f4097efa53324ecdef81bf9d5d8cf377c766c9eaa878911b
+h 0644          - usr/share/zoneinfo/right/America/Curacao => usr/share/zoneinfo/right/America/Anguilla
+- 0644       1238 usr/share/zoneinfo/right/America/Danmarkshavn  sha256:b0f544bc8ba665b6161ff97e73576e93e67c68e749f3e0e7570c6328a0d01423
+- 0644       2154 usr/share/zoneinfo/right/America/Dawson  sha256:b725095ec5a156d826fbd33eabcd5e586b6704e0f8f3c9eb008239155bc59203
+- 0644       1590 usr/share/zoneinfo/right/America/Dawson_Creek  sha256:0050974703fe2be1b07d298ce6353e955e9839e04bc06969a577df0e7fb17e73
+- 0644       3000 usr/share/zoneinfo/right/America/Denver  sha256:ae1bf405e5ac44760cb20eecb074550da61af3508c01cdf0421abc6e685e754c
+- 0644       2770 usr/share/zoneinfo/right/America/Detroit  sha256:1457c435a8325a433ae71ecdf100a4e7e8b165f9864ec91ea82f8a80336268ed
+h 0644          - usr/share/zoneinfo/right/America/Dominica => usr/share/zoneinfo/right/America/Anguilla
+- 0644       2872 usr/share/zoneinfo/right/America/Edmonton  sha256:adc4cc0ce4f91bb9675069ccb61a5c31aedfad408c5abbbcbb95d41abcb3dfe3
+- 0644       1182 usr/share/zoneinfo/right/America/Eirunepe  sha256:43940082bff063eb3343a4368fcb73c266279738edba5e3b18503b688a4ab53e
+- 0644        764 usr/share/zoneinfo/right/America/El_Salvador  sha256:4ab2bcd279d423184ce855bf07241bb92bdf39c22358f8bbaf084930b742e3fd
+- 0644       2998 usr/share/zoneinfo/right/America/Ensenada  sha256:8b44247232ded7f892cac48db6390b88813860574c24502f8c2cd984d65e1a74
+- 0644       2780 usr/share/zoneinfo/right/America/Fort_Nelson  sha256:662281f1f0efb834e0a462e41c06776db0b892eef2e99c686e87810bfac58bd0
+- 0644       2222 usr/share/zoneinfo/right/America/Fort_Wayne  sha256:f74db87853fc76f9992799c250fc6efe23f0f39d847b4ac91e552eed93fc29d0
+- 0644       1242 usr/share/zoneinfo/right/America/Fortaleza  sha256:618768a21c7bf63c6b939c6ae99f5a5c30403420cc35da27d3f83e224dc4ae56
+- 0644       2732 usr/share/zoneinfo/right/America/Glace_Bay  sha256:3a1ade3234f10ce3166f747c4ab5ab1a3e37b224349375add816a6eb203468f0
+- 0644       2429 usr/share/zoneinfo/right/America/Godthab  sha256:955b7defca892dac0a3cb3f89f80a32203690761a23f87fc4136ad03208b945c
+- 0644       3750 usr/share/zoneinfo/right/America/Goose_Bay  sha256:e8f36386ce530142d371cb1b7df3d187c0a83fc9cbff721c639fadca67e8be66
+- 0644       2374 usr/share/zoneinfo/right/America/Grand_Turk  sha256:162410282fd2b49528f3d268ff17b5ca7f3b8c905eeb53c762b7d11ffa4bf7f9
+h 0644          - usr/share/zoneinfo/right/America/Grenada => usr/share/zoneinfo/right/America/Anguilla
+h 0644          - usr/share/zoneinfo/right/America/Guadeloupe => usr/share/zoneinfo/right/America/Anguilla
+- 0644        820 usr/share/zoneinfo/right/America/Guatemala  sha256:3703ac250321367a153a18801238457db970ff1e93c945bc76207027a8608c6d
+- 0644        772 usr/share/zoneinfo/right/America/Guayaquil  sha256:ad7d9895775f457bf049e1a89ec931624fe1df1aaa276ebe328fca325d9c647a
+- 0644        788 usr/share/zoneinfo/right/America/Guyana  sha256:2ead96b0a5816ab4deb0eaf68a375ebdd41112f97cee0cdcc9d393fbcf3bb14c
+- 0644       3964 usr/share/zoneinfo/right/America/Halifax  sha256:2843d77177b88426ef03a9de7edb2e25b4325a5cf6cbe38cbb2926b65990b129
+- 0644       2956 usr/share/zoneinfo/right/America/Havana  sha256:00f0718cdeeb8642ecaa3e16aee6dcdb79c1470245c7f26a8ecef54b267e5768
+- 0644        928 usr/share/zoneinfo/right/America/Hermosillo  sha256:8e5a98af8aa520119206953a69ba37f3c0ce10f8b96c197e03f2eba77c9c4e09
+d 0755          - usr/share/zoneinfo/right/America/Indiana/
+h 0644          - usr/share/zoneinfo/right/America/Indiana/Indianapolis => usr/share/zoneinfo/right/America/Fort_Wayne
+- 0644       2984 usr/share/zoneinfo/right/America/Indiana/Knox  sha256:157d43631493fb1d4b67d280107e6bff72ef6c910bc72eecb227bd96c1f6b09d
+- 0644       2278 usr/share/zoneinfo/right/America/Indiana/Marengo  sha256:2f08bdc2cf2e19cc208b89e6dd550554817b681399fb652c803b6a782dd034c0
+- 0644       2460 usr/share/zoneinfo/right/America/Indiana/Petersburg  sha256:e0aeaf68ed8693116636454d1199957d6da2ce1e90c63b8eead3b5d0c4cca974
+- 0644       2240 usr/share/zoneinfo/right/America/Indiana/Tell_City  sha256:07612d49fedd90f8261691c21e9b62bdf457a7fb03e19ca81ca92b3d8106a5b3
+- 0644       1970 usr/share/zoneinfo/right/America/Indiana/Vevay  sha256:1d87d68a3711fc82741703ae5409d1c12a0e2b69ad97c535e9687c611ed2ab48
+- 0644       2250 usr/share/zoneinfo/right/America/Indiana/Vincennes  sha256:9527640643c5d3164469a2a94e7da5b03464a23451853ef089dba55a65755617
+- 0644       2334 usr/share/zoneinfo/right/America/Indiana/Winamac  sha256:4fe603a9457d07c2bfb0b321e3da4a53d3513d68a0f7e36dbd068618d8bf1829
+h 0644          - usr/share/zoneinfo/right/America/Indianapolis => usr/share/zoneinfo/right/America/Fort_Wayne
+- 0644       2614 usr/share/zoneinfo/right/America/Inuvik  sha256:6b688e6c0de86d290b58f172d31404e1797d63ddfc76d9237550ac58a08cbfe3
+- 0644       2742 usr/share/zoneinfo/right/America/Iqaluit  sha256:45b43ff629a21565bed409c89d773cc5a2e73d13120a166b7cdb8684143cd08e
+- 0644       1022 usr/share/zoneinfo/right/America/Jamaica  sha256:aea66118420ba88ab3a4591579801293f5ff32d7af56c82e48ba1e11f99ddb0e
+h 0644          - usr/share/zoneinfo/right/America/Jujuy => usr/share/zoneinfo/right/America/Argentina/Jujuy
+- 0644       2893 usr/share/zoneinfo/right/America/Juneau  sha256:47c6d0e98e62dcbe3bb54111a5de6924cdc997eb712e0f8db4c378ed13d8e73e
+d 0755          - usr/share/zoneinfo/right/America/Kentucky/
+- 0644       3328 usr/share/zoneinfo/right/America/Kentucky/Louisville  sha256:7cdb111f5b730a0418b6fbcc216122ff14ae0736e532b3e542f8219d885fc930
+- 0644       2908 usr/share/zoneinfo/right/America/Kentucky/Monticello  sha256:7648d3bdb013399e2cb3e158098fee51039901e2493d4747b44de043e1e1d751
+h 0644          - usr/share/zoneinfo/right/America/Knox_IN => usr/share/zoneinfo/right/America/Indiana/Knox
+h 0644          - usr/share/zoneinfo/right/America/Kralendijk => usr/share/zoneinfo/right/America/Anguilla
+- 0644        758 usr/share/zoneinfo/right/America/La_Paz  sha256:882bab088caa59570d910c1accb3b6574a80830e2933751d249b83c215c17ddc
+- 0644        932 usr/share/zoneinfo/right/America/Lima  sha256:3fd0a7bdd8c494de8656227a6a5a3b2719a24df06d27c1679a0c18637eb70018
+- 0644       3392 usr/share/zoneinfo/right/America/Los_Angeles  sha256:88b375a8fda2c05bec7ee1066246b4080efeb61bfb541e6dc6ea794abdf0d835
+h 0644          - usr/share/zoneinfo/right/America/Louisville => usr/share/zoneinfo/right/America/Kentucky/Louisville
+h 0644          - usr/share/zoneinfo/right/America/Lower_Princes => usr/share/zoneinfo/right/America/Anguilla
+- 0644       1270 usr/share/zoneinfo/right/America/Maceio  sha256:7a9f2f8e7063ca3a470325bd254f408a065d327f726f6111d80cf052ed45ef96
+- 0644        970 usr/share/zoneinfo/right/America/Managua  sha256:6f852b1439fb0938a21997c1cfa5acfee03a3e3d1b1041b5cf2ce09c7f47d0d0
+- 0644       1130 usr/share/zoneinfo/right/America/Manaus  sha256:d0f91a55a7bf0911877cb0ef4c77bc0b3c8c9802ce1a44bbcb2e97729c0c6ea5
+h 0644          - usr/share/zoneinfo/right/America/Marigot => usr/share/zoneinfo/right/America/Anguilla
+- 0644        772 usr/share/zoneinfo/right/America/Martinique  sha256:a2be7f415ce96183c6153ff1d39d5480ff77ae1c5c54f72f7777c1092461c589
+- 0644       1958 usr/share/zoneinfo/right/America/Matamoros  sha256:52fb8ab036cefc6d9fb5cf8f9978bb67a2e347825aa41dec3bce452f5ca468d8
+- 0644       1600 usr/share/zoneinfo/right/America/Mazatlan  sha256:2c3e0a4f5f41ee58da0df484637fc836ec3713eda1b3dd7a38822a959f748054
+h 0644          - usr/share/zoneinfo/right/America/Mendoza => usr/share/zoneinfo/right/America/Argentina/Mendoza
+- 0644       2814 usr/share/zoneinfo/right/America/Menominee  sha256:bc4c0725e2d9cf2ae58a1b74b17d8b0a114cc845a8e8b2f21fb2f7385026ee7c
+- 0644       1544 usr/share/zoneinfo/right/America/Merida  sha256:1962a72a5f985bb50bad1dfc033672bb8660e9525ea16d1768097d8766772cb1
+- 0644       1963 usr/share/zoneinfo/right/America/Metlakatla  sha256:22e883e942b95542955eac4abbe9a2be97b8721bc4150f5891efbef621cd809a
+- 0644       1762 usr/share/zoneinfo/right/America/Mexico_City  sha256:5ad5148af7f7031cc1338404c5aef93a9715758eed6da522921f9aaf9b40746e
+- 0644       2192 usr/share/zoneinfo/right/America/Miquelon  sha256:cf2b989598fd40ed7d4f7f50db3c03b5b9f1d7234340a83ec2d0d026d23086bf
+- 0644       3694 usr/share/zoneinfo/right/America/Moncton  sha256:5c953c923b365b588fdca74f847b41b74671724342dc088f1c958444aacbb42f
+- 0644       1654 usr/share/zoneinfo/right/America/Monterrey  sha256:a211366232edc661ead4951cc4a9d24b7d085f8f3be9ea413a6887caea98de56
+- 0644       2036 usr/share/zoneinfo/right/America/Montevideo  sha256:70313553e1c4323da5b11e3256fb56394e57696c23c45fe5c7a563c5816943ee
+- 0644       4034 usr/share/zoneinfo/right/America/Montreal  sha256:c6b3dafd06b43fc19718bee58b155c5bf5d22e383db2d32f0128fa4e3bed3f6c
+h 0644          - usr/share/zoneinfo/right/America/Montserrat => usr/share/zoneinfo/right/America/Anguilla
+h 0644          - usr/share/zoneinfo/right/America/Nassau => usr/share/zoneinfo/right/America/Montreal
+- 0644       4092 usr/share/zoneinfo/right/America/New_York  sha256:7bb140f56dad3d2bb3a13a1de9fa49dbd99cda666eb71e78cb125da17e1dd672
+h 0644          - usr/share/zoneinfo/right/America/Nipigon => usr/share/zoneinfo/right/America/Montreal
+- 0644       2907 usr/share/zoneinfo/right/America/Nome  sha256:a9c7d5f2b9455db243c8e6dd6e3b980bb01462e83f37465127133d2694e10564
+- 0644       1242 usr/share/zoneinfo/right/America/Noronha  sha256:bd75ae922e0038c3397eb5851e554804ab080d60441118c2d289fcc54ffb8a47
+d 0755          - usr/share/zoneinfo/right/America/North_Dakota/
+- 0644       2936 usr/share/zoneinfo/right/America/North_Dakota/Beulah  sha256:5906f934b6f25299847ed3c743da120b78ffa11d286e57e656b32113a93949bb
+- 0644       2936 usr/share/zoneinfo/right/America/North_Dakota/Center  sha256:c0ea48a5819ddf2890170b30bde1a9e44d413a380b4e32ff2f8758835425d50d
+- 0644       2936 usr/share/zoneinfo/right/America/North_Dakota/New_Salem  sha256:56fffef3a6c506850a3ed9a5c769c022cec471aa4c754c7c8edfdd4bc1e4eb9e
+h 0644          - usr/share/zoneinfo/right/America/Nuuk => usr/share/zoneinfo/right/America/Godthab
+- 0644       2064 usr/share/zoneinfo/right/America/Ojinaga  sha256:e750ea549ada4cef08bfaf723dbcddfb679d7e901f7f2640f45a5495e93ef598
+h 0644          - usr/share/zoneinfo/right/America/Panama => usr/share/zoneinfo/right/America/Atikokan
+h 0644          - usr/share/zoneinfo/right/America/Pangnirtung => usr/share/zoneinfo/right/America/Iqaluit
+- 0644        788 usr/share/zoneinfo/right/America/Paramaribo  sha256:426ed930b0429fafaabc39ced0e9535fe074302ed84dba95c2e677e91e167ec0
+h 0644          - usr/share/zoneinfo/right/America/Phoenix => usr/share/zoneinfo/right/America/Creston
+- 0644       1974 usr/share/zoneinfo/right/America/Port-au-Prince  sha256:6a814da25b75a3572c7701d955fd76a0f67bc16da072801139e73842c0c03356
+h 0644          - usr/share/zoneinfo/right/America/Port_of_Spain => usr/share/zoneinfo/right/America/Anguilla
+- 0644       1154 usr/share/zoneinfo/right/America/Porto_Acre  sha256:fe360ae6ad78f5b2a3d80bb008c513040d163cb2b3336158dfc0ce1e8c27423f
+- 0644       1102 usr/share/zoneinfo/right/America/Porto_Velho  sha256:3fc1d3f1df5aef6e1d4ede4080d4d18a4b079d0219316fe41db1e0029505f6fa
+h 0644          - usr/share/zoneinfo/right/America/Puerto_Rico => usr/share/zoneinfo/right/America/Anguilla
+- 0644       2442 usr/share/zoneinfo/right/America/Punta_Arenas  sha256:617d4c58044df24ca525b3914b696ec8b4db1f594ba51175e2c944a2af11364f
+- 0644       3408 usr/share/zoneinfo/right/America/Rainy_River  sha256:f5b2158f105dc4499b31f156fa6a99e19198474ae32248a86e20a032adb14f87
+- 0644       2606 usr/share/zoneinfo/right/America/Rankin_Inlet  sha256:c6ec3e8925cdb45a507f020f249863403eba7eef540a05f1e23954ce670db362
+- 0644       1242 usr/share/zoneinfo/right/America/Recife  sha256:06a0fa35afed92c7fc936068d353ac373768c92fd2564f948d780ce72f0abd5c
+- 0644       1520 usr/share/zoneinfo/right/America/Regina  sha256:8e8a5a66a6f3b3ec3bf25b260bdb1157847968f1c439badf5a1aee787ec31cee
+- 0644       2606 usr/share/zoneinfo/right/America/Resolute  sha256:396ffcf87a0116bbc2dfe94dff429c9fe3d70f9f59d220dd830da3e34c0b41de
+h 0644          - usr/share/zoneinfo/right/America/Rio_Branco => usr/share/zoneinfo/right/America/Porto_Acre
+h 0644          - usr/share/zoneinfo/right/America/Rosario => usr/share/zoneinfo/right/America/Argentina/Cordoba
+h 0644          - usr/share/zoneinfo/right/America/Santa_Isabel => usr/share/zoneinfo/right/America/Ensenada
+- 0644       1128 usr/share/zoneinfo/right/America/Santarem  sha256:9293a36c17726e9bdc2574d3e723aadae552449dbb2ca8573ec627bb51dc8d61
+- 0644       3055 usr/share/zoneinfo/right/America/Santiago  sha256:a4974f4a367f58e0d884cc9f0f566b8f738009ca968505570688aae998ef0dba
+- 0644        998 usr/share/zoneinfo/right/America/Santo_Domingo  sha256:d758ab3698792929bad03f0821f99299d0e14bae01e7d0480386d5ffad872ffe
+- 0644       1970 usr/share/zoneinfo/right/America/Sao_Paulo  sha256:d48650f928ef29c118c0e21157954a8c1a22606c9541bc215888d4b0caca78a0
+- 0644       2475 usr/share/zoneinfo/right/America/Scoresbysund  sha256:a807f3ad35a1228610f7d7aeba5a07d44961b613b75cdc8167344b89d6c78fe4
+h 0644          - usr/share/zoneinfo/right/America/Shiprock => usr/share/zoneinfo/right/America/Denver
+- 0644       2869 usr/share/zoneinfo/right/America/Sitka  sha256:73efa5b87eb61a6284ab99af60c20e9d06e6ead73801ade803daba73b2ea4e22
+h 0644          - usr/share/zoneinfo/right/America/St_Barthelemy => usr/share/zoneinfo/right/America/Anguilla
+- 0644       4195 usr/share/zoneinfo/right/America/St_Johns  sha256:a381975f17f65a179d4e61e21f09a32f5b9814db51b33d0e2e73e663df443265
+h 0644          - usr/share/zoneinfo/right/America/St_Kitts => usr/share/zoneinfo/right/America/Anguilla
+h 0644          - usr/share/zoneinfo/right/America/St_Lucia => usr/share/zoneinfo/right/America/Anguilla
+h 0644          - usr/share/zoneinfo/right/America/St_Thomas => usr/share/zoneinfo/right/America/Anguilla
+h 0644          - usr/share/zoneinfo/right/America/St_Vincent => usr/share/zoneinfo/right/America/Anguilla
+- 0644       1100 usr/share/zoneinfo/right/America/Swift_Current  sha256:e8e4b669fba01c1259e91eee27d152728e035dc7a08a73dc43e6f48427f869a8
+- 0644        792 usr/share/zoneinfo/right/America/Tegucigalpa  sha256:178fa99342cdffb7e3ea79b1a33dda21a66a896f5b935a12b6e43a88d83ff0ff
+- 0644       2042 usr/share/zoneinfo/right/America/Thule  sha256:3a856cf45b974a963656d7f728fe6ab77bf118218f2e2c6637757cff5d96fa59
+h 0644          - usr/share/zoneinfo/right/America/Thunder_Bay => usr/share/zoneinfo/right/America/Montreal
+h 0644          - usr/share/zoneinfo/right/America/Tijuana => usr/share/zoneinfo/right/America/Ensenada
+h 0644          - usr/share/zoneinfo/right/America/Toronto => usr/share/zoneinfo/right/America/Montreal
+h 0644          - usr/share/zoneinfo/right/America/Tortola => usr/share/zoneinfo/right/America/Anguilla
+- 0644       3432 usr/share/zoneinfo/right/America/Vancouver  sha256:846c05716bc5f1e0f5e1c3498b52f7590c73c59dac7ce9f693792bd86561a61c
+h 0644          - usr/share/zoneinfo/right/America/Virgin => usr/share/zoneinfo/right/America/Anguilla
+- 0644       2154 usr/share/zoneinfo/right/America/Whitehorse  sha256:5d8a4cb1bdbebe5ceaeec8452fde9dbf406b365388c52a998ef6a0734760ad32
+h 0644          - usr/share/zoneinfo/right/America/Winnipeg => usr/share/zoneinfo/right/America/Rainy_River
+- 0644       2845 usr/share/zoneinfo/right/America/Yakutat  sha256:4cee8d752bccefa30cc879205652a431d919a3b987af9d445a105921511bea25
+h 0644          - usr/share/zoneinfo/right/America/Yellowknife => usr/share/zoneinfo/right/America/Edmonton
+d 0755          - usr/share/zoneinfo/right/Antarctica/
+- 0644        963 usr/share/zoneinfo/right/Antarctica/Casey  sha256:797a788098dba3912535039cd9a8ab75bb5ba0f6002921943394a2c5af40d3b0
+- 0644        823 usr/share/zoneinfo/right/Antarctica/Davis  sha256:c8f9fc9ee276cd3584450cab432e9d34d86bdab4a8c6e824d590038344e505d0
+- 0644        712 usr/share/zoneinfo/right/Antarctica/DumontDUrville  sha256:cfa56252a887456ef7757e7a4fd2760dd5b3394489ad7836d9f4614ade7785db
+- 0644       2800 usr/share/zoneinfo/right/Antarctica/Macquarie  sha256:1dc462da964c4ad21010cd749d724bac32a9ec7e23c123c8d1f47efad08b2c53
+- 0644        725 usr/share/zoneinfo/right/Antarctica/Mawson  sha256:8f551dff347653b6c7dce57189e7d0accb8647d4d6a169a9398899f8b17641ca
+- 0644       2977 usr/share/zoneinfo/right/Antarctica/McMurdo  sha256:6db396b64ca16732617f100677a2c2930727b41d1308adfc15141bda92b6d7d0
+- 0644       1944 usr/share/zoneinfo/right/Antarctica/Palmer  sha256:fe442401ef0ca402f79a17ed99131941149b25d1f6cfa44c2c796e36a9fcce8b
+- 0644        690 usr/share/zoneinfo/right/Antarctica/Rothera  sha256:0ad14109fa9842310abb4db35a384f1c0bcc4918a932047bff63f1b3bf8bb01a
+h 0644          - usr/share/zoneinfo/right/Antarctica/South_Pole => usr/share/zoneinfo/right/Antarctica/McMurdo
+- 0644        691 usr/share/zoneinfo/right/Antarctica/Syowa  sha256:66db780a8dc100309138b1bf7834482d0210587178ef9b52b70686974ea5b348
+- 0644       1688 usr/share/zoneinfo/right/Antarctica/Troll  sha256:c599fde30452e67c10d51b6bdae110fdfa9b81a236b40b5015227310d97c5bfa
+- 0644        753 usr/share/zoneinfo/right/Antarctica/Vostok  sha256:d9c2f0ab04f26d02c004bef2837d417e180f6f3bf1753fe6eb72072d1c723bd6
+d 0755          - usr/share/zoneinfo/right/Arctic/
+- 0644       2838 usr/share/zoneinfo/right/Arctic/Longyearbyen  sha256:7823fbce1df592b45c804e5f213263a7b1c933ebcf3489920bbc2da066d2b2a8
+d 0755          - usr/share/zoneinfo/right/Asia/
+h 0644          - usr/share/zoneinfo/right/Asia/Aden => usr/share/zoneinfo/right/Antarctica/Syowa
+- 0644       1523 usr/share/zoneinfo/right/Asia/Almaty  sha256:8089a5ce3c13e0b0a2e57939568899f16c811d65ef87a1296c60817b72a0b232
+- 0644       1973 usr/share/zoneinfo/right/Asia/Amman  sha256:747cd2a9bd012fc2fc7709e9c59bd1b48cf90782e60904b4b0a4c9ae995a25ec
+- 0644       1714 usr/share/zoneinfo/right/Asia/Anadyr  sha256:f266f6dc5c7493c903f3e4dfe2054ae9a280e5f9f7511af51a236d2a82f35c2a
+- 0644       1509 usr/share/zoneinfo/right/Asia/Aqtau  sha256:2f152e6a6c381b24dbea910084c5ecec2b8f0e2f151550abcaa718aaf7d1f36e
+- 0644       1537 usr/share/zoneinfo/right/Asia/Aqtobe  sha256:4870c19fb05da1aee071721cfe950081e5c1969e23590fa09100836006dac1ce
+- 0644       1145 usr/share/zoneinfo/right/Asia/Ashgabat  sha256:f7905cd4df9f93e39b535ccb674e83a5b469658f81c4827fb327186d98bf4c83
+h 0644          - usr/share/zoneinfo/right/Asia/Ashkhabad => usr/share/zoneinfo/right/Asia/Ashgabat
+- 0644       1517 usr/share/zoneinfo/right/Asia/Atyrau  sha256:5a43f15ec469d51ed03408117f5158ad47d26768ad7f210967db1556949ba1f4
+- 0644       1509 usr/share/zoneinfo/right/Asia/Baghdad  sha256:7708072f0ea05dc57e2b03860991413c6799605cba64b63d633bd1af6a15a041
+- 0644        725 usr/share/zoneinfo/right/Asia/Bahrain  sha256:c17044478042c99e8cb57d8286c65b6cfc9c5c69272229886c27ace17a22cb5c
+- 0644       1753 usr/share/zoneinfo/right/Asia/Baku  sha256:7f871bd0bf15cdf5e76fa9af31d721d68d2dd4a1a15e31a81551c8cb8087c380
+- 0644        725 usr/share/zoneinfo/right/Asia/Bangkok  sha256:db5ab1f7cdf863ac2698b3c41f29f6c3cd78be6455589a27f22dc5e890b38e6b
+- 0644       1747 usr/share/zoneinfo/right/Asia/Barnaul  sha256:37aec54db5976e653a5ffc5be3e502c563edcdc16eda24b52e7affc215306c43
+- 0644       2694 usr/share/zoneinfo/right/Asia/Beirut  sha256:5eb5304e5507dcadc198706b27d8240cba8f5f282713cc85e5aadfbd406c71e2
+- 0644       1509 usr/share/zoneinfo/right/Asia/Bishkek  sha256:b6c98b5dadcb037359843c893f6601eb6b3a7ac93d5b51aab3dee44e110aec54
+- 0644       1009 usr/share/zoneinfo/right/Asia/Brunei  sha256:08afd71d5b43978934a955553fe3c219c20e88c392635425ff3b6db6ec57853d
+- 0644        825 usr/share/zoneinfo/right/Asia/Calcutta  sha256:10cc9f7ac5e408608cca4643e4c93e70da11f40c0b21e21b72f05003f26f98c4
+- 0644       1747 usr/share/zoneinfo/right/Asia/Chita  sha256:f37ac9264a9797bc0f7809a4896afafc90a0001765fa593fb0beb03fa5fd537f
+- 0644       1417 usr/share/zoneinfo/right/Asia/Choibalsan  sha256:d10c3b0ecf5f3631dcbb43509b650909bb619f53405923b600f91fb0965e6e6c
+- 0644       1101 usr/share/zoneinfo/right/Asia/Chongqing  sha256:0f1b7b1f187bc86e2843779cdefc6b38df2ac977a28b930fdf98e3a7d69a36b1
+h 0644          - usr/share/zoneinfo/right/Asia/Chungking => usr/share/zoneinfo/right/Asia/Chongqing
+- 0644        898 usr/share/zoneinfo/right/Asia/Colombo  sha256:56547a72733e9aa9efbf0220988dd3cbc43367ed9219d69805ed826b900a8d97
+- 0644        863 usr/share/zoneinfo/right/Asia/Dacca  sha256:727a72e3d34ec7d5140278a87e4451c7a178787e55e26b0fccf3849c611c4733
+- 0644       2413 usr/share/zoneinfo/right/Asia/Damascus  sha256:f05b953dae1a2df4a0bb48c8fd43d810eabd9608f97408bc13f65b210dfa6f37
+h 0644          - usr/share/zoneinfo/right/Asia/Dhaka => usr/share/zoneinfo/right/Asia/Dacca
+- 0644        797 usr/share/zoneinfo/right/Asia/Dili  sha256:65433595dbc4274528f39719a7ef6ab022e2a2004c0b01677c18675eae58325e
+- 0644        691 usr/share/zoneinfo/right/Asia/Dubai  sha256:021471fd3e9592d041fba58278210017b210d0ba4e34991eae656d239a8b28fb
+- 0644       1117 usr/share/zoneinfo/right/Asia/Dushanbe  sha256:5df87ce400417a624bde88dd023d55230a6180a386048e38c71688d2b4a0c834
+- 0644       2568 usr/share/zoneinfo/right/Asia/Famagusta  sha256:bbefccfda0eef52f86b25c776e6d1c6b5fb9434a68f83fdb0e5a286da834a295
+- 0644       4384 usr/share/zoneinfo/right/Asia/Gaza  sha256:74535d1c9f8bc7135adf3ed55b6edbff75fe79d0f867eae15b1e23070b6fc85c
+h 0644          - usr/share/zoneinfo/right/Asia/Harbin => usr/share/zoneinfo/right/Asia/Chongqing
+- 0644       4412 usr/share/zoneinfo/right/Asia/Hebron  sha256:9c5c7f3814c5c57c7c8d7a02e0b1aa6e760b012500bcd38fdbe2be817001cf9e
+- 0644        877 usr/share/zoneinfo/right/Asia/Ho_Chi_Minh  sha256:8834fb47d285572c22bb0384848710b530079dab8915c8bf8a70cf110f321728
+- 0644       1773 usr/share/zoneinfo/right/Asia/Hong_Kong  sha256:6f045e01c0c80e157f240abd549d3ce8957972b9bb6c9f04f75f3d69f3afc36f
+- 0644       1417 usr/share/zoneinfo/right/Asia/Hovd  sha256:bdcbcb464df602e87a840d7fb4ca3fffbc33ffe0d662958b16920bc3f81f971f
+- 0644       1769 usr/share/zoneinfo/right/Asia/Irkutsk  sha256:dd893ad3a5636f2503d1fbd21810fd3363548fa0b2617ed91ca6ad269860cc6c
+- 0644       2473 usr/share/zoneinfo/right/Asia/Istanbul  sha256:e2640cd78debae6a10e359224f1ef88ead514442de48f437d5985dae35e548fd
+- 0644        923 usr/share/zoneinfo/right/Asia/Jakarta  sha256:1700ef66a03b82c6844e5ed7315f50a2a96127165cc2dfa959535c0a0c1c5f06
+- 0644        761 usr/share/zoneinfo/right/Asia/Jayapura  sha256:f50c463a9260839b47573c021c6e2aa0a29a30ab47aa717b546ec3e5c8519fa7
+- 0644       2928 usr/share/zoneinfo/right/Asia/Jerusalem  sha256:350225f72e887f6f2d2ff4455a19e5a86e0ec099d8563ffbdab91478dc72e57b
+- 0644        734 usr/share/zoneinfo/right/Asia/Kabul  sha256:c16331aa3f5a7c44d58bb1e773ed3915b3587a582848265973dc6f0d61b664ba
+- 0644       1692 usr/share/zoneinfo/right/Asia/Kamchatka  sha256:97ebd11ef87485a5484ac884ad3c9a305d158b307037fb5cf0b934a18ee2f5a1
+- 0644        919 usr/share/zoneinfo/right/Asia/Karachi  sha256:0ab0a0c7739df847b67aa1aa1b6cf5879e373d84afa90df8250cfc0279ff9a2c
+- 0644        691 usr/share/zoneinfo/right/Asia/Kashgar  sha256:dabef678ba11b958632dc97bb3e87bb2f0da15aeb1aaf4eaea892529f3c3d062
+- 0644        738 usr/share/zoneinfo/right/Asia/Kathmandu  sha256:7c04a919306d960a119c08f407b345efa1db5f724d5446ae79c98e2a422d00e0
+h 0644          - usr/share/zoneinfo/right/Asia/Katmandu => usr/share/zoneinfo/right/Asia/Kathmandu
+- 0644       1797 usr/share/zoneinfo/right/Asia/Khandyga  sha256:fc383b8bd52963bf15452cd2f06f68e426c46eb2b88f76c2170f8467ed0051b6
+h 0644          - usr/share/zoneinfo/right/Asia/Kolkata => usr/share/zoneinfo/right/Asia/Calcutta
+- 0644       1733 usr/share/zoneinfo/right/Asia/Krasnoyarsk  sha256:682d4062cb16d446e5a2fce69525611016b0855edc27a93e855387d648298d55
+- 0644        941 usr/share/zoneinfo/right/Asia/Kuala_Lumpur  sha256:7fbaff2860adb2356b02c311b4f27b2ef8bddc4c69643e37b3af561417a532e0
+h 0644          - usr/share/zoneinfo/right/Asia/Kuching => usr/share/zoneinfo/right/Asia/Brunei
+h 0644          - usr/share/zoneinfo/right/Asia/Kuwait => usr/share/zoneinfo/right/Antarctica/Syowa
+- 0644       1767 usr/share/zoneinfo/right/Asia/Macao  sha256:c24a7fef867d62f0791f7b37c64ab8e00c3568a149daee0e1c50d096a923af4d
+h 0644          - usr/share/zoneinfo/right/Asia/Macau => usr/share/zoneinfo/right/Asia/Macao
+- 0644       1748 usr/share/zoneinfo/right/Asia/Magadan  sha256:1970e1dc1b874f0c831a1366ba27762b5824ad691f47ae480bec8069317559a4
+- 0644        794 usr/share/zoneinfo/right/Asia/Makassar  sha256:0c5322eec6b1ca98bfe3f4a3360661dc3d7b43f72676401314199a90d39e282d
+- 0644        962 usr/share/zoneinfo/right/Asia/Manila  sha256:8d0eb473771b7d08e1013710ddd2b12e45aa8b34ced0fad3a0b42a5701ed7508
+h 0644          - usr/share/zoneinfo/right/Asia/Muscat => usr/share/zoneinfo/right/Asia/Dubai
+- 0644       2542 usr/share/zoneinfo/right/Asia/Nicosia  sha256:80f19eaf8e9e0cced62b8c86f58ce2033e9af90e897f258ab744961e8395de92
+- 0644       1691 usr/share/zoneinfo/right/Asia/Novokuznetsk  sha256:fff3101b1d4e96191b619d9e980331bdec9021b865d29183d2cc4f10c73e7fad
+- 0644       1747 usr/share/zoneinfo/right/Asia/Novosibirsk  sha256:e04473f3d482ea9ba9916aea41b26b2202341b62c4c6cdb8f2fe4fcff4d34734
+- 0644       1733 usr/share/zoneinfo/right/Asia/Omsk  sha256:8cb6ecaac0bcd2559cc6250c8499ee38891ba7c55f0543fd9fa8ed1f65f57c2d
+- 0644       1531 usr/share/zoneinfo/right/Asia/Oral  sha256:a5ddcae8e80c9a393e72d09f48bd12bf90ba6a46c1cc6fa0933fefac4c2ac65f
+h 0644          - usr/share/zoneinfo/right/Asia/Phnom_Penh => usr/share/zoneinfo/right/Asia/Bangkok
+- 0644        893 usr/share/zoneinfo/right/Asia/Pontianak  sha256:3d0c139143f6a8bef84ff6f069c31d1a6815861c0dec14918e9ee7bc7d727fc2
+- 0644        777 usr/share/zoneinfo/right/Asia/Pyongyang  sha256:569f166f78dc24437e2ce67f7fa3672df8af74527b74c092ae6d214c43962c79
+h 0644          - usr/share/zoneinfo/right/Asia/Qatar => usr/share/zoneinfo/right/Asia/Bahrain
+- 0644       1565 usr/share/zoneinfo/right/Asia/Qostanay  sha256:6c2bc286b1e3a4f2ed07ac4f84a21f2b6d61117f3e9d992259721c039ebacff2
+- 0644       1551 usr/share/zoneinfo/right/Asia/Qyzylorda  sha256:19007705e36a1f6d51e2527501e6abf3994ff2eca23ee3a62e273fef35c069f0
+- 0644        794 usr/share/zoneinfo/right/Asia/Rangoon  sha256:125ffa42c4aec706806021994c1ecaf7999146666f40dd6f3653817acecb958a
+h 0644          - usr/share/zoneinfo/right/Asia/Riyadh => usr/share/zoneinfo/right/Antarctica/Syowa
+h 0644          - usr/share/zoneinfo/right/Asia/Saigon => usr/share/zoneinfo/right/Asia/Ho_Chi_Minh
+- 0644       1728 usr/share/zoneinfo/right/Asia/Sakhalin  sha256:6bed3041a8faeed299a6a70ee61392dedbfe1b6be11a2cb92cb18e912d32b90a
+- 0644       1103 usr/share/zoneinfo/right/Asia/Samarkand  sha256:7b5b60dd5a280b4d2e8aed65f8cf53c8289a1d14f2dcca45f3d948269c2e93d1
+- 0644       1157 usr/share/zoneinfo/right/Asia/Seoul  sha256:3b7d73ae2f17d29d083063996745062e47de1f3c2cd2e228f4bda7584d736317
+h 0644          - usr/share/zoneinfo/right/Asia/Shanghai => usr/share/zoneinfo/right/Asia/Chongqing
+h 0644          - usr/share/zoneinfo/right/Asia/Singapore => usr/share/zoneinfo/right/Asia/Kuala_Lumpur
+- 0644       1734 usr/share/zoneinfo/right/Asia/Srednekolymsk  sha256:2f3d3f13866fe5cf13ce3bfe86ff2f437fea0cf3a8e64f87e1e890f8b4e7e39d
+- 0644       1301 usr/share/zoneinfo/right/Asia/Taipei  sha256:5ac5d0257da8e472d7f55343e8bca0863ca7f3c10833aed8cbee8af6a04e77ba
+- 0644       1117 usr/share/zoneinfo/right/Asia/Tashkent  sha256:09f62c2e37e824e2f0a75651bb94c556b000e6b09efb44d59be2e6315141d323
+- 0644       1561 usr/share/zoneinfo/right/Asia/Tbilisi  sha256:0fef30597eddef86e31be51e04c3c3d37bffe67c1d0c54a7db4c744c5a3d4a91
+- 0644       1788 usr/share/zoneinfo/right/Asia/Tehran  sha256:ad72495c660729f0e33cf64d2e1aeea46989decac71d0a8922eff6d39591e649
+h 0644          - usr/share/zoneinfo/right/Asia/Tel_Aviv => usr/share/zoneinfo/right/Asia/Jerusalem
+- 0644        729 usr/share/zoneinfo/right/Asia/Thimbu  sha256:794c223c90d5e126e143c118093a1bde4e89ceecfa0a3e78c06f50096338ceac
+h 0644          - usr/share/zoneinfo/right/Asia/Thimphu => usr/share/zoneinfo/right/Asia/Thimbu
+- 0644        849 usr/share/zoneinfo/right/Asia/Tokyo  sha256:58a1c13838423566caaea0400bee1da77ae1f4e5722a93581d64973f68c81210
+- 0644       1747 usr/share/zoneinfo/right/Asia/Tomsk  sha256:dc59ef865536e017c28afefa7c37bb8480eb2a67522a44ac4bef1df21e1414da
+h 0644          - usr/share/zoneinfo/right/Asia/Ujung_Pandang => usr/share/zoneinfo/right/Asia/Makassar
+h 0644          - usr/share/zoneinfo/right/Asia/Ulaanbaatar => usr/share/zoneinfo/right/Asia/Choibalsan
+h 0644          - usr/share/zoneinfo/right/Asia/Ulan_Bator => usr/share/zoneinfo/right/Asia/Choibalsan
+h 0644          - usr/share/zoneinfo/right/Asia/Urumqi => usr/share/zoneinfo/right/Asia/Kashgar
+- 0644       1778 usr/share/zoneinfo/right/Asia/Ust-Nera  sha256:8292be55ba54e886ea2d5ee9f1c8b1fe78a8c580f7d35812d41591c37a490f1e
+h 0644          - usr/share/zoneinfo/right/Asia/Vientiane => usr/share/zoneinfo/right/Asia/Bangkok
+- 0644       1734 usr/share/zoneinfo/right/Asia/Vladivostok  sha256:d357f01229efb11e34542d760dc6434a27487beca0e32706e0bd73a08c15ee66
+- 0644       1733 usr/share/zoneinfo/right/Asia/Yakutsk  sha256:a7f732eb939f61c9b302c9f7960a03044540cb9a794eba95d1544aef52d919a4
+h 0644          - usr/share/zoneinfo/right/Asia/Yangon => usr/share/zoneinfo/right/Asia/Rangoon
+- 0644       1769 usr/share/zoneinfo/right/Asia/Yekaterinburg  sha256:3640cfff23344d084a895b2b936d181a73b323c6b746e254d1d1dd1df1c4a471
+- 0644       1677 usr/share/zoneinfo/right/Asia/Yerevan  sha256:ace7e6e36d7bf12c4b5b4378dc56fd3b291663a2e4c5bb02afab5cf4b0dbbffc
+d 0755          - usr/share/zoneinfo/right/Atlantic/
+- 0644       3982 usr/share/zoneinfo/right/Atlantic/Azores  sha256:3961a8c1f1d4e21c8980ef9e064aa828d9a5a35bcdf8ca1b70a9c73463fe8614
+- 0644       2936 usr/share/zoneinfo/right/Atlantic/Bermuda  sha256:02d4071e74e8c3cb2c2c9bd89adcb75c4fc84588eee9c45684205906ce2ddd7d
+- 0644       2437 usr/share/zoneinfo/right/Atlantic/Canary  sha256:9b1a4deab550ec9b67a1282214e4476744ba2af06295d08401521bc77256c5d1
+- 0644        796 usr/share/zoneinfo/right/Atlantic/Cape_Verde  sha256:fa90f81876ba69056291d45d5768616f7cca1755c163f54606a6aedfb41bfaa9
+- 0644       2355 usr/share/zoneinfo/right/Atlantic/Faeroe  sha256:8d4b05aabb767f726b2f88895bbda845488a365d88f28ca9d7da802b2e80b5cb
+h 0644          - usr/share/zoneinfo/right/Atlantic/Faroe => usr/share/zoneinfo/right/Atlantic/Faeroe
+h 0644          - usr/share/zoneinfo/right/Atlantic/Jan_Mayen => usr/share/zoneinfo/right/Arctic/Longyearbyen
+- 0644       3917 usr/share/zoneinfo/right/Atlantic/Madeira  sha256:5d5c5132fe2f05c537d4b901be1cb8d9ad4d6a0bb7502a985bbd5bff7af2c055
+h 0644          - usr/share/zoneinfo/right/Atlantic/Reykjavik => usr/share/zoneinfo/right/Africa/Abidjan
+- 0644        690 usr/share/zoneinfo/right/Atlantic/South_Georgia  sha256:9dae92611be278cf1589e2dcb4cafccf751887fbc609e5f8fccde6ae19ae2b6a
+h 0644          - usr/share/zoneinfo/right/Atlantic/St_Helena => usr/share/zoneinfo/right/Africa/Abidjan
+- 0644       1740 usr/share/zoneinfo/right/Atlantic/Stanley  sha256:828a8d83e57893ccbdbdbf1ad750ee07f3b2b24eb021f249161827593666e2b8
+d 0755          - usr/share/zoneinfo/right/Australia/
+- 0644       2730 usr/share/zoneinfo/right/Australia/ACT  sha256:e970347c261081869c06a5c365815cc48bee0602d1e19da0d3a6e28ef5901a27
+- 0644       2748 usr/share/zoneinfo/right/Australia/Adelaide  sha256:e39a6d188f38b6a1d159c36797ec0b855357605b1a95b1abbef2c72143f33815
+- 0644        959 usr/share/zoneinfo/right/Australia/Brisbane  sha256:11e4c3667175e366c7d07b2e7920ac18ce3db33ac60d3bd053b9057e2104939c
+- 0644       2769 usr/share/zoneinfo/right/Australia/Broken_Hill  sha256:48bf8160d40642e0c58adec8391a742285f49404c54b44cc482ad233f51cf881
+h 0644          - usr/share/zoneinfo/right/Australia/Canberra => usr/share/zoneinfo/right/Australia/ACT
+- 0644       2898 usr/share/zoneinfo/right/Australia/Currie  sha256:692b51d2cbf99d56140ab30c94566be5d5f61d3fb93cb9a59c902ad8e8cd4e1b
+- 0644        865 usr/share/zoneinfo/right/Australia/Darwin  sha256:69e90dc1d9059141fea2c359ea1aafe47cb6d600f25135902ea71163a9818a74
+- 0644        996 usr/share/zoneinfo/right/Australia/Eucla  sha256:be2403879f69d4fdf71b889ab089693baf7e762278d16c37d0ab58c2f115172f
+h 0644          - usr/share/zoneinfo/right/Australia/Hobart => usr/share/zoneinfo/right/Australia/Currie
+- 0644       2386 usr/share/zoneinfo/right/Australia/LHI  sha256:f504eb72841a9ed6b7cb9e34fa394122f83e0e0d0b9d5863f53cad163edd199f
+- 0644       1015 usr/share/zoneinfo/right/Australia/Lindeman  sha256:711d5c83a7914d328449f9363c5199ebb0ba0e601100059075276c81a687ccb4
+h 0644          - usr/share/zoneinfo/right/Australia/Lord_Howe => usr/share/zoneinfo/right/Australia/LHI
+- 0644       2730 usr/share/zoneinfo/right/Australia/Melbourne  sha256:c5e94e7035809e180aa050b55dd448125e535cfa546078e3b251f053ad062407
+h 0644          - usr/share/zoneinfo/right/Australia/NSW => usr/share/zoneinfo/right/Australia/ACT
+h 0644          - usr/share/zoneinfo/right/Australia/North => usr/share/zoneinfo/right/Australia/Darwin
+- 0644        986 usr/share/zoneinfo/right/Australia/Perth  sha256:0fb5587b5905a2f161c674c108567ba9d37e21a4436a05bdbce24d5fa2368564
+h 0644          - usr/share/zoneinfo/right/Australia/Queensland => usr/share/zoneinfo/right/Australia/Brisbane
+h 0644          - usr/share/zoneinfo/right/Australia/South => usr/share/zoneinfo/right/Australia/Adelaide
+h 0644          - usr/share/zoneinfo/right/Australia/Sydney => usr/share/zoneinfo/right/Australia/ACT
+h 0644          - usr/share/zoneinfo/right/Australia/Tasmania => usr/share/zoneinfo/right/Australia/Currie
+h 0644          - usr/share/zoneinfo/right/Australia/Victoria => usr/share/zoneinfo/right/Australia/Melbourne
+h 0644          - usr/share/zoneinfo/right/Australia/West => usr/share/zoneinfo/right/Australia/Perth
+h 0644          - usr/share/zoneinfo/right/Australia/Yancowinna => usr/share/zoneinfo/right/Australia/Broken_Hill
+d 0755          - usr/share/zoneinfo/right/Brazil/
+h 0644          - usr/share/zoneinfo/right/Brazil/Acre => usr/share/zoneinfo/right/America/Porto_Acre
+h 0644          - usr/share/zoneinfo/right/Brazil/DeNoronha => usr/share/zoneinfo/right/America/Noronha
+h 0644          - usr/share/zoneinfo/right/Brazil/East => usr/share/zoneinfo/right/America/Sao_Paulo
+h 0644          - usr/share/zoneinfo/right/Brazil/West => usr/share/zoneinfo/right/America/Manaus
+- 0644       3473 usr/share/zoneinfo/right/CET  sha256:1baeb784afd6829575c4b87ab80ee925c7799b44bb9231eb9dd35e5af899ff1d
+h 0644          - usr/share/zoneinfo/right/CST6CDT => usr/share/zoneinfo/right/America/Chicago
+d 0755          - usr/share/zoneinfo/right/Canada/
+h 0644          - usr/share/zoneinfo/right/Canada/Atlantic => usr/share/zoneinfo/right/America/Halifax
+h 0644          - usr/share/zoneinfo/right/Canada/Central => usr/share/zoneinfo/right/America/Rainy_River
+h 0644          - usr/share/zoneinfo/right/Canada/Eastern => usr/share/zoneinfo/right/America/Montreal
+h 0644          - usr/share/zoneinfo/right/Canada/Mountain => usr/share/zoneinfo/right/America/Edmonton
+h 0644          - usr/share/zoneinfo/right/Canada/Newfoundland => usr/share/zoneinfo/right/America/St_Johns
+h 0644          - usr/share/zoneinfo/right/Canada/Pacific => usr/share/zoneinfo/right/America/Vancouver
+h 0644          - usr/share/zoneinfo/right/Canada/Saskatchewan => usr/share/zoneinfo/right/America/Regina
+h 0644          - usr/share/zoneinfo/right/Canada/Yukon => usr/share/zoneinfo/right/America/Whitehorse
+d 0755          - usr/share/zoneinfo/right/Chile/
+h 0644          - usr/share/zoneinfo/right/Chile/Continental => usr/share/zoneinfo/right/America/Santiago
+- 0644       2759 usr/share/zoneinfo/right/Chile/EasterIsland  sha256:1350d65a6c0a8f3f90419857d942ce6598fe540964647f0ada38054533df62e0
+h 0644          - usr/share/zoneinfo/right/Cuba => usr/share/zoneinfo/right/America/Havana
+- 0644       2802 usr/share/zoneinfo/right/EET  sha256:32f04244ac89a0fd55c2c66af308c9bc7639ef79c127037c990f47d8e922219a
+h 0644          - usr/share/zoneinfo/right/EST => usr/share/zoneinfo/right/America/Atikokan
+h 0644          - usr/share/zoneinfo/right/EST5EDT => usr/share/zoneinfo/right/America/New_York
+h 0644          - usr/share/zoneinfo/right/Egypt => usr/share/zoneinfo/right/Africa/Cairo
+- 0644       4032 usr/share/zoneinfo/right/Eire  sha256:e338ff6ec99a666cf71b5e5be32a990af469b32c73cc7c61689d284144f853a9
+d 0755          - usr/share/zoneinfo/right/Etc/
+- 0644        654 usr/share/zoneinfo/right/Etc/GMT  sha256:39bef83dc0ad7e25d3d8cc1b7ba9e1b4cf34049c35af380933d1d77d2bc5caae
+h 0644          - usr/share/zoneinfo/right/Etc/GMT+0 => usr/share/zoneinfo/right/Etc/GMT
+- 0644        656 usr/share/zoneinfo/right/Etc/GMT+1  sha256:c6567fa0886268c7350128a133752b33eff831898257d83d8ad8179f639ba02f
+- 0644        657 usr/share/zoneinfo/right/Etc/GMT+10  sha256:19ee5a634f44691b6fafd35c0f533e9004ecb0221bdf3f8e5cf2ebb6ebead085
+- 0644        657 usr/share/zoneinfo/right/Etc/GMT+11  sha256:c11f6359495493a5b150d2e8a73a61959ba51e93769d5c59a62e58ac8cf03f91
+- 0644        657 usr/share/zoneinfo/right/Etc/GMT+12  sha256:b8a84265c0724ec8baa61cc913185db89cac39ba88a295e1188993d8131ed7a8
+- 0644        656 usr/share/zoneinfo/right/Etc/GMT+2  sha256:c0f79340974422266215a3564959f6cca517044bc1cba2b8273b17a15129a9c9
+- 0644        656 usr/share/zoneinfo/right/Etc/GMT+3  sha256:09127dbe200bacfe14824dd6effeaf8ea6afa56c6bc8c2c5e573a37bdba3b02f
+- 0644        656 usr/share/zoneinfo/right/Etc/GMT+4  sha256:1e3727ae8838213327e0303fa8834569c6985e2ab858849a9c452ce8aec4f98c
+- 0644        656 usr/share/zoneinfo/right/Etc/GMT+5  sha256:8045434e963a07aa6abdbf56d851be3073bcb0ebb0c31349d8e2d144147a915a
+- 0644        656 usr/share/zoneinfo/right/Etc/GMT+6  sha256:5f989002e671c9e1e021710e088b3042656188425bf0b35762e9d1e091c6c993
+- 0644        656 usr/share/zoneinfo/right/Etc/GMT+7  sha256:60b24a52910e9a2aaa921840cabaec35d8e68c1805aa198f50b2612dfeac663a
+- 0644        656 usr/share/zoneinfo/right/Etc/GMT+8  sha256:75943b89555ae23416cf3cb09174ad8b318c849547e400d509840fbcab90f6dd
+- 0644        656 usr/share/zoneinfo/right/Etc/GMT+9  sha256:ed9a09ea8ff9196e72c9b5512e15cf9982067c9892fc0e374143803ef9db29a5
+h 0644          - usr/share/zoneinfo/right/Etc/GMT-0 => usr/share/zoneinfo/right/Etc/GMT
+- 0644        657 usr/share/zoneinfo/right/Etc/GMT-1  sha256:1a78fd36aa65bfb4d1e940c36f89b0b66c28034d79f848e73cfc541f7a05666f
+- 0644        658 usr/share/zoneinfo/right/Etc/GMT-10  sha256:2fe361f40fe58e1f76b2422a8f1d3259ac99ba5364b723f2a699769362dd76de
+- 0644        658 usr/share/zoneinfo/right/Etc/GMT-11  sha256:f9529333fc6e8df23db1c6cab200718f261cfdfcd60b950827b50e8385536787
+- 0644        658 usr/share/zoneinfo/right/Etc/GMT-12  sha256:590021b5095baccb671afd41ecbaab04eb1ce2b0e98395b05ca280821210264b
+- 0644        658 usr/share/zoneinfo/right/Etc/GMT-13  sha256:06750a9cbe8c5902700b11ae5566ce4753592a3167c1ac59a75d8b1e5cdd0d38
+- 0644        658 usr/share/zoneinfo/right/Etc/GMT-14  sha256:0d13b3132c77ecc045639ad8ff63e2f687b7377446c631adb9e4df43db8cd391
+- 0644        657 usr/share/zoneinfo/right/Etc/GMT-2  sha256:378931c0bdcaea0a41ab7a08f6ca9fd17ff83d82a4d9619c36a3cd208c078624
+- 0644        657 usr/share/zoneinfo/right/Etc/GMT-3  sha256:c5d7c486b2a2bd078d9b46941f1a380889c4bb91ae6c34e7b6d5eafbea355a70
+- 0644        657 usr/share/zoneinfo/right/Etc/GMT-4  sha256:a90191c0a3ed7375dcd6776a64a7aaa8612b9a4aea503b4555f8496b2bfbb38a
+- 0644        657 usr/share/zoneinfo/right/Etc/GMT-5  sha256:58092434c80162cf2a23b506b256e1f991b25fc29d22642b3be1bdbc71f98be8
+- 0644        657 usr/share/zoneinfo/right/Etc/GMT-6  sha256:cfa610926189b8751342fa7fdef9f09cf72e294a0521bfea013a4a468eaffafb
+- 0644        657 usr/share/zoneinfo/right/Etc/GMT-7  sha256:3dda58ed2feafb03deafccaacb68e3370f78fc23743740817a1d93be697495c8
+- 0644        657 usr/share/zoneinfo/right/Etc/GMT-8  sha256:df59bf6611958713b8c8cd1a425d879fe02d5894c3bb37f3de5327599a62304e
+- 0644        657 usr/share/zoneinfo/right/Etc/GMT-9  sha256:3c809522f01269598f9c1e5bb2e04389bfd3677a48d791d4e8a6656d1e4ba5d8
+h 0644          - usr/share/zoneinfo/right/Etc/GMT0 => usr/share/zoneinfo/right/Etc/GMT
+h 0644          - usr/share/zoneinfo/right/Etc/Greenwich => usr/share/zoneinfo/right/Etc/GMT
+- 0644        654 usr/share/zoneinfo/right/Etc/UCT  sha256:ba3f58c59f1dd7b807fb3fe09c4dbabac2465307d7f5044c18cdd7f721c44fcb
+h 0644          - usr/share/zoneinfo/right/Etc/UTC => usr/share/zoneinfo/right/Etc/UCT
+h 0644          - usr/share/zoneinfo/right/Etc/Universal => usr/share/zoneinfo/right/Etc/UCT
+h 0644          - usr/share/zoneinfo/right/Etc/Zulu => usr/share/zoneinfo/right/Etc/UCT
+d 0755          - usr/share/zoneinfo/right/Europe/
+h 0644          - usr/share/zoneinfo/right/Europe/Amsterdam => usr/share/zoneinfo/right/CET
+- 0644       2282 usr/share/zoneinfo/right/Europe/Andorra  sha256:a002c39765cca056ad2a376dff3ba17e939de31d9c3c60bbec85d979e2bba3c1
+- 0644       1691 usr/share/zoneinfo/right/Europe/Astrakhan  sha256:266ccfb3b78123e8d957b2564c73ae08ae560975d24b90d328fc9c9b5394fd09
+h 0644          - usr/share/zoneinfo/right/Europe/Athens => usr/share/zoneinfo/right/EET
+- 0644       4204 usr/share/zoneinfo/right/Europe/Belfast  sha256:d64800146d1579a6df7d5f7abc1163d7cc299030e8b28abc1886b873db8b2fce
+- 0644       2460 usr/share/zoneinfo/right/Europe/Belgrade  sha256:7c1b9262ae825027582780b957866e5a9549ba936f466c1ee7dae8e9f34e20b9
+h 0644          - usr/share/zoneinfo/right/Europe/Berlin => usr/share/zoneinfo/right/Arctic/Longyearbyen
+- 0644       2841 usr/share/zoneinfo/right/Europe/Bratislava  sha256:d3f8ea734f203995e5d0212523b0e97ba5bf43518150ce6965a4ce90cafd1ed8
+h 0644          - usr/share/zoneinfo/right/Europe/Brussels => usr/share/zoneinfo/right/CET
+- 0644       2724 usr/share/zoneinfo/right/Europe/Bucharest  sha256:b156c97eabbfaccc44d7d5b589724582ae23051488210e3e10fd6048e6259127
+- 0644       2908 usr/share/zoneinfo/right/Europe/Budapest  sha256:ccffa6faeeda285e54044483121c454734a2f019cc8c0cad543720f14e3e0a3e
+- 0644       2449 usr/share/zoneinfo/right/Europe/Busingen  sha256:dbe2654d9a9d59613ee28b204a1ae506ea940c89416783a2e5f4aa389749a980
+- 0644       2930 usr/share/zoneinfo/right/Europe/Chisinau  sha256:a0f535eb064530e55c03898c2a07c3b7cf7c688f3770b95cfefddcb542a56dc0
+h 0644          - usr/share/zoneinfo/right/Europe/Copenhagen => usr/share/zoneinfo/right/Arctic/Longyearbyen
+h 0644          - usr/share/zoneinfo/right/Europe/Dublin => usr/share/zoneinfo/right/Eire
+- 0644       3608 usr/share/zoneinfo/right/Europe/Gibraltar  sha256:43898d133325feae5395a21fde1fd5560fdaed2c93997d75d1c7d8eaccaef21d
+h 0644          - usr/share/zoneinfo/right/Europe/Guernsey => usr/share/zoneinfo/right/Europe/Belfast
+- 0644       2440 usr/share/zoneinfo/right/Europe/Helsinki  sha256:a19e7a0ac525c6adcbe41f34e7f7d11a67fa2a74c7991347c0888197217cff1f
+h 0644          - usr/share/zoneinfo/right/Europe/Isle_of_Man => usr/share/zoneinfo/right/Europe/Belfast
+h 0644          - usr/share/zoneinfo/right/Europe/Istanbul => usr/share/zoneinfo/right/Asia/Istanbul
+h 0644          - usr/share/zoneinfo/right/Europe/Jersey => usr/share/zoneinfo/right/Europe/Belfast
+- 0644       2033 usr/share/zoneinfo/right/Europe/Kaliningrad  sha256:a734545243fa1602565e6bf8b0844b4c4d4889d108d1a2775743dce829e8b5a7
+- 0644       2660 usr/share/zoneinfo/right/Europe/Kiev  sha256:a43eac7c7db8b241e43230567ccbc326ac44b1434238e906df1c058b3ce266ca
+- 0644       1725 usr/share/zoneinfo/right/Europe/Kirov  sha256:92f8371765831f78864db75804ae4b3098f871bb68a23a3da430306739f4bab8
+h 0644          - usr/share/zoneinfo/right/Europe/Kyiv => usr/share/zoneinfo/right/Europe/Kiev
+- 0644       4067 usr/share/zoneinfo/right/Europe/Lisbon  sha256:58462eb76ab53da39284ce8cfb6b7f87380c91f09214b8d28f6ef4bb2a397f17
+h 0644          - usr/share/zoneinfo/right/Europe/Ljubljana => usr/share/zoneinfo/right/Europe/Belgrade
+h 0644          - usr/share/zoneinfo/right/Europe/London => usr/share/zoneinfo/right/Europe/Belfast
+h 0644          - usr/share/zoneinfo/right/Europe/Luxembourg => usr/share/zoneinfo/right/CET
+- 0644       3154 usr/share/zoneinfo/right/Europe/Madrid  sha256:c2ae74c18f1dfd1e375fcaf0f61551724b7f0ad91ae4cc5d715d7e5522574380
+- 0644       3160 usr/share/zoneinfo/right/Europe/Malta  sha256:a76e5bec75193fa168139bebbd3db961acf9e332b73d5bceb08266400cf28a33
+h 0644          - usr/share/zoneinfo/right/Europe/Mariehamn => usr/share/zoneinfo/right/Europe/Helsinki
+- 0644       1847 usr/share/zoneinfo/right/Europe/Minsk  sha256:478afd802e4e05e455198bca6f9d0baf6020143a52a7a515b00533316e10baa2
+- 0644       3502 usr/share/zoneinfo/right/Europe/Monaco  sha256:772e4b7c501a44b2c153661ab23272cf2a6f0b87c1bad22034ac208e69c43d1f
+- 0644       2075 usr/share/zoneinfo/right/Europe/Moscow  sha256:3fa6d1da420a48ae49c1999e0473331ff29794ed61f1634549b29d575fd19513
+h 0644          - usr/share/zoneinfo/right/Europe/Nicosia => usr/share/zoneinfo/right/Asia/Nicosia
+h 0644          - usr/share/zoneinfo/right/Europe/Oslo => usr/share/zoneinfo/right/Arctic/Longyearbyen
+h 0644          - usr/share/zoneinfo/right/Europe/Paris => usr/share/zoneinfo/right/Europe/Monaco
+h 0644          - usr/share/zoneinfo/right/Europe/Podgorica => usr/share/zoneinfo/right/Europe/Belgrade
+h 0644          - usr/share/zoneinfo/right/Europe/Prague => usr/share/zoneinfo/right/Europe/Bratislava
+- 0644       2738 usr/share/zoneinfo/right/Europe/Riga  sha256:48dfec3433f4ad15f15461280a85fcb051f60774055c8a400afb6c90f1c0e8a7
+- 0644       3181 usr/share/zoneinfo/right/Europe/Rome  sha256:47b8943eb7e2b24c5e78a13c5686c6c387d0614e7d59f610c02d2612a6d6f394
+- 0644       1741 usr/share/zoneinfo/right/Europe/Samara  sha256:3855b13a200df6d907f8088b146cd890a61f29743fa043916bf0cae7d6171545
+h 0644          - usr/share/zoneinfo/right/Europe/San_Marino => usr/share/zoneinfo/right/Europe/Rome
+h 0644          - usr/share/zoneinfo/right/Europe/Sarajevo => usr/share/zoneinfo/right/Europe/Belgrade
+- 0644       1709 usr/share/zoneinfo/right/Europe/Saratov  sha256:5ef1d024210ee5c3dbdd93411996158dd12ee5fa46db6a13f0b4471618aae433
+- 0644       2009 usr/share/zoneinfo/right/Europe/Simferopol  sha256:8bce314149af0b3d845d5e116198a4dcd340d4ab07ceab4df3c7de22ec1ffc50
+h 0644          - usr/share/zoneinfo/right/Europe/Skopje => usr/share/zoneinfo/right/Europe/Belgrade
+- 0644       2617 usr/share/zoneinfo/right/Europe/Sofia  sha256:86830f8f4f2deb5f325b57a0f8f57f3fa0c62850b4e957b0e0885b96bab1c60d
+h 0644          - usr/share/zoneinfo/right/Europe/Stockholm => usr/share/zoneinfo/right/Arctic/Longyearbyen
+- 0644       2688 usr/share/zoneinfo/right/Europe/Tallinn  sha256:ac8d7cf012dd60c2382c128510bee536c81dd5b5f88be97f48cb4b940985d58f
+- 0644       2624 usr/share/zoneinfo/right/Europe/Tirane  sha256:c6433608b5d62d562b7e580dc16a7b9fed07dab7934ede52cc34c1d555e10cc8
+h 0644          - usr/share/zoneinfo/right/Europe/Tiraspol => usr/share/zoneinfo/right/Europe/Chisinau
+- 0644       1793 usr/share/zoneinfo/right/Europe/Ulyanovsk  sha256:c1d140fe9be55f207449cc57f5b16006b6ea6e519676baaa5a10fbd3ed50cfed
+h 0644          - usr/share/zoneinfo/right/Europe/Uzhgorod => usr/share/zoneinfo/right/Europe/Kiev
+h 0644          - usr/share/zoneinfo/right/Europe/Vaduz => usr/share/zoneinfo/right/Europe/Busingen
+h 0644          - usr/share/zoneinfo/right/Europe/Vatican => usr/share/zoneinfo/right/Europe/Rome
+- 0644       2740 usr/share/zoneinfo/right/Europe/Vienna  sha256:1c8c704b5e303be879b52a9c8e3e6457307dc9569ef3b472b795177c0567061d
+- 0644       2702 usr/share/zoneinfo/right/Europe/Vilnius  sha256:81ffeb8647187c21e0f3bb77422d988a4b1dbe6d7123d174da48a767a7a1020d
+- 0644       1733 usr/share/zoneinfo/right/Europe/Volgograd  sha256:fe22aa87b319a9c30965a1d98c7bdd7c005bb1d2c7866ebb9f487f6426c0790e
+- 0644       3194 usr/share/zoneinfo/right/Europe/Warsaw  sha256:ffc7204033c7e0ef8411664d5d1708330eb00d63b4ad4ba157d4cdc3d6934998
+h 0644          - usr/share/zoneinfo/right/Europe/Zagreb => usr/share/zoneinfo/right/Europe/Belgrade
+h 0644          - usr/share/zoneinfo/right/Europe/Zaporozhye => usr/share/zoneinfo/right/Europe/Kiev
+h 0644          - usr/share/zoneinfo/right/Europe/Zurich => usr/share/zoneinfo/right/Europe/Busingen
+- 0644        656 usr/share/zoneinfo/right/Factory  sha256:ae36208305c159f17f8cc209093178b5f1815ca03983b65dec23fc72427ecfae
+h 0644          - usr/share/zoneinfo/right/GB => usr/share/zoneinfo/right/Europe/Belfast
+h 0644          - usr/share/zoneinfo/right/GB-Eire => usr/share/zoneinfo/right/Europe/Belfast
+h 0644          - usr/share/zoneinfo/right/GMT => usr/share/zoneinfo/right/Etc/GMT
+h 0644          - usr/share/zoneinfo/right/GMT+0 => usr/share/zoneinfo/right/Etc/GMT
+h 0644          - usr/share/zoneinfo/right/GMT-0 => usr/share/zoneinfo/right/Etc/GMT
+h 0644          - usr/share/zoneinfo/right/GMT0 => usr/share/zoneinfo/right/Etc/GMT
+h 0644          - usr/share/zoneinfo/right/Greenwich => usr/share/zoneinfo/right/Etc/GMT
+- 0644        869 usr/share/zoneinfo/right/HST  sha256:1e8ccbc97ab9805bad4cfce89300c2321166547f5bf4bf2b8c7a48b6f069f884
+h 0644          - usr/share/zoneinfo/right/Hongkong => usr/share/zoneinfo/right/Asia/Hong_Kong
+h 0644          - usr/share/zoneinfo/right/Iceland => usr/share/zoneinfo/right/Africa/Abidjan
+d 0755          - usr/share/zoneinfo/right/Indian/
+h 0644          - usr/share/zoneinfo/right/Indian/Antananarivo => usr/share/zoneinfo/right/Africa/Addis_Ababa
+- 0644        725 usr/share/zoneinfo/right/Indian/Chagos  sha256:7a44be5cdc9c358a9d5d716c732e7376d14a748e7e16fa96a4af16d42857feda
+h 0644          - usr/share/zoneinfo/right/Indian/Christmas => usr/share/zoneinfo/right/Asia/Bangkok
+h 0644          - usr/share/zoneinfo/right/Indian/Cocos => usr/share/zoneinfo/right/Asia/Rangoon
+h 0644          - usr/share/zoneinfo/right/Indian/Comoro => usr/share/zoneinfo/right/Africa/Addis_Ababa
+- 0644        725 usr/share/zoneinfo/right/Indian/Kerguelen  sha256:61b962e3a68d89e5f1a168ae4f94f98634e7c82087642bc4adec4ef8049c2a97
+h 0644          - usr/share/zoneinfo/right/Indian/Mahe => usr/share/zoneinfo/right/Asia/Dubai
+h 0644          - usr/share/zoneinfo/right/Indian/Maldives => usr/share/zoneinfo/right/Indian/Kerguelen
+- 0644        767 usr/share/zoneinfo/right/Indian/Mauritius  sha256:9791c2422a4b5b1e20bf631d5c370f8ccfbd8dc50f49870e7d32b37eb4a15e69
+h 0644          - usr/share/zoneinfo/right/Indian/Mayotte => usr/share/zoneinfo/right/Africa/Addis_Ababa
+h 0644          - usr/share/zoneinfo/right/Indian/Reunion => usr/share/zoneinfo/right/Asia/Dubai
+h 0644          - usr/share/zoneinfo/right/Iran => usr/share/zoneinfo/right/Asia/Tehran
+h 0644          - usr/share/zoneinfo/right/Israel => usr/share/zoneinfo/right/Asia/Jerusalem
+h 0644          - usr/share/zoneinfo/right/Jamaica => usr/share/zoneinfo/right/America/Jamaica
+h 0644          - usr/share/zoneinfo/right/Japan => usr/share/zoneinfo/right/Asia/Tokyo
+- 0644        842 usr/share/zoneinfo/right/Kwajalein  sha256:1a9ebb22411c00377e506f35c1d4d0552736e480544c18ef19889b1ff1acdd02
+h 0644          - usr/share/zoneinfo/right/Libya => usr/share/zoneinfo/right/Africa/Tripoli
+h 0644          - usr/share/zoneinfo/right/MET => usr/share/zoneinfo/right/CET
+h 0644          - usr/share/zoneinfo/right/MST => usr/share/zoneinfo/right/America/Creston
+h 0644          - usr/share/zoneinfo/right/MST7MDT => usr/share/zoneinfo/right/America/Denver
+d 0755          - usr/share/zoneinfo/right/Mexico/
+h 0644          - usr/share/zoneinfo/right/Mexico/BajaNorte => usr/share/zoneinfo/right/America/Ensenada
+h 0644          - usr/share/zoneinfo/right/Mexico/BajaSur => usr/share/zoneinfo/right/America/Mazatlan
+h 0644          - usr/share/zoneinfo/right/Mexico/General => usr/share/zoneinfo/right/America/Mexico_City
+h 0644          - usr/share/zoneinfo/right/NZ => usr/share/zoneinfo/right/Antarctica/McMurdo
+- 0644       2594 usr/share/zoneinfo/right/NZ-CHAT  sha256:b49934d5f4cd40cf8aec23c8ce2e65e09e8f62cf15cd1f6957c4ce3ee6baced4
+h 0644          - usr/share/zoneinfo/right/Navajo => usr/share/zoneinfo/right/America/Denver
+h 0644          - usr/share/zoneinfo/right/PRC => usr/share/zoneinfo/right/Asia/Chongqing
+h 0644          - usr/share/zoneinfo/right/PST8PDT => usr/share/zoneinfo/right/America/Los_Angeles
+d 0755          - usr/share/zoneinfo/right/Pacific/
+- 0644       1138 usr/share/zoneinfo/right/Pacific/Apia  sha256:d7861ecaa4700f603ee593c1cf1878e0df15f2dfd3f9a11406074907795e9f8a
+h 0644          - usr/share/zoneinfo/right/Pacific/Auckland => usr/share/zoneinfo/right/Antarctica/McMurdo
+- 0644        794 usr/share/zoneinfo/right/Pacific/Bougainville  sha256:a7a2a4d24753db30bbd686c81bd6fef86f9a84f2a6bd7b56df0dd209b92b2d08
+h 0644          - usr/share/zoneinfo/right/Pacific/Chatham => usr/share/zoneinfo/right/NZ-CHAT
+h 0644          - usr/share/zoneinfo/right/Pacific/Chuuk => usr/share/zoneinfo/right/Antarctica/DumontDUrville
+h 0644          - usr/share/zoneinfo/right/Pacific/Easter => usr/share/zoneinfo/right/Chile/EasterIsland
+- 0644       1064 usr/share/zoneinfo/right/Pacific/Efate  sha256:7f56a3ef14ab638b4703108391c82836d1b699de402eff65df0aec9463143247
+- 0644        760 usr/share/zoneinfo/right/Pacific/Enderbury  sha256:042264a8b4210c8925022271fedde5bc43cb849806eaea7b2b7ca509d7111f7c
+- 0644        726 usr/share/zoneinfo/right/Pacific/Fakaofo  sha256:c59e3ce984efb02d9a34481377abf74af648df7fc15d3f200804d71fdb441b6d
+- 0644       1104 usr/share/zoneinfo/right/Pacific/Fiji  sha256:d50bae2d5ecd0258e313f4cdaf7087df9dfe165cb0eca3b888c4a9ecc7ad47ea
+- 0644        692 usr/share/zoneinfo/right/Pacific/Funafuti  sha256:8edbbfc7dbd19b1bf2473fa735a3030ce00e14624a14f2517cf9fcc9f6a7d3e9
+- 0644        764 usr/share/zoneinfo/right/Pacific/Galapagos  sha256:4faf25093b31b9bb22a48c5016456292d44f5c7e68357fa52d20356ec621075d
+- 0644        690 usr/share/zoneinfo/right/Pacific/Gambier  sha256:4152a43b16c08998c85400993490eff26a28164af99873f33284fc2c62e1ded4
+- 0644        692 usr/share/zoneinfo/right/Pacific/Guadalcanal  sha256:e7b56a9da29a5e44ad7ccea18879d719a0b830daa900b1481bed3d4d0f971f48
+- 0644       1034 usr/share/zoneinfo/right/Pacific/Guam  sha256:ee4aab7829cc0046ffd1e4d82deb087d610a9a14fd9dcfe7cf82f4224a362d65
+h 0644          - usr/share/zoneinfo/right/Pacific/Honolulu => usr/share/zoneinfo/right/HST
+h 0644          - usr/share/zoneinfo/right/Pacific/Johnston => usr/share/zoneinfo/right/HST
+h 0644          - usr/share/zoneinfo/right/Pacific/Kanton => usr/share/zoneinfo/right/Pacific/Enderbury
+- 0644        764 usr/share/zoneinfo/right/Pacific/Kiritimati  sha256:92c95df1d19c1e86c5f62cd1acb165e465919a28a65d1823c95d20c7b0f5ae5b
+- 0644        877 usr/share/zoneinfo/right/Pacific/Kosrae  sha256:e2564f2a4bc0443cae815bd32045462a5b19ef5eac978fa1780ecb5fb9fe87b8
+h 0644          - usr/share/zoneinfo/right/Pacific/Kwajalein => usr/share/zoneinfo/right/Kwajalein
+h 0644          - usr/share/zoneinfo/right/Pacific/Majuro => usr/share/zoneinfo/right/Pacific/Funafuti
+- 0644        699 usr/share/zoneinfo/right/Pacific/Marquesas  sha256:0d6ff8d598d640f9c7a19ed7af3d47e01459264ade90290278f05f86706b1a08
+- 0644        715 usr/share/zoneinfo/right/Pacific/Midway  sha256:6ee8bfcef1ffa96bb23edeea00e3e70e8204471f529a3c33b98ae575d4037d28
+- 0644        778 usr/share/zoneinfo/right/Pacific/Nauru  sha256:21fad9210343e707ec4b881777d5a558ae755e99abb00abbbe7b2b58c1b3bfee
+- 0644        729 usr/share/zoneinfo/right/Pacific/Niue  sha256:7bcc5c886e79394c40293cdc8040c89ad74c7b66fe86372c21202d07f5932c13
+- 0644       1406 usr/share/zoneinfo/right/Pacific/Norfolk  sha256:8e241cc84941853cc9c95179267bc40fb5e58558430ffc5276353d8ac2e8d1f6
+- 0644        830 usr/share/zoneinfo/right/Pacific/Noumea  sha256:d01a027312b592f682d27087752708e28f0c1ed5653a039d9ab52bb8027a332c
+h 0644          - usr/share/zoneinfo/right/Pacific/Pago_Pago => usr/share/zoneinfo/right/Pacific/Midway
+- 0644        706 usr/share/zoneinfo/right/Pacific/Palau  sha256:fc836dffe58522d24ebb5aa5febcf72f8bbec82867bf4749fc79194555e9f7b6
+- 0644        728 usr/share/zoneinfo/right/Pacific/Pitcairn  sha256:a408a00217a80eeb1b9c7ed80a966cf8595ee302bac5f52aab2349d9ff5c71c0
+h 0644          - usr/share/zoneinfo/right/Pacific/Pohnpei => usr/share/zoneinfo/right/Pacific/Guadalcanal
+h 0644          - usr/share/zoneinfo/right/Pacific/Ponape => usr/share/zoneinfo/right/Pacific/Guadalcanal
+h 0644          - usr/share/zoneinfo/right/Pacific/Port_Moresby => usr/share/zoneinfo/right/Antarctica/DumontDUrville
+- 0644       1129 usr/share/zoneinfo/right/Pacific/Rarotonga  sha256:a88f04061b5ecef71ec2b3a8eeff5d56844d7241389c9f12c474320f3d38a8a4
+h 0644          - usr/share/zoneinfo/right/Pacific/Saipan => usr/share/zoneinfo/right/Pacific/Guam
+h 0644          - usr/share/zoneinfo/right/Pacific/Samoa => usr/share/zoneinfo/right/Pacific/Midway
+- 0644        691 usr/share/zoneinfo/right/Pacific/Tahiti  sha256:87bcc7f7df28bf5ac74d705b599e6948071393bbb9b60bc86bb9f96faaaeafd1
+h 0644          - usr/share/zoneinfo/right/Pacific/Tarawa => usr/share/zoneinfo/right/Pacific/Funafuti
+- 0644        898 usr/share/zoneinfo/right/Pacific/Tongatapu  sha256:7c3c381528eaedabe3301d2890f4183bca3b08e65310609181a0487cbbe8137c
+h 0644          - usr/share/zoneinfo/right/Pacific/Truk => usr/share/zoneinfo/right/Antarctica/DumontDUrville
+h 0644          - usr/share/zoneinfo/right/Pacific/Wake => usr/share/zoneinfo/right/Pacific/Funafuti
+h 0644          - usr/share/zoneinfo/right/Pacific/Wallis => usr/share/zoneinfo/right/Pacific/Funafuti
+h 0644          - usr/share/zoneinfo/right/Pacific/Yap => usr/share/zoneinfo/right/Antarctica/DumontDUrville
+h 0644          - usr/share/zoneinfo/right/Poland => usr/share/zoneinfo/right/Europe/Warsaw
+h 0644          - usr/share/zoneinfo/right/Portugal => usr/share/zoneinfo/right/Europe/Lisbon
+h 0644          - usr/share/zoneinfo/right/ROC => usr/share/zoneinfo/right/Asia/Taipei
+h 0644          - usr/share/zoneinfo/right/ROK => usr/share/zoneinfo/right/Asia/Seoul
+h 0644          - usr/share/zoneinfo/right/Singapore => usr/share/zoneinfo/right/Asia/Kuala_Lumpur
+h 0644          - usr/share/zoneinfo/right/Turkey => usr/share/zoneinfo/right/Asia/Istanbul
+h 0644          - usr/share/zoneinfo/right/UCT => usr/share/zoneinfo/right/Etc/UCT
+d 0755          - usr/share/zoneinfo/right/US/
+h 0644          - usr/share/zoneinfo/right/US/Alaska => usr/share/zoneinfo/right/America/Anchorage
+h 0644          - usr/share/zoneinfo/right/US/Aleutian => usr/share/zoneinfo/right/America/Adak
+h 0644          - usr/share/zoneinfo/right/US/Arizona => usr/share/zoneinfo/right/America/Creston
+h 0644          - usr/share/zoneinfo/right/US/Central => usr/share/zoneinfo/right/America/Chicago
+h 0644          - usr/share/zoneinfo/right/US/East-Indiana => usr/share/zoneinfo/right/America/Fort_Wayne
+h 0644          - usr/share/zoneinfo/right/US/Eastern => usr/share/zoneinfo/right/America/New_York
+h 0644          - usr/share/zoneinfo/right/US/Hawaii => usr/share/zoneinfo/right/HST
+h 0644          - usr/share/zoneinfo/right/US/Indiana-Starke => usr/share/zoneinfo/right/America/Indiana/Knox
+h 0644          - usr/share/zoneinfo/right/US/Michigan => usr/share/zoneinfo/right/America/Detroit
+h 0644          - usr/share/zoneinfo/right/US/Mountain => usr/share/zoneinfo/right/America/Denver
+h 0644          - usr/share/zoneinfo/right/US/Pacific => usr/share/zoneinfo/right/America/Los_Angeles
+h 0644          - usr/share/zoneinfo/right/US/Samoa => usr/share/zoneinfo/right/Pacific/Midway
+h 0644          - usr/share/zoneinfo/right/UTC => usr/share/zoneinfo/right/Etc/UCT
+h 0644          - usr/share/zoneinfo/right/Universal => usr/share/zoneinfo/right/Etc/UCT
+h 0644          - usr/share/zoneinfo/right/W-SU => usr/share/zoneinfo/right/Europe/Moscow
+h 0644          - usr/share/zoneinfo/right/WET => usr/share/zoneinfo/right/Europe/Lisbon
+h 0644          - usr/share/zoneinfo/right/Zulu => usr/share/zoneinfo/right/Etc/UCT
+- 0644      18822 usr/share/zoneinfo/zone.tab  sha256:586b4207e6c76722de82adcda6bf49d761f668517f45a673f64da83b333eecc4
+- 0644      17597 usr/share/zoneinfo/zone1970.tab  sha256:57194e43b001b8f832987b21b82953d997aeeaebeb53a8520140bc12d7d8cfcc

--- a/tools/nativelink/rootfs_manifest.bzl
+++ b/tools/nativelink/rootfs_manifest.bzl
@@ -1,0 +1,54 @@
+"""Rules over the rootfs.manifest golden: a `buck2 run` target that regenerates
+it in the source tree after a re-pin, and a target whose output is the diff
+between it and the freshly built tar (buck2.sh prints that diff when a bootstrap
+digest mismatch means the built rootfs no longer matches the pinned one).
+"""
+
+def _rootfs_manifest_diff_impl(ctx: AnalysisContext) -> list[Provider]:
+    out = ctx.actions.declare_output("rootfs.manifest.diff")
+    ctx.actions.run(
+        cmd_args(
+            ctx.attrs.py[RunInfo],
+            ctx.attrs.script,
+            "diff",
+            ctx.attrs.golden,
+            ctx.attrs.tar[DefaultInfo].default_outputs[0],
+            out.as_output(),
+        ),
+        category = "rootfs_manifest_diff",
+    )
+    return [DefaultInfo(default_output = out)]
+
+rootfs_manifest_diff = rule(
+    impl = _rootfs_manifest_diff_impl,
+    attrs = {
+        "golden": attrs.source(),
+        "py": attrs.exec_dep(providers = [RunInfo]),
+        "script": attrs.source(),
+        "tar": attrs.dep(providers = [DefaultInfo]),
+    },
+)
+
+def _rootfs_manifest_update_impl(ctx: AnalysisContext) -> list[Provider]:
+    # buck2 run's cwd is the project root, so `dest` is a source-relative path
+    # (see lib/rust sqlx copyback for the same idiom).
+    return [
+        DefaultInfo(),
+        RunInfo(args = cmd_args(
+            ctx.attrs.py[RunInfo],
+            ctx.attrs.script,
+            "build",
+            ctx.attrs.tar[DefaultInfo].default_outputs[0],
+            ctx.attrs.dest,
+        )),
+    ]
+
+rootfs_manifest_update = rule(
+    impl = _rootfs_manifest_update_impl,
+    attrs = {
+        "dest": attrs.string(doc = "Source-relative path to write the manifest to."),
+        "py": attrs.exec_dep(providers = [RunInfo]),
+        "script": attrs.source(),
+        "tar": attrs.dep(providers = [DefaultInfo]),
+    },
+)

--- a/tools/nativelink/rootfs_manifest.py
+++ b/tools/nativelink/rootfs_manifest.py
@@ -1,0 +1,109 @@
+"""Canonical, human-readable manifest of the worker-layer tar.
+
+WORKER_LAYER_DIGEST is the sha256 of make_layer.py's normalized tar, so the
+digest is a pure function of that tar's bytes.
+This reads the generated tar back and lists, per member in tar order, the
+header fields those bytes carry — type, mode, size, name, link target — with
+file content reduced to a sha256.
+uid, gid, mtime, uname, and gname are normalized to constants by make_layer.py;
+a member carries one only where it deviates from its constant, surfacing a
+normalization bug.
+
+  rootfs_manifest.py build <tar> <out>          write <tar>'s manifest to <out>
+  rootfs_manifest.py diff <golden> <tar> <out>  write <golden>-vs-<tar> diff to
+      <out> (the telemetry buck2.sh prints when a bootstrap digest mismatch
+      means the built rootfs no longer matches the pinned one)
+  rootfs_manifest.py <tar> <golden> <stamp>     check <tar> matches <golden>; on
+      mismatch print the diff and exit 1, else write <stamp> (cached_check form)
+"""
+
+import difflib
+import hashlib
+import sys
+import tarfile
+
+# make_layer.py zeroes these; the manifest annotates any member that carries
+# a different value.
+_NORMALIZED = {"uid": 0, "gid": 0, "mtime": 0, "uname": "", "gname": ""}
+
+
+def _row(kind, mode, size, name, extra=""):
+    return "{} {:04o} {:>10} {}{}".format(kind, mode, size, name, extra)
+
+
+def _anomalies(m):
+    return "".join(
+        " {}={!r}".format(field, getattr(m, field))
+        for field, want in _NORMALIZED.items()
+        if getattr(m, field) != want
+    )
+
+
+def _manifest(tar_path):
+    lines = []
+    with tarfile.open(tar_path, mode="r:") as tar:
+        for m in tar:
+            if m.issym():
+                line = _row("l", m.mode, "-", m.name, " -> " + m.linkname)
+            elif m.islnk():
+                line = _row("h", m.mode, "-", m.name, " => " + m.linkname)
+            elif m.isdir():
+                line = _row("d", m.mode, "-", m.name + "/")
+            elif m.isreg():
+                digest = hashlib.sha256(tar.extractfile(m).read()).hexdigest()
+                line = _row("-", m.mode, m.size, m.name, "  sha256:" + digest)
+            else:
+                # A device or fifo would need devmajor/devminor to describe in
+                # full; the rootfs has none, so this records the typeflag.
+                line = _row("?", m.mode, "-", m.name, " type=" + m.type.decode())
+            lines.append(line + _anomalies(m))
+    return "".join(line + "\n" for line in lines)
+
+
+def _diff(old_text, new_text, old_name, new_name):
+    return "".join(
+        difflib.unified_diff(
+            old_text.splitlines(keepends=True),
+            new_text.splitlines(keepends=True),
+            fromfile=old_name,
+            tofile=new_name,
+        )
+    )
+
+
+def main(argv):
+    if argv[1] == "build":
+        tar, out = argv[2], argv[3]
+        with open(out, "w", encoding="utf-8") as fh:
+            fh.write(_manifest(tar))
+        return 0
+    if argv[1] == "diff":
+        golden, tar, out = argv[2], argv[3], argv[4]
+        with open(golden, encoding="utf-8") as fh:
+            want = fh.read()
+        with open(out, "w", encoding="utf-8") as fh:
+            fh.write(_diff(want, _manifest(tar), "golden", "built"))
+        return 0
+
+    # cached_check form: <tar> <golden> <stamp>.
+    tar, golden, stamp = argv[1], argv[2], argv[3]
+    built = _manifest(tar)
+    with open(golden, encoding="utf-8") as fh:
+        want = fh.read()
+    if built != want:
+        sys.stderr.write(
+            "rootfs manifest does not match {}; the worker rootfs changed. "
+            "Regenerate it (buck2 run //tools/nativelink:rootfs_manifest_update) "
+            "alongside WORKER_LAYER_DIGEST; the diff below describes the change:\n".format(
+                golden.rsplit("/", 1)[-1]
+            )
+        )
+        sys.stderr.write(_diff(want, built, "golden", "built"))
+        return 1
+    with open(stamp, "w", encoding="utf-8") as fh:
+        fh.write("ok")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/tools/nativelink/rootfs_manifest_unit_test.py
+++ b/tools/nativelink/rootfs_manifest_unit_test.py
@@ -1,0 +1,124 @@
+"""Unit checks for rootfs_manifest.py's tar-to-manifest projection.
+
+Fabricated tars exercise each member kind, hardlink dedup, the anomaly
+path, and the diff/check modes at the python interface, so a change that
+alters the projection or the mode dispatch fails here.
+
+argv[1] is rootfs_manifest.py, argv[2] the output to touch on success.
+"""
+
+import hashlib
+import importlib.util
+import io
+import os
+import sys
+import tarfile
+import tempfile
+
+mod_path, out = sys.argv[1], sys.argv[2]
+
+spec = importlib.util.spec_from_file_location("rootfs_manifest", mod_path)
+rm = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(rm)
+
+BODY = b"hello\n"
+DIGEST = hashlib.sha256(BODY).hexdigest()
+
+
+def _member(name, type_, mode, linkname="", **attrs):
+    ti = tarfile.TarInfo(name)
+    ti.type = type_
+    ti.mode = mode
+    ti.linkname = linkname
+    for key, value in attrs.items():
+        setattr(ti, key, value)
+    return ti
+
+
+def write_tar(path, members):
+    with tarfile.open(path, mode="w", format=tarfile.GNU_FORMAT) as tar:
+        for ti, data in members:
+            if data is None:
+                tar.addfile(ti)
+            else:
+                ti.size = len(data)
+                tar.addfile(ti, io.BytesIO(data))
+
+
+def manifest_of(members):
+    with tempfile.TemporaryDirectory() as td:
+        path = os.path.join(td, "t.tar")
+        write_tar(path, members)
+        return rm._manifest(path)
+
+
+# Every member kind, in tar order, with hardlink dedup: z/Accra shares
+# z/Abidjan's inode, so tarfile emits it as a link with no content.
+lines = manifest_of(
+    [
+        (_member("bin", tarfile.DIRTYPE, 0o755), None),
+        (_member("bin/sh", tarfile.SYMTYPE, 0o755, linkname="busybox"), None),
+        (_member("bin/tool", tarfile.REGTYPE, 0o755), BODY),
+        (_member("etc/hosts", tarfile.REGTYPE, 0o644), BODY),
+        (_member("z/Abidjan", tarfile.REGTYPE, 0o644), BODY),
+        (_member("z/Accra", tarfile.LNKTYPE, 0o644, linkname="z/Abidjan"), None),
+    ]
+).splitlines()
+assert lines == [
+    rm._row("d", 0o755, "-", "bin/"),
+    rm._row("l", 0o755, "-", "bin/sh", " -> busybox"),
+    rm._row("-", 0o755, len(BODY), "bin/tool", "  sha256:" + DIGEST),
+    rm._row("-", 0o644, len(BODY), "etc/hosts", "  sha256:" + DIGEST),
+    rm._row("-", 0o644, len(BODY), "z/Abidjan", "  sha256:" + DIGEST),
+    rm._row("h", 0o644, "-", "z/Accra", " => z/Abidjan"),
+], lines
+
+# A device node has no content; the fallback records its typeflag.
+special = manifest_of([(_member("dev/null", tarfile.CHRTYPE, 0o644), None)])
+assert special == rm._row("?", 0o644, "-", "dev/null", " type=3") + "\n", special
+
+# Anomalies: a fully normalized member carries nothing; a member with a
+# non-constant field carries just that field, in _NORMALIZED order.
+assert rm._anomalies(tarfile.TarInfo("x")) == ""
+assert rm._anomalies(_member("x", tarfile.REGTYPE, 0o644, uid=1000, mtime=5)) == " uid=1000 mtime=5"
+anomalous = manifest_of([(_member("f", tarfile.REGTYPE, 0o644, uid=1000, gname="dev"), BODY)])
+assert anomalous.rstrip("\n").endswith(" uid=1000 gname='dev'"), anomalous
+
+with tempfile.TemporaryDirectory() as td:
+    tar = os.path.join(td, "t.tar")
+    write_tar(tar, [(_member("f", tarfile.REGTYPE, 0o644), BODY)])
+    golden = os.path.join(td, "golden")
+    stamp = os.path.join(td, "stamp")
+
+    # build writes the manifest; that manifest is the matching golden.
+    assert rm.main(["prog", "build", tar, golden]) == 0
+    with open(golden, encoding="utf-8") as fh:
+        assert fh.read() == rm._manifest(tar)
+
+    # check: matching golden writes the stamp and returns 0.
+    assert rm.main(["prog", tar, golden, stamp]) == 0
+    with open(stamp, encoding="utf-8") as fh:
+        assert fh.read() == "ok"
+
+    # check: a golden the tar no longer matches returns 1 and does not stamp.
+    stale = os.path.join(td, "stale")
+    other = os.path.join(td, "u.tar")
+    write_tar(other, [(_member("f", tarfile.REGTYPE, 0o755), BODY)])
+    rm.main(["prog", "build", other, stale])
+    missing = os.path.join(td, "missing_stamp")
+    assert rm.main(["prog", tar, stale, missing]) == 1
+    assert not os.path.exists(missing)
+
+    # diff: golden vs a changed tar names the changed member; identical is empty.
+    changed = os.path.join(td, "changed.diff")
+    assert rm.main(["prog", "diff", stale, tar, changed]) == 0
+    with open(changed, encoding="utf-8") as fh:
+        diff_text = fh.read()
+    assert "-- 0755" in diff_text and "+- 0644" in diff_text, diff_text
+    same = os.path.join(td, "same.diff")
+    rm.main(["prog", "diff", golden, tar, same])
+    with open(same, encoding="utf-8") as fh:
+        assert fh.read() == "", "identical tar must diff empty"
+
+with open(out, "w", encoding="utf-8") as fh:
+    fh.write("ok")


### PR DESCRIPTION
WORKER_LAYER_DIGEST is the sha256 of make_layer.py's normalized tar of the rootfs, so a mismatch — a re-pin, or a non-hermetic rootfs across build machines — surfaces as two opaque hashes.

rootfs_manifest.py reads the generated tar and lists, per member in tar order, the header fields its bytes carry — type, mode, size, name, link target, content sha256 — plus uid/gid/mtime/uname/gname where one deviates from make_layer.py's normalized constant.
The committed rootfs.manifest golden is that listing for the pinned tar.

Two places surface it:

- buck2.sh, when its bootstrap digest check fails, describes the rootfs change: the validated //tools/nativelink:layer build fails on the mismatch, and //tools/nativelink:rootfs_manifest_diff builds the same tar through the unvalidated :layer[layer] to diff it against the golden.
- the buck2 CI job, on a pin bump, diffs the built tar's manifest against the base golden and prints it, so review sees the member-level change without depending on the author regenerating the golden.

rootfs_manifest_test keeps the golden in step with the rootfs; buck2 run //tools/nativelink:rootfs_manifest_update regenerates it.
rootfs_manifest_unit_test drives each member kind, hardlink dedup, the anomaly path, and the build/diff/check modes over fabricated tars.
