### PR TITLE
ci: fix buck2 log parse and harden ci-metrics

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -243,10 +243,10 @@ jobs:
   # Metrics collection runs as a separate job depending on `build` and
   # `buck2` so that their step logs are finalized by the time `record`
   # reads them. Inside a job, the GH logs endpoint 404s on the
-  # presigned Azure blob until the job ends. The whole job is best-effort
-  # (`if: always()` + `continue-on-error` per step) so a metrics failure
-  # never turns a green build red, and metrics still get collected when
-  # the build itself failed.
+  # presigned Azure blob until the job ends. `if: always()` runs this even
+  # when the build failed, so metrics are still collected then — but the
+  # metrics steps are not best-effort: a failure to record, upload, or
+  # comment is a real failure and reddens this job.
   ci-metrics:
     runs-on: ubuntu-latest
     needs: [build, buck2]
@@ -261,6 +261,8 @@ jobs:
           bazelisk-cache: true
           disk-cache: ${{ github.workflow }}-ci-metrics
           repository-cache: true
+      # Absent when the build failed before producing it; Record runs without
+      # it, so tolerate only this missing-artifact case.
       - name: Download per-gate timings
         continue-on-error: true
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
@@ -274,20 +276,20 @@ jobs:
       # `--check-timings` is the JSONL produced by `tools/check.sh` under
       # `CHECK_TIMING_JSONL` in the `build` job, downloaded above.
       - name: Record CI metrics
-        continue-on-error: true
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           BUILDBUDDY_API_KEY: ${{ secrets.BUILDBUDDY_ORG_API_KEY }}
         run: |
-          bazel run $BB_FLAGS //tools/ci_health -- record \
-            --run-id ${{ github.run_id }} \
-            --job build \
-            --out "${{ github.workspace }}/ci-metrics.json" \
-            --check-timings "${{ github.workspace }}/check-timings.jsonl" \
-            --buck2-job buck2 \
+          args=(record
+            --run-id ${{ github.run_id }}
+            --job build
+            --out "${{ github.workspace }}/ci-metrics.json"
+            --buck2-job buck2)
+          timings="${{ github.workspace }}/check-timings.jsonl"
+          [ -f "$timings" ] && args+=(--check-timings "$timings")
+          bazel run $BB_FLAGS //tools/ci_health -- "${args[@]}" \
             ${{ github.event.pull_request.number && format('--pr {0}', github.event.pull_request.number) || '' }}
       - name: Upload CI metrics artifact
-        continue-on-error: true
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
           name: ci-metrics-${{ github.run_id }}
@@ -296,10 +298,9 @@ jobs:
           if-no-files-found: ignore
       # Posts a marked comment on the PR only if this run is materially
       # slower or has worse cache behavior than the rolling baseline.
-      # Silent on healthy runs. Best-effort: never fails the build.
+      # Silent on healthy runs; a failure to post reddens this job.
       - name: Comment on PR if regressed
         if: always() && github.event_name == 'pull_request' && hashFiles('ci-metrics.json') != ''
-        continue-on-error: true
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |

--- a/tools/ci_health/src/buck2.rs
+++ b/tools/ci_health/src/buck2.rs
@@ -121,15 +121,19 @@ fn parse_commands(rest: &str) -> Result<Commands> {
     })
 }
 
-/// Parse `Up: 270KiB  Down: 90MiB  (GRPC-SESSION-ID)`.
+/// Parse buck2's `Network:` remainder, accepting both the
+/// `Up: 270KiB  Down: 90MiB  (SESSION)` and `up 5.1KiB  down 4.2MiB  session
+/// SESSION` shapes.
 fn parse_network(rest: &str) -> Result<Network> {
-    let side = |key: &str| -> Result<u64> {
-        let val = after(rest, key).with_context(|| format!("missing {key}"))?;
+    let side = |upper: &str, lower: &str| -> Result<u64> {
+        let val = after(rest, upper)
+            .or_else(|| after(rest, lower))
+            .with_context(|| format!("missing {lower}"))?;
         parse_size(token(val))
     };
     Ok(Network {
-        up: side("Up: ")?,
-        down: side("Down: ")?,
+        up: side("Up: ", "up ")?,
+        down: side("Down: ", "down ")?,
     })
 }
 
@@ -221,6 +225,25 @@ BUILD SUCCEEDED
         assert_eq!(got[0].bytes_uploaded, 0);
         assert_eq!(got[0].bytes_downloaded, 0);
         assert_eq!(got[0].commands_cached, 0);
+    }
+
+    /// The newer buck2 `Network:` line shape: lowercase `up`/`down` with a
+    /// `session` label.
+    #[test]
+    fn parses_newer_network_line_shape() {
+        let log = "\
+[2026-08-08T11:58:50.676+00:00] Build ID: aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee
+[2026-08-08T11:58:50.676+00:00] Commands: 7 (cached: 4, remote: 0, local: 3)
+[2026-08-08T11:58:50.676+00:00] Network: up 5.1KiB  down 4.2MiB  session GRPC-SESSION-ID
+BUILD SUCCEEDED
+";
+        let got = extract_invocations(log).unwrap();
+        assert_eq!(got.len(), 1);
+        assert_eq!(got[0].bytes_uploaded, (5.1_f64 * 1024.0).round() as u64);
+        assert_eq!(
+            got[0].bytes_downloaded,
+            (4.2_f64 * 1024.0 * 1024.0).round() as u64
+        );
     }
 
     /// `buck2 clean` / `buck2 kill` print a `Build ID:` but run no


### PR DESCRIPTION
buck2 changed its end-of-build `Network:` line from `Up: 270KiB  Down: 90MiB  (SESSION)` to `up 5.1KiB  down 4.2MiB  session SESSION`, which ci_health's parser rejected — failing the `record` step.
parse_network now accepts both shapes; a test covers the new one.

With that fixed, the ci-metrics steps drop `continue-on-error`: the job still runs on `if: always()` so metrics are collected even when the build failed, but a failure to record, upload, or comment now reddens the job instead of being swallowed.
Record passes `--check-timings` only when the file is present, so a build that failed before producing the timings still records.
