### PR TITLE
shell: enforce strict error handling repo-wide

### DIFF
--- a/.github/workflows/auto-queue.yml
+++ b/.github/workflows/auto-queue.yml
@@ -2,6 +2,10 @@ name: auto-queue
 on:
   pull_request_target:
     types: [labeled, edited]
+# GitHub's default step shell (`bash -e {0}`) omits pipefail; force our own.
+defaults:
+  run:
+    shell: bash --noprofile --norc -euo pipefail {0}
 jobs:
   auto-queue:
     runs-on: ubuntu-latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -99,8 +99,14 @@ jobs:
           pin_changed=false
           base="${{ steps.base_head.outputs.base }}"
           head="${{ steps.base_head.outputs.head }}"
-          if [ -n "$base" ] && ! git diff --quiet "$base" "$head" -- tools/nativelink/pin.bzl; then
-            pin_changed=true
+          if [ -n "$base" ]; then
+            rc=0
+            git diff --quiet "$base" "$head" -- tools/nativelink/pin.bzl || rc=$?
+            case "$rc" in
+              0) ;;
+              1) pin_changed=true ;;
+              *) echo "git diff --quiet errored ($rc)" >&2; exit 1 ;;
+            esac
           fi
           echo "pin_changed=$pin_changed" >> "$GITHUB_OUTPUT"
       - name: Install buck2
@@ -171,8 +177,14 @@ jobs:
           changed=false
           base="${{ steps.base_head.outputs.base }}"
           head="${{ steps.base_head.outputs.head }}"
-          if [ -n "$base" ] && ! git diff --quiet "$base" "$head" -- renovate.json; then
-            changed=true
+          if [ -n "$base" ]; then
+            rc=0
+            git diff --quiet "$base" "$head" -- renovate.json || rc=$?
+            case "$rc" in
+              0) ;;
+              1) changed=true ;;
+              *) echo "git diff --quiet errored ($rc)" >&2; exit 1 ;;
+            esac
           fi
           echo "changed=$changed" >> "$GITHUB_OUTPUT"
       # See tools/renovate/README.md, "functional_check (buck2)".
@@ -228,18 +240,35 @@ jobs:
       # CI is isolating actions; it makes no claim about dev environments.
       - name: Verify undeclared inputs are invisible
         run: |
-          if buck2 build probes//:undeclared_read; then
+          rc=0
+          out="$(buck2 build probes//:undeclared_read 2>&1)" || rc=$?
+          if [ "$rc" -eq 0 ]; then
             echo "undeclared read unexpectedly succeeded" >&2
             exit 1
           fi
+          # Must fail because staging blocked the read; assert the probe's error.
+          grep -qF "can't open 'README.md'" <<<"$out" || {
+            echo "build failed ($rc), but not on the undeclared read:" >&2
+            printf '%s\n' "$out" >&2
+            exit 1
+          }
       - name: Show NativeLink log on failure
         if: failure()
         run: cat ~/.cache/causes-nativelink/nativelink.log || true
       - name: Shut down buck2 daemon
         if: always()
         run: |
-          buck2 kill || true
-          pkill -x nativelink || true
+          # Signal, then confirm each is actually gone. buck2-bin is the raw
+          # binary (the launcher would re-bootstrap on `kill`).
+          buck2-bin kill || true
+          [ "$(buck2-bin status 2>&1)" = 'no buckd running' ] \
+            || { echo "buckd still running after kill" >&2; exit 1; }
+          pkill -x nativelink || [ "$?" -eq 1 ]
+          for _ in $(seq 50); do pgrep -x nativelink >/dev/null || break; sleep 0.1; done
+          if pgrep -x nativelink >/dev/null; then
+            echo "nativelink still running after kill" >&2
+            exit 1
+          fi
   # Metrics collection runs as a separate job depending on `build` and
   # `buck2` so that their step logs are finalized by the time `record`
   # reads them. Inside a job, the GH logs endpoint 404s on the

--- a/.github/workflows/ci-health-trend.yml
+++ b/.github/workflows/ci-health-trend.yml
@@ -11,6 +11,10 @@ permissions:
   contents: read
   issues: write
   actions: read
+# GitHub's default step shell (`bash -e {0}`) omits pipefail; force our own.
+defaults:
+  run:
+    shell: bash --noprofile --norc -euo pipefail {0}
 jobs:
   trend:
     runs-on: ubuntu-latest

--- a/.github/workflows/renovate-lockfile.yml
+++ b/.github/workflows/renovate-lockfile.yml
@@ -30,6 +30,10 @@ permissions:
 concurrency:
   group: renovate-fix-${{ github.ref }}
   cancel-in-progress: false
+# GitHub's default step shell (`bash -e {0}`) omits pipefail; force our own.
+defaults:
+  run:
+    shell: bash --noprofile --norc -euo pipefail {0}
 jobs:
   update-lockfile:
     runs-on: ubuntu-latest
@@ -79,6 +83,12 @@ jobs:
             requirements_lock.txt \
             infra/terraform/.terraform.lock.hcl \
             infra/github/.terraform.lock.hcl
-          git diff --cached --quiet && exit 0
+          rc=0
+          git diff --cached --quiet || rc=$?
+          case "$rc" in
+            0) exit 0 ;;
+            1) ;;
+            *) echo "git diff --cached --quiet errored ($rc)" >&2; exit 1 ;;
+          esac
           git commit -m "chore: update generated lockfiles"
           git push

--- a/.github/workflows/renovate-sha.yml
+++ b/.github/workflows/renovate-sha.yml
@@ -27,6 +27,10 @@ permissions:
 concurrency:
   group: renovate-fix-${{ github.ref }}
   cancel-in-progress: false
+# GitHub's default step shell (`bash -e {0}`) omits pipefail; force our own.
+defaults:
+  run:
+    shell: bash --noprofile --norc -euo pipefail {0}
 jobs:
   fix-sha:
     runs-on: ubuntu-latest
@@ -50,14 +54,30 @@ jobs:
       - name: Recompute archive sha256 pins
         run: |
           git fetch -q --depth=1 origin master
-          git diff --name-only FETCH_HEAD -- ':(glob)**/BUCK' MODULE.bazel | while read -r pinfile; do
+          # Capture separately so a git failure aborts (a pipe to while would exit 0).
+          changed="$(git diff --name-only FETCH_HEAD -- ':(glob)**/BUCK' MODULE.bazel)"
+          while IFS= read -r pinfile; do
+            [ -n "$pinfile" ] || continue
             base="$(mktemp)"
-            git show "FETCH_HEAD:$pinfile" >"$base" 2>/dev/null || : >"$base"
+            # A pinfile new since master is absent at FETCH_HEAD; an empty base
+            # then means "all pins new". Test existence structurally so any
+            # other git failure still aborts.
+            if git cat-file -e "FETCH_HEAD:$pinfile" 2>/dev/null; then
+              git show "FETCH_HEAD:$pinfile" >"$base"
+            else
+              : >"$base"
+            fi
             bash tools/renovate/update_archive_sha.sh "$pinfile" "$base"
-          done
+          done <<<"$changed"
       - name: Push fix if the pins changed
         run: |
-          git diff --quiet && exit 0
+          rc=0
+          git diff --quiet || rc=$?
+          case "$rc" in
+            0) exit 0 ;;
+            1) ;;
+            *) echo "git diff --quiet errored ($rc)" >&2; exit 1 ;;
+          esac
           git config user.name "github-actions[bot]"
           git config user.email \
             "41898282+github-actions[bot]@users.noreply.github.com"

--- a/docs/BUILD.bazel
+++ b/docs/BUILD.bazel
@@ -33,6 +33,7 @@ genrule(
     ],
     outs = ["site.tar.gz"],
     cmd = """
+        set -euo pipefail
         EXECROOT=$$(pwd)
         OUTDIR=$$EXECROOT/$(@D)
         # Zensical requires the config to sit at the project root with relative paths.
@@ -50,7 +51,7 @@ genrule(
         # Zensical locates its theme assets via __file__ at runtime, but the Bazel
         # runfiles layout differs from a regular pip install, so it silently skips
         # the copy. Copy them manually from the tool's runfiles.
-        ZENSICAL_ASSETS=$$(find $$EXECROOT/$(location :zensical).runfiles -path "*/zensical/templates/assets" -type d | head -1)
+        ZENSICAL_ASSETS=$$(find $$EXECROOT/$(location :zensical).runfiles -path "*/zensical/templates/assets" -type d -print -quit)
         cp -rL "$$ZENSICAL_ASSETS" $$OUTDIR/site/assets
         tar czf $$EXECROOT/$@ -C $$OUTDIR site
     """,

--- a/docs/site_builder.bash
+++ b/docs/site_builder.bash
@@ -45,7 +45,7 @@ build_docs_site() {
 	# bazel run (where RUNFILES_DIR may be absent).
 	local runfiles_root assets
 	runfiles_root="$(dirname "$(dirname "$(dirname "$ZENSICAL")")")"
-	assets=$(find "$runfiles_root" -path "*/zensical/templates/assets" -type d 2>/dev/null | head -1)
+	assets=$(find "$runfiles_root" -path "*/zensical/templates/assets" -type d -print -quit 2>/dev/null)
 	if [[ -z "$assets" ]]; then
 		echo >&2 "ERROR: zensical theme assets not found under runfiles root: $runfiles_root"
 		return 1

--- a/infra/deploy.sh
+++ b/infra/deploy.sh
@@ -25,6 +25,11 @@ bazel --quiet run //infra:tofu -- infra/terraform apply -replace=aws_instance.ca
 
 IP=$(bazel --quiet run //infra:tofu -- infra/terraform output -raw ec2_public_ip)
 ssh-keygen -R "$IP" 2>/dev/null || true
+# Confirm the stale host key is actually gone before we connect.
+if ssh-keygen -F "$IP" >/dev/null 2>&1; then
+	echo "error: stale host key for $IP survived removal" >&2
+	exit 1
+fi
 
 echo "==> Deployed. Instance at ${IP}"
 echo "    Wait ~30s for the container to start and obtain a TLS certificate."

--- a/infra/postgres/testfixture.sh
+++ b/infra/postgres/testfixture.sh
@@ -41,6 +41,10 @@ pg_start() {
 
 pg_stop() {
 	if [[ -n "${PGBIN:-}" && -n "${PGDATA:-}" ]]; then
-		"$PGBIN/pg_ctl" stop -D "$PGDATA" -m immediate -q 2>/dev/null || true
+		# pg_ctl stop waits for shutdown, so a clean exit means it is down.
+		# Guard on status so a repeated trap is a no-op.
+		if "$PGBIN/pg_ctl" status -D "$PGDATA" >/dev/null 2>&1; then
+			"$PGBIN/pg_ctl" stop -D "$PGDATA" -m immediate -s
+		fi
 	fi
 }

--- a/proto/BUILD.bazel
+++ b/proto/BUILD.bazel
@@ -53,8 +53,9 @@ genrule(
     ],
     outs = ["proto_docs.md"],
     cmd = """
+        set -euo pipefail
         EXECROOT=$$(pwd)
-        WKT_DIR=$$(dirname $$(echo '$(locations @protobuf//:well_known_type_protos)' | tr ' ' '\\n' | head -1))
+        WKT_DIR=$$(dirname $$(echo '$(locations @protobuf//:well_known_type_protos)' | tr ' ' '\\n' | sed -n 1p))
         WKT_ROOT=$$(echo "$$WKT_DIR" | sed 's|/google/protobuf$$||')
         PROTO_FILES=$$(echo '$(locations :proto_srcs)' | tr ' ' '\\n' | sed "s|^|$$EXECROOT/|" | tr '\\n' ' ')
         $(location @protobuf//:protoc) \

--- a/tools/buck2/buck2.sh
+++ b/tools/buck2/buck2.sh
@@ -18,11 +18,24 @@ done
 
 # A live daemon means this repo is already bootstrapped for this session.
 no_daemon() {
-	buck2-bin status 2>&1 | grep -qx 'no buckd running'
+	# Match on the output, not the pipe exit (pipefail would let a failed
+	# status mask the grep).
+	local out
+	out="$(buck2-bin status 2>&1)" || true
+	grep -qx 'no buckd running' <<<"$out"
 }
 
 if [[ -e "$root/.buckroot" ]] && no_daemon; then
-	pkill -x nativelink 2>/dev/null || true
+	# Clear any stale worker, then confirm it is gone before starting a new one.
+	pkill -x nativelink 2>/dev/null || [ "$?" -eq 1 ]
+	for _ in $(seq 50); do
+		pgrep -x nativelink >/dev/null || break
+		sleep 0.1
+	done
+	if pgrep -x nativelink >/dev/null; then
+		echo "error: stale nativelink survived kill" >&2
+		exit 1
+	fi
 
 	if [[ -f "$root/.buckconfig.local" ]]; then
 		printf '[buck2_re_client]\n%s\n%s\n%s\n%s\n' \
@@ -43,6 +56,10 @@ if [[ -e "$root/.buckroot" ]] && no_daemon; then
 	# bootstrap config (RE config only binds at daemon startup); kill it
 	# so the next command starts fresh under the committed config.
 	buck2-bin kill >/dev/null 2>&1 || true
+	no_daemon || {
+		echo "error: buck2 daemon alive after kill" >&2
+		exit 1
+	}
 	if [[ "$bootstrap_rc" -ne 0 ]]; then
 		# The validated :layer build fails when the built tar's digest does
 		# not match the pin; :layer[layer] is that tar without the check, so
@@ -98,6 +115,10 @@ if [[ -e "$root/.buckroot" ]] && no_daemon; then
 	container="causes-nativelink-$digest"
 	export XDG_RUNTIME_DIR="$nl_cache/xdg"
 	crun delete -f "$container" >/dev/null 2>&1 || true
+	if crun state "$container" >/dev/null 2>&1; then
+		echo "error: container $container survived delete" >&2
+		exit 1
+	fi
 	(
 		flock -n 9 || exit 0
 		crun run --bundle "$bundle" --detach --no-new-keyring "$container" \
@@ -108,8 +129,9 @@ if [[ -e "$root/.buckroot" ]] && no_daemon; then
 		sleep 0.1
 	done
 	if ! (exec 3<>/dev/tcp/127.0.0.1/50051) 2>/dev/null; then
-		echo "warning: NativeLink did not become ready on 127.0.0.1:50051;" \
+		echo "error: NativeLink did not become ready on 127.0.0.1:50051;" \
 			"see ~/.cache/causes-nativelink/nativelink.log" >&2
+		exit 1
 	fi
 fi
 

--- a/tools/check.sh
+++ b/tools/check.sh
@@ -133,7 +133,7 @@ compute_cache_key() {
 	target="@"
 	while [[ -z "$(jj diff -r "$target" --summary 2>/dev/null)" ]]; do
 		parent_ids="$(jj log -r "$target-" --no-graph -T 'commit_id ++ "\n"' 2>/dev/null)"
-		parent_count=$(printf '%s' "$parent_ids" | grep -c . || true)
+		parent_count="$(printf '%s\n' "$parent_ids" | awk 'NF{n++} END{print n+0}')"
 		if [[ "$parent_count" -ne 1 ]]; then
 			# Walked up empty diffs and hit either a merge (2+ parents) or
 			# the root (0 parents). Two cases:
@@ -281,8 +281,12 @@ run_agent_scan() {
 	# Comma-separated set of extensions present in master, used by the
 	# new-language detector. Computed once per agent run; cheap (a single
 	# jj invocation listing tracked paths).
-	local master_exts
-	master_exts="$(jj file list --ignore-working-copy -r master 2>/dev/null |
+	local master_exts master_files
+	if ! master_files="$(jj file list --ignore-working-copy -r master)"; then
+		echo "agent mode requires jj (could not list master files)" >&2
+		exit 1
+	fi
+	master_exts="$(printf '%s\n' "$master_files" |
 		awk -F/ '{print $NF}' |
 		awk -F. 'NF > 1 { print $NF }' |
 		sort -u | tr '\n' ',')"
@@ -294,15 +298,31 @@ run_agent_scan() {
 
 check_rules_rs_macros() {
 	local files
-	files="$(jj file list --ignore-working-copy 'glob:**/BUILD.bazel' 2>/dev/null)"
+	# List tracked BUILD.bazel files: jj locally, git in CI (no jj there).
+	if command -v jj >/dev/null; then
+		files="$(jj file list --ignore-working-copy 'glob:**/BUILD.bazel')"
+	else
+		files="$(git ls-files ':(glob)**/BUILD.bazel')"
+	fi
 	if [[ -z "$files" ]]; then
 		return 0
 	fi
-	if echo "$files" | xargs grep -n \
-		'load("@rules_rs//rs:rust_\(binary\|library\|test\)\.bzl"' 2>/dev/null; then
+	local -a filelist
+	mapfile -t filelist <<<"$files"
+	local rc=0
+	grep -n 'load("@rules_rs//rs:rust_\(binary\|library\|test\)\.bzl"' \
+		-- "${filelist[@]}" || rc=$?
+	case "$rc" in
+	0)
 		echo "ERROR: Use //build:rust.bzl macros instead of @rules_rs directly." >&2
 		return 1
-	fi
+		;;
+	1) ;;
+	*)
+		echo "check_rules_rs_macros: grep errored ($rc)" >&2
+		exit 1
+		;;
+	esac
 }
 
 check_package_readmes() {

--- a/tools/defs.bzl
+++ b/tools/defs.bzl
@@ -70,14 +70,15 @@ def _cached_http_archive_impl(ctx: AnalysisContext) -> list[Provider]:
     out = ctx.actions.declare_output("out", dir = True)
     if ctx.attrs.zstd:
         # tar has no zstd support on the platforms this runs on; decompress
-        # through the pinned zstd tool first and hand tar a plain stream.
-        extract = '"$zstd" -dc "$archive" | tar -x -f - -C "{dest}"'
+        # through the pinned zstd tool first, to a temp file (its own
+        # statement) so set -e catches a zstd failure.
+        extract = '"$zstd" -dc "$archive" >"$zstd_tmp"; tar -x -f "$zstd_tmp" -C "{dest}"'
         tool_args = [ctx.attrs.zstd[RunInfo]]
-        arg_prefix = 'zstd="$1"; archive="$2"; out="$3"; shift 3'
+        arg_prefix = 'set -eu; zstd="$1"; archive="$2"; out="$3"; shift 3; zstd_tmp="$(mktemp)"'
     else:
         extract = 'tar -x -f "$archive" -C "{dest}"'
         tool_args = []
-        arg_prefix = 'archive="$1"; out="$2"; shift 2'
+        arg_prefix = 'set -eu; archive="$1"; out="$2"; shift 2'
 
     if ctx.attrs.paths:
         # tar's own path-selection argument is broken for directory
@@ -87,12 +88,12 @@ def _cached_http_archive_impl(ctx: AnalysisContext) -> list[Provider]:
         # `strip_components`-deep) subtrees' entries out by hand instead.
         # paths must be disjoint (no path nested under another), since
         # entries from each land directly in the shared "$out".
-        script = arg_prefix + '; tmp="$(mktemp -d)"; mkdir -p "$out" && ' + \
-                 extract.format(dest = "$tmp") + " && " + \
-                 'for p in "$@"; do for e in "$tmp/$p"/* "$tmp/$p"/.[!.]* "$tmp/$p"/..?*; do ' + \
-                 '[ -e "$e" ] && mv "$e" "$out/"; done; done; true'
+        script = arg_prefix + '; tmp="$(mktemp -d)"; mkdir -p "$out"; ' + \
+                 extract.format(dest = "$tmp") + \
+                 '; for p in "$@"; do for e in "$tmp/$p"/* "$tmp/$p"/.[!.]* "$tmp/$p"/..?*; do ' + \
+                 'if [ -e "$e" ]; then mv "$e" "$out/"; fi; done; done'
     else:
-        script = arg_prefix + '; mkdir -p "$out" && ' + \
+        script = arg_prefix + '; mkdir -p "$out"; ' + \
                  extract.format(dest = "$out") + \
                  ' --strip-components={} "$@"'.format(ctx.attrs.strip_components)
 

--- a/tools/nativelink/rootfs.bzl
+++ b/tools/nativelink/rootfs.bzl
@@ -12,7 +12,10 @@ zoneinfo="$3"
 mkdir -p "$root/bin" "$root/usr/bin" "$root/usr/share" "$root/tmp" "$root/proc" "$root/dev" "$root/etc"
 cp "$bb" "$root/bin/busybox"
 chmod 0755 "$root/bin/busybox"
-"$bb" --list | while read -r applet; do
+# Capture separately so set -e catches a --list failure (a pipe to while
+# would not).
+applets="$("$bb" --list)"
+for applet in $applets; do
   [ "$applet" = busybox ] && continue
   # env also at /usr/bin, where #!/usr/bin/env shebangs look.
   [ "$applet" = env ] && ln -s /bin/busybox "$root/usr/bin/env"

--- a/tools/renovate/functional_check.sh
+++ b/tools/renovate/functional_check.sh
@@ -152,9 +152,9 @@ jq \
 mv "$config.new" "$config"
 
 log="$work/renovate.log"
+rc=0
 XDG_RUNTIME_DIR="$xdg" crun run --no-new-keyring -b "$bundle" \
-	"renovate-functional-check-$$" >"$log" 2>&1
-rc=$?
+	"renovate-functional-check-$$" >"$log" 2>&1 || rc=$?
 
 fail=0
 if [[ "$rc" -ne 0 ]]; then

--- a/tools/require_bazel_quiet_test.sh
+++ b/tools/require_bazel_quiet_test.sh
@@ -9,7 +9,19 @@ set -uo pipefail
 violations_file="$(mktemp)"
 trap 'rm -f "$violations_file"' EXIT
 
+# List tracked files: jj locally, git in CI (no jj there). Abort on a
+# listing failure so a broken enumeration can't pass by scanning nothing.
+if command -v jj >/dev/null; then
+	files="$(jj file list --ignore-working-copy 'glob:**/*.sh' 'glob:**/*.md')"
+else
+	files="$(git ls-files ':(glob)**/*.sh' ':(glob)**/*.md')"
+fi || {
+	echo "FAIL: could not list tracked files" >&2
+	exit 1
+}
+
 while IFS= read -r file; do
+	[[ -n "$file" ]] || continue
 	awk -v file="$file" '
 		file ~ /\.sh$/ && /^[[:space:]]*#/ { next }
 		/\$\([^)]*bazel/ {
@@ -19,8 +31,7 @@ while IFS= read -r file; do
 			print "    " $0
 		}
 	' "$file"
-done < <(jj file list --ignore-working-copy 'glob:**/*.sh' 'glob:**/*.md' 2>/dev/null |
-	sort) >"$violations_file"
+done <<<"$(printf '%s\n' "$files" | sort)" >"$violations_file"
 
 if [[ -s "$violations_file" ]]; then
 	echo "FAIL: bazel run/build commands missing --quiet:" >&2

--- a/tools/require_readme_test.sh
+++ b/tools/require_readme_test.sh
@@ -6,7 +6,15 @@
 set -euo pipefail
 
 missing=()
+# List tracked BUILD files: jj locally, git in CI (no jj there). Either
+# failing aborts (set -e) rather than scanning nothing.
+if command -v jj >/dev/null; then
+	build_files="$(jj file list --ignore-working-copy 'glob:**/BUILD.bazel' 'glob:**/BUILD')"
+else
+	build_files="$(git ls-files ':(glob)**/BUILD.bazel' ':(glob)**/BUILD')"
+fi
 while IFS= read -r build_file; do
+	[[ -n "$build_file" ]] || continue
 	pkg_dir="$(dirname "$build_file")"
 	# Root package — always has README.
 	if [[ "$pkg_dir" == "." ]]; then
@@ -15,9 +23,7 @@ while IFS= read -r build_file; do
 	if [[ ! -f "$pkg_dir/README.md" ]]; then
 		missing+=("$pkg_dir")
 	fi
-done < <(jj file list --ignore-working-copy 'glob:**/BUILD.bazel' 'glob:**/BUILD' 2>/dev/null |
-	sed 's|^|./|' |
-	sort)
+done <<<"$(printf '%s\n' "$build_files" | sed 's|^|./|' | sort)"
 
 if ((${#missing[@]} > 0)); then
 	echo "FAIL: the following Bazel packages are missing a README.md:" >&2

--- a/workspace_status.sh
+++ b/workspace_status.sh
@@ -1,3 +1,6 @@
 #!/usr/bin/env bash
-echo "COMMIT_SHA $(git rev-parse HEAD)"
+set -euo pipefail
+# Capture before echo so a git failure aborts (echo would exit 0).
+sha="$(git rev-parse HEAD)"
+echo "COMMIT_SHA $sha"
 echo "REPO_URL https://github.com/causes-tracker/causes-tracker.git"


### PR DESCRIPTION
The file-listing gates fall back to git because the CI build job has no jj.
