### PR TITLE
ci: grant ci-metrics job pull-requests: write

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -251,6 +251,12 @@ jobs:
     runs-on: ubuntu-latest
     needs: [build, buck2]
     if: always()
+    # A job-level block replaces the workflow's contents: write, so re-grant
+    # contents: read for checkout; the regression comment needs
+    # pull-requests: write.
+    permissions:
+      contents: read
+      pull-requests: write
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7
       - name: Remove deprecated gold linker


### PR DESCRIPTION
The ci-metrics job's "Comment on PR if regressed" step POSTs a comment with `secrets.GITHUB_TOKEN`, but the workflow grants only `contents: write`, so the token 403s `Resource not accessible by integration`.
A job-level `permissions:` block replaces the workflow default rather than extending it, so it re-grants `contents: read` for checkout alongside `pull-requests: write`.
Surfaced once #546 fixed the parser and let Record succeed and reach the comment step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
