### PR TITLE
ci: revoke merge intent when a labeled PR gets new commits

### DIFF
--- a/.github/workflows/auto-queue.yml
+++ b/.github/workflows/auto-queue.yml
@@ -1,15 +1,47 @@
 name: auto-queue
 on:
   pull_request_target:
-    types: [labeled, edited]
+    types: [labeled, edited, synchronize]
 jobs:
   auto-queue:
     runs-on: ubuntu-latest
     if: >-
-      contains(github.event.pull_request.labels.*.name, 'merge') && github.event.pull_request.base.ref == 'master'
+      github.event.action != 'synchronize' && contains(github.event.pull_request.labels.*.name, 'merge') && github.event.pull_request.base.ref == 'master'
     steps:
       - name: Add to merge queue
         env:
           GH_TOKEN: ${{ secrets.AUTO_QUEUE_TOKEN }}
           PR: ${{ github.event.pull_request.number }}
         run: gh pr merge "$PR" --repo "$GITHUB_REPOSITORY" --auto
+  # New commits supersede the review that earned the merge label, and the
+  # ruleset requires no re-approval, so cancel the pending merge; a maintainer
+  # must re-label after seeing the new head.
+  revoke-merge-intent:
+    runs-on: ubuntu-latest
+    if: >-
+      github.event.action == 'synchronize' && contains(github.event.pull_request.labels.*.name, 'merge') && github.event.pull_request.base.ref == 'master'
+    steps:
+      - name: Strip label, cancel auto-merge, and dequeue
+        env:
+          GH_TOKEN: ${{ secrets.AUTO_QUEUE_TOKEN }}
+          PR: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          owner="${REPO%%/*}"
+          name="${REPO##*/}"
+          pr="$(gh api graphql -f query='
+            query($o: String!, $n: String!, $p: Int!) {
+              repository(owner: $o, name: $n) {
+                pullRequest(number: $p) { id autoMergeRequest { enabledAt } isInMergeQueue }
+              }
+            }' -f o="$owner" -f n="$name" -F p="$PR")"
+          node="$(jq -er '.data.repository.pullRequest.id' <<<"$pr")"
+          has_auto="$(jq -r '.data.repository.pullRequest.autoMergeRequest != null' <<<"$pr")"
+          in_queue="$(jq -r '.data.repository.pullRequest.isInMergeQueue' <<<"$pr")"
+          gh pr edit "$PR" --repo "$REPO" --remove-label merge
+          if [ "$has_auto" = true ]; then
+            gh api graphql -f query='mutation($id: ID!) { disablePullRequestAutoMerge(input: {pullRequestId: $id}) { clientMutationId } }' -f id="$node"
+          fi
+          if [ "$in_queue" = true ]; then
+            gh api graphql -f query='mutation($id: ID!) { dequeuePullRequest(input: {id: $id}) { clientMutationId } }' -f id="$node"
+          fi


### PR DESCRIPTION
## Problem

master's ruleset requires no PR approval — a PR merges on `build` + `buck2` passing, gated only by the maintainer-applied `merge` label driving `--auto`.
So a fork PR labeled `merge`, then updated with new commits, has its *new* head merged with nothing re-gating it: the reviewed code is not the merged code, and there is no required review to go stale and dismiss.

## Change

Add `synchronize` to the trigger. A new `revoke-merge-intent` job fires only on `synchronize` for a `merge`-labeled PR targeting master and:

- strips the `merge` label (a maintainer must re-label after seeing the new head),
- disables auto-merge if enabled,
- dequeues if queued.

The existing `auto-queue` job is unchanged except for a guard so it does not re-queue on `synchronize`.

State is read once (`autoMergeRequest`, `isInMergeQueue`) and each mutation runs only when applicable, so there are no `|| true` masks or stringly-typed "nothing to disable" errors.

## Caveat — defense in depth, not enforcement

`synchronize` fires this job and the merge-queue re-evaluation concurrently; this relies on the revoke (seconds) beating the required checks (minutes) on the new head.
The race-free fix is a ruleset rule requiring approval of the most recent push, which is out of reach while the repo has a single author.

## Open question — `edited` and stacked PRs

`edited` is kept on the `auto-queue` job (it fires on base-branch retarget, which is how a stacked child reaches master).
Revoke is deliberately `synchronize`-only, so platform-initiated retargets do not strip labels.
Whether GitHub's native stacked-PR feature changes what `edited` needs to cover is unresolved.

## Verification

The read query and both mutation input shapes (`dequeuePullRequest.id`, `disablePullRequestAutoMerge.pullRequestId`) were checked against the live GraphQL API.
The mutations themselves are not executed here (they alter a live PR); the first real labeled-then-pushed PR exercises them.

Touches auto-queue.yml, which #544 also edits (its strict-shell block); whichever merges second needs a trivial rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
